### PR TITLE
审查默认编码的使用

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/multiplayer/MultiplayerClient.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/multiplayer/MultiplayerClient.java
@@ -27,6 +27,7 @@ import java.io.*;
 import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.util.TimerTask;
 import java.util.logging.Level;
 
@@ -83,8 +84,8 @@ public class MultiplayerClient extends Thread {
         for (int i = 0; i < 5; i++) {
             KeepAliveThread keepAliveThread = null;
             try (Socket socket = new Socket(InetAddress.getLoopbackAddress(), port);
-                 BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
-                 BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream()))) {
+                 BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+                 BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8))) {
                 MultiplayerServer.Endpoint endpoint = new MultiplayerServer.Endpoint(socket, writer);
                 LOG.info("Connected to 127.0.0.1:" + port);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/multiplayer/MultiplayerManager.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/multiplayer/MultiplayerManager.java
@@ -118,7 +118,7 @@ public final class MultiplayerManager {
 
             CompletableFuture<CatoSession> future = new CompletableFuture<>();
 
-            BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(process.getOutputStream()));
+            BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(process.getOutputStream(), StandardCharsets.UTF_8));
 
             session.onExit().register(() -> {
                 try {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/multiplayer/MultiplayerServer.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/multiplayer/MultiplayerServer.java
@@ -27,6 +27,7 @@ import org.jackhuang.hmcl.util.gson.JsonUtils;
 import java.io.*;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
@@ -129,8 +130,8 @@ public class MultiplayerServer extends Thread {
         String clientName = null;
         LOG.info("Accepted client " + address);
         try (Socket clientSocket = targetSocket;
-             BufferedReader reader = new BufferedReader(new InputStreamReader(clientSocket.getInputStream()));
-             BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(clientSocket.getOutputStream()))) {
+             BufferedReader reader = new BufferedReader(new InputStreamReader(clientSocket.getInputStream(), StandardCharsets.UTF_8));
+             BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(clientSocket.getOutputStream(), StandardCharsets.UTF_8))) {
             clientSocket.setKeepAlive(true);
             Endpoint endpoint = new Endpoint(clientSocket, writer);
             clients.put(address, endpoint);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
@@ -447,7 +447,7 @@ public class DefaultLauncher extends Launcher {
 
         if (!FileUtils.makeFile(scriptFile))
             throw new IOException("Script file: " + scriptFile + " cannot be created.");
-        try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(scriptFile)))) {
+        try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(scriptFile), OperatingSystem.NATIVE_CHARSET))) {
             if (isWindows) {
                 writer.write("@echo off");
                 writer.newLine();
@@ -495,12 +495,12 @@ public class DefaultLauncher extends Launcher {
         Thread stdout = Lang.thread(new StreamPump(managedProcess.getProcess().getInputStream(), it -> {
             processListener.onLog(it, Optional.ofNullable(Log4jLevel.guessLevel(it)).orElse(Log4jLevel.INFO));
             managedProcess.addLine(it);
-        }), "stdout-pump", isDaemon);
+        }, OperatingSystem.NATIVE_CHARSET), "stdout-pump", isDaemon);
         managedProcess.addRelatedThread(stdout);
         Thread stderr = Lang.thread(new StreamPump(managedProcess.getProcess().getErrorStream(), it -> {
             processListener.onLog(it, Log4jLevel.ERROR);
             managedProcess.addLine(it);
-        }), "stderr-pump", isDaemon);
+        }, OperatingSystem.NATIVE_CHARSET), "stderr-pump", isDaemon);
         managedProcess.addRelatedThread(stderr);
         managedProcess.addRelatedThread(Lang.thread(new ExitWaiter(managedProcess, Arrays.asList(stdout, stderr), processListener::onExit), "exit-waiter", isDaemon));
     }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/StreamPump.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/StreamPump.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 
