### PR TITLE
Fix IllegalAccessError: tried to access protected method

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/offline/YggdrasilServer.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/offline/YggdrasilServer.java
@@ -94,9 +94,16 @@ public class YggdrasilServer extends HttpServer {
         if (!request.getQuery().containsKey("username")) {
             return badRequest();
         }
-        return findCharacterByName(request.getQuery().get("username"))
-                .map(character -> ok(character.toCompleteResponse(getRootUrl())))
-                .orElseGet(HttpServer::noContent);
+
+        Optional<Character> character = findCharacterByName(request.getQuery().get("username"));
+
+        //Workaround for JDK-8138667
+        //noinspection OptionalIsPresent
+        if (character.isPresent()) {
+            return ok(character.get().toCompleteResponse(getRootUrl()));
+        } else {
+            return HttpServer.noContent();
+        }
     }
 
     private Response joinServer(Request request) {
@@ -106,9 +113,15 @@ public class YggdrasilServer extends HttpServer {
     private Response profile(Request request) {
         String uuid = request.getPathVariables().group("uuid");
 
-        return findCharacterByUuid(UUIDTypeAdapter.fromString(uuid))
-                .map(character -> ok(character.toCompleteResponse(getRootUrl())))
-                .orElseGet(HttpServer::noContent);
+        Optional<Character> character = findCharacterByUuid(UUIDTypeAdapter.fromString(uuid));
+
+        //Workaround for JDK-8138667
+        //noinspection OptionalIsPresent
+        if (character.isPresent()) {
+            return ok(character.get().toCompleteResponse(getRootUrl()));
+        } else {
+            return HttpServer.noContent();
+        }
     }
 
     private Response texture(Request request) {


### PR DESCRIPTION
来自开黑啦用户 Power_tile 的报告，曾经也有过同类报告，在我这里无法复现。

似乎是 [JDK-8138667](https://bugs.openjdk.java.net/browse/JDK-8138667) 的重现，但按理说 JDK 9 中已经修复了，而这两例都出现在 OracleJDK 16.0.1 上。

Bug 应该出现在使用方法引用访问超类的 protected  方法，这里使用 workaround 绕过去。

```
---- Hello Minecraft! Crash Report ----
  Version: 3.4.208
  Time: 2021-10-24 12:52:05
  Thread: Thread[NanoHttpd Request Processor (#3),5,main]

  Content: 
    java.lang.IllegalAccessError: class org.jackhuang.hmcl.auth.offline.YggdrasilServer$$Lambda$1995/0x0000000801239238 tried to access protected method 'fi.iki.elonen.NanoHTTPD$Response org.jackhuang.hmcl.util.io.HttpServer.noContent()' (org.jackhuang.hmcl.auth.offline.YggdrasilServer$$Lambda$1995/0x0000000801239238 and org.jackhuang.hmcl.util.io.HttpServer are in unnamed module of loader 'app')
	at java.base/java.util.Optional.orElseGet(Optional.java:364)
	at org.jackhuang.hmcl.auth.offline.YggdrasilServer.profile(YggdrasilServer.java:111)
	at org.jackhuang.hmcl.util.io.HttpServer$DefaultRoute.serve(HttpServer.java:130)
	at org.jackhuang.hmcl.util.io.HttpServer.serve(HttpServer.java:90)
	at fi.iki.elonen.NanoHTTPD$HTTPSession.execute(NanoHTTPD.java:945)
	at fi.iki.elonen.NanoHTTPD$ClientHandler.run(NanoHTTPD.java:192)
	at java.base/java.lang.Thread.run(Thread.java:831)


-- System Details --
  Operating System: Windows 10 10.0
  Java Version: 16.0.1, Oracle Corporation
  Java VM Version: OpenJDK 64-Bit Server VM (mixed mode, sharing), Oracle Corporation
  JVM Max Memory: 8434745344
  JVM Total Memory: 92274688
  JVM Free Memory: 24042016
```