### PR TITLE
优化联机码生成

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/multiplayer/MultiplayerManager.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/multiplayer/MultiplayerManager.java
@@ -207,7 +207,7 @@ public final class MultiplayerManager {
     }
 
     public static Invitation parseInvitationCode(String invitationCode) throws JsonParseException {
-        String json = new String(Base64.getDecoder().decode(invitationCode.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+        String json = new String(Base64.getDecoder().decode(invitationCode), StandardCharsets.UTF_8);
         return JsonUtils.fromNonNullJson(json, Invitation.class);
     }
 
@@ -350,8 +350,8 @@ public final class MultiplayerManager {
             if (id == null) {
                 throw new IllegalStateException("id not generated");
             }
-            String json = JsonUtils.GSON.toJson(new Invitation(CATO_VERSION, id, name, serverPort));
-            return new String(Base64.getEncoder().encode(json.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+            String json = JsonUtils.UGLY_GSON.toJson(new Invitation(CATO_VERSION, id, name, serverPort));
+            return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
         }
 
         public EventManager<CatoExitEvent> onExit() {


### PR DESCRIPTION
* 使用 `UGLY_GSON` 取代 `GSON` 序列化联机码，有效缩短生成的联机码长度。
* 使用 `Base64.Encoder::encodeToString(byte[])` 和 `Base64.Decoder::decode(String)` 进行编码解码，让代码更清洁，并得到优化的机会（JDK 内部未来可能可以优化掉数组校验和拷贝）。