### PR TITLE
Set the network timeout to 8000ms.

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/NetworkUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/NetworkUtils.java
@@ -35,6 +35,7 @@ import static org.jackhuang.hmcl.util.StringUtils.*;
 public final class NetworkUtils {
     public static final String PARAMETER_SEPARATOR = "&";
     public static final String NAME_VALUE_SEPARATOR = "=";
+    private static final int TIME_OUT = 8000;
 
     private NetworkUtils() {
     }
@@ -88,8 +89,8 @@ public final class NetworkUtils {
     public static URLConnection createConnection(URL url) throws IOException {
         URLConnection connection = url.openConnection();
         connection.setUseCaches(false);
-        connection.setConnectTimeout(5000);
-        connection.setReadTimeout(5000);
+        connection.setConnectTimeout(TIME_OUT);
+        connection.setReadTimeout(TIME_OUT);
         connection.setRequestProperty("Accept-Language", Locale.getDefault().toString());
         return connection;
     }
@@ -142,10 +143,9 @@ public final class NetworkUtils {
     public static HttpURLConnection resolveConnection(HttpURLConnection conn) throws IOException {
         int redirect = 0;
         while (true) {
-
             conn.setUseCaches(false);
-            conn.setConnectTimeout(8000);
-            conn.setReadTimeout(8000);
+            conn.setConnectTimeout(TIME_OUT);
+            conn.setReadTimeout(TIME_OUT);
             conn.setInstanceFollowRedirects(false);
             Map<String, List<String>> properties = conn.getRequestProperties();
             String method = conn.getRequestMethod();


### PR DESCRIPTION
统一超时时间到 8000ms
![image](https://github.com/HMCL-dev/HMCL/assets/88144530/2a94f461-0516-49e4-bc51-b36b48e0a71e)
旧版本 3000ms，目前遗留的 5000ms 均远小于浏览器的超时时间（60000ms），导致中国大陆地区的用户容易出现浏览器打得开，但 HMCL 打不开的情况