@@ -36,20 +37,27 @@ public final class StreamPump implements Runnable {
 
     private final InputStream inputStream;
     private final Consumer<String> callback;
+    private final Charset charset;
 
     public StreamPump(InputStream inputStream) {
-        this(inputStream, s -> {
-        });
+        this(inputStream, s -> {});
     }
 
     public StreamPump(InputStream inputStream, Consumer<String> callback) {
         this.inputStream = inputStream;
         this.callback = callback;
+        this.charset = StandardCharsets.UTF_8;
+    }
+
+    public StreamPump(InputStream inputStream, Consumer<String> callback, Charset charset) {
+        this.inputStream = inputStream;
+        this.callback = callback;
+        this.charset = charset;
     }
 
     @Override
     public void run() {
-        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream, Charset.defaultCharset()))) {
+        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream, charset))) {
             String line;
             while ((line = bufferedReader.readLine()) != null) {
                 if (Thread.currentThread().isInterrupted()) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/StringUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/StringUtils.java
@@ -21,6 +21,7 @@ import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -35,8 +36,12 @@ public final class StringUtils {
 
     public static String getStackTrace(Throwable throwable) {
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        throwable.printStackTrace(new PrintStream(stream));
-        return stream.toString();
+        try {
+            throwable.printStackTrace(new PrintStream(stream, false, "UTF-8"));
+            return stream.toString("UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new InternalError(e);
+        }
     }
 
     public static String getStackTrace(StackTraceElement[] elements) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/CompressingUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/CompressingUtils.java
@@ -17,6 +17,7 @@
  */
 package org.jackhuang.hmcl.util.io;
 
+import org.jackhuang.hmcl.util.platform.OperatingSystem;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -89,7 +90,8 @@ public final class CompressingUtils {
 
     public static Charset findSuitableEncoding(Path zipFile, Collection<Charset> candidates) throws IOException {
         if (testEncoding(zipFile, StandardCharsets.UTF_8)) return StandardCharsets.UTF_8;
-        if (testEncoding(zipFile, Charset.defaultCharset())) return Charset.defaultCharset();
+        if (OperatingSystem.NATIVE_CHARSET != StandardCharsets.UTF_8 && testEncoding(zipFile, OperatingSystem.NATIVE_CHARSET))
+            return OperatingSystem.NATIVE_CHARSET;
 
         for (Charset charset : candidates)
             if (charset != null && testEncoding(zipFile, charset))

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/IOUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/IOUtils.java
@@ -65,7 +65,7 @@ public final class IOUtils {
     }
 
     public static String readFullyAsString(InputStream stream) throws IOException {
-        return readFully(stream).toString();
+        return readFully(stream).toString("UTF-8");
     }
 
     public static String readFullyAsString(InputStream stream, Charset charset) throws IOException {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/Architecture.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/Architecture.java
@@ -196,7 +196,7 @@ public enum Architecture {
             try {
                 Process process = Runtime.getRuntime().exec("/usr/bin/arch");
                 if (process.waitFor(3, TimeUnit.SECONDS)) {
-                    try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                    try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), OperatingSystem.NATIVE_CHARSET))) {
                         sysArchName = reader.readLine().trim();
                     } catch (Exception e) {
                         e.printStackTrace();

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/JavaVersion.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/JavaVersion.java
@@ -137,7 +137,7 @@ public final class JavaVersion {
         Platform platform = null;
 
         Process process = new ProcessBuilder(executable.toString(), "-XshowSettings:properties", "-version").start();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream(), OperatingSystem.NATIVE_CHARSET))) {
             for (String line; (line = reader.readLine()) != null; ) {
                 Matcher m;
 
@@ -171,7 +171,7 @@ public final class JavaVersion {
         if (version == null) {
             boolean is64Bit = false;
             process = new ProcessBuilder(executable.toString(), "-version").start();
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream(), OperatingSystem.NATIVE_CHARSET))) {
                 for (String line; (line = reader.readLine()) != null; ) {
                     Matcher m = REGEX.matcher(line);
                     if (m.find())
@@ -413,7 +413,7 @@ public final class JavaVersion {
         List<String> res = new ArrayList<>();
 
         Process process = Runtime.getRuntime().exec(new String[] { "cmd", "/c", "reg", "query", location });
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), OperatingSystem.NATIVE_CHARSET))) {
             for (String line; (line = reader.readLine()) != null;) {
                 if (line.startsWith(location) && !line.equals(location)) {
                     res.add(line);
@@ -427,7 +427,7 @@ public final class JavaVersion {
         boolean last = false;
         Process process = Runtime.getRuntime().exec(new String[] { "cmd", "/c", "reg", "query", location, "/v", name });
 
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), OperatingSystem.NATIVE_CHARSET))) {
             for (String line; (line = reader.readLine()) != null;) {
                 if (StringUtils.isNotBlank(line)) {
                     if (last && line.trim().startsWith(name)) {


### PR DESCRIPTION
#1029 因为时间过久，与主线有所冲突，本 PR 是 #1029 的重制版。

[JEP 400](https://openjdk.java.net/jeps/400) 已经合并至 OpenJDK 18 中，`Charset.defaultCharset()` 将被调整为 UTF-8，并用 Java 17 中引入的新的系统属性 `native.encoding` 表示本机编码，这会为依赖于默认编码的 Java 程序带来行为变化。

本 PR 审查了 HMCL 内部的这些用法，明确指定编码，以此避免未知的行为变化。