### PR TITLE
Fix #645, #1381

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/LibraryAnalyzer.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/LibraryAnalyzer.java
@@ -237,4 +237,15 @@ public final class LibraryAnalyzer implements Iterable<LibraryAnalyzer.LibraryMa
     public static final String LAUNCH_WRAPPER_MAIN = "net.minecraft.launchwrapper.Launch";
     public static final String MOD_LAUNCHER_MAIN = "cpw.mods.modlauncher.Launcher";
     public static final String BOOTSTRAP_LAUNCHER_MAIN = "cpw.mods.bootstraplauncher.BootstrapLauncher";
+
+    public static final String[] FORGE_TWEAKERS = new String[] {
+        "net.minecraftforge.legacy._1_5_2.LibraryFixerTweaker", // 1.5.2
+        "cpw.mods.fml.common.launcher.FMLTweaker", // 1.6.1 ~ 1.7.10
+        "net.minecraftforge.fml.common.launcher.FMLTweaker" // 1.8 ~ 1.12.2
+    };
+    public static final String[] OPTIFINE_TWEAKERS = new String[] {
+        "optifine.OptiFineTweaker",
+        "optifine.OptiFineForgeTweaker"
+    };
+    public static final String LITELOADER_TWEAKER = "com.mumfrey.liteloader.launch.LiteLoaderTweaker";
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/game/VersionLibraryBuilder.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/game/VersionLibraryBuilder.java
@@ -58,6 +58,10 @@ public final class VersionLibraryBuilder {
                 .setLibraries(libraries);
     }
 
+    public boolean hasTweakClass(String tweakClass) {
+        return useMcArgs && mcArgs.contains(tweakClass) || game.stream().anyMatch(arg -> arg.toString().equals(tweakClass));
+    }
+
     public void removeTweakClass(String target) {
         replaceTweakClass(target, null, false);
     }
@@ -94,6 +98,20 @@ public final class VersionLibraryBuilder {
      * @param inPlace if true, replace the tweak class in place, otherwise add the tweak class to the end of the argument list without replacement.
      */
     public void replaceTweakClass(String target, String replacement, boolean inPlace) {
+        replaceTweakClass(target, replacement, inPlace, false);
+    }
+
+    /**
+     * Replace existing tweak class.
+     * If the tweak class does not exist, the new tweak class will be added to argument list.
+     * If the tweak class appears more than one time, the tweak classes will be removed excluding the first one.
+     *
+     * @param target the tweak class to replace
+     * @param replacement the new tweak class to be replaced with, if null, remove the tweak class only
+     * @param inPlace if true, replace the tweak class in place, otherwise add the tweak class to the end of the argument list without replacement.
+     * @param reserve if true, add the tweak class to the start of the argument list.
+     */
+    public void replaceTweakClass(String target, String replacement, boolean inPlace, boolean reserve) {
         if (replacement == null && inPlace)
             throw new IllegalArgumentException("Replacement cannot be null in replace mode");
 
@@ -102,7 +120,7 @@ public final class VersionLibraryBuilder {
             for (int i = 0; i + 1 < mcArgs.size(); ++i) {
                 String arg0Str = mcArgs.get(i);
                 String arg1Str = mcArgs.get(i + 1);
-                if (arg0Str.equals("--tweakClass") && arg1Str.toLowerCase().contains(target)) {
+                if (arg0Str.equals("--tweakClass") && arg1Str.equals(target)) {
                     if (!replaced && inPlace) {
                         // for the first one, we replace the tweak class only.
                         mcArgs.set(i + 1, replacement);
@@ -124,7 +142,7 @@ public final class VersionLibraryBuilder {
                 // We need to preserve the tokens
                 String arg0Str = arg0.toString();
                 String arg1Str = arg1.toString();
-                if (arg0Str.equals("--tweakClass") && arg1Str.toLowerCase().contains(target)) {
+                if (arg0Str.equals("--tweakClass") && arg1Str.equals(target)) {
                     if (!replaced && inPlace) {
                         // for the first one, we replace the tweak class only.
                         game.set(i + 1, new StringArgument(replacement));
@@ -141,8 +159,18 @@ public final class VersionLibraryBuilder {
 
         // if the tweak class does not exist, add a new one to the end.
         if (!replaced && replacement != null) {
-            game.add(new StringArgument("--tweakClass"));
-            game.add(new StringArgument(replacement));
+            if (reserve) {
+                if (useMcArgs) {
+                    mcArgs.add(0, replacement);
+                    mcArgs.add(0, "--tweakClass");
+                } else {
+                    game.add(0, new StringArgument(replacement));
+                    game.add(0, new StringArgument("--tweakClass"));
+                }
+            } else {
+                game.add(new StringArgument("--tweakClass"));
+                game.add(new StringArgument(replacement));
+            }
         }
     }
 


### PR DESCRIPTION
- 用更准确的 `equals` 代替原先笼统的 `contains`，以避免某些 tweakClass 被错误地替换；#1381
- 现在默认的 tweakClass 顺序是 Forge Tweaker -> OptiFine Tweaker -> LiteLoader Tweaker -> 其他 Tweaker，而不是原来的 Forge Tweaker -> 其他 Tweaker -> LiteLoader Tweaker -> OptiFine Tweaker。#645
   我调查了 [LabyMod](https://labymod.net/)、[The 5zig Mod](https://5zigreborn.eu/)、[Impact](https://impactclient.net/)、[ViveCraft](http://www.vivecraft.org/) 等借助 LaunchWrapper 实现的独立客户端，他们都有把 OptiFine Tweaker 放在他们自己的 Tweaker 之前的要求，同时我目前也没有发现一个流行的独立客户端要求把 OptiFine Tweaker 放在其后执行，因此这个做法我认为是可行的。
   