### PR TITLE
在 GitHub Action Artifact 名称内加入短 hash 以做区分

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,8 +19,10 @@ jobs:
         java-package: jdk+fx
     - name: Build with Gradle
       run: ./gradlew build
+    - name: Get short SHA
+      run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: HMCL
+        name: HMCL-${{ env.SHORT_SHA }}
         path: HMCL/build/libs


### PR DESCRIPTION
现在每个 commit 的 artifact  都叫 `HMCL.zip`，我的下载文件夹里堆了一堆 `HMCL（1）.zip`、`HMCL（2）.zip` 之类的了，artifact 名里加上 commit hash 就好多了。