### PR TITLE
修复 GitHub Action JavaCI 的警告

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Checkout submodules
       run: git submodule update --init --recursive
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         distribution: 'zulu'
         java-version: '11'


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20694662/137592739-5790c138-2516-4842-bd61-63aa95dccace.png)

setup-java v1 不支持指定 distribution，导致多了一个无效参数而报错，升级到 v2 即可。