### PR TITLE
清理 ManagedProcess::getPid()

### DIFF
--- a/HMCLCore/build.gradle.kts
+++ b/HMCLCore/build.gradle.kts
@@ -13,20 +13,4 @@ dependencies {
     api("org.nanohttpd:nanohttpd:2.3.1")
     api("org.apache.commons:commons-compress:1.25.0")
     compileOnlyApi("org.jetbrains:annotations:24.1.0")
-    compileOnlyApi("com.github.burningtnt:BytecodeImplGenerator:b45b6638eeaeb903aa22ea947d37c45e5716a18c")
-}
-
-tasks.getByName<JavaCompile>("compileJava") {
-    val bytecodeClasses = listOf(
-        "org/jackhuang/hmcl/util/platform/ManagedProcess"
-    )
-
-    doLast {
-        javaexec {
-            classpath(project.sourceSets["main"].compileClasspath)
-            mainClass.set("net.burningtnt.bcigenerator.BytecodeImplGenerator")
-            System.getProperty("bci.debug.address")?.let { address -> jvmArgs("-agentlib:jdwp=transport=dt_socket,server=n,address=$address,suspend=y") }
-            args(bytecodeClasses.map { s -> project.layout.buildDirectory.file("classes/java/main/$s.class").get().asFile.path })
-        }
-    }
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/ManagedProcess.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/ManagedProcess.java
@@ -93,7 +93,6 @@ public class ManagedProcess {
         if (JavaVersion.CURRENT_JAVA.getParsedVersion() >= 9) {
             // Method Process.pid() is provided (Java 9 or later). Invoke it to get the pid.
             try {
-
                 return (long) MethodHandles.publicLookup()
                         .findVirtual(Process.class, "pid", MethodType.methodType(long.class))
                         .invokeExact(process);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/ManagedProcess.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/ManagedProcess.java
@@ -17,12 +17,12 @@
  */
 package org.jackhuang.hmcl.util.platform;
 
-import net.burningtnt.bcigenerator.api.BytecodeImpl;
-import net.burningtnt.bcigenerator.api.BytecodeImplError;
 import org.jackhuang.hmcl.launch.StreamPump;
 import org.jackhuang.hmcl.util.Lang;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.util.*;
 import java.util.function.Consumer;
@@ -92,7 +92,14 @@ public class ManagedProcess {
     public long getPID() throws UnsupportedOperationException {
         if (JavaVersion.CURRENT_JAVA.getParsedVersion() >= 9) {
             // Method Process.pid() is provided (Java 9 or later). Invoke it to get the pid.
-            return getPID0(process);
+            try {
+
+                return (long) MethodHandles.publicLookup()
+                        .findVirtual(Process.class, "pid", MethodType.methodType(long.class))
+                        .invokeExact(process);
+            } catch (Throwable e) {
+                throw new UnsupportedOperationException("Cannot get the pid", e);
+            }
         } else {
             // Method Process.pid() is not provided. (Java 8).
             if (OperatingSystem.CURRENT_OS == OperatingSystem.WINDOWS) {
@@ -116,23 +123,6 @@ public class ManagedProcess {
                 throw new UnsupportedOperationException(String.format("Cannot get the pid of a Process on Java 8 on Unknown Operating System (%s).", System.getProperty("os.name")));
             }
         }
-    }
-
-    /**
-     * Get the PID of a process with BytecodeImplGenerator
-     */
-    @BytecodeImpl({
-            "LABEL METHOD_HEAD",
-            "ALOAD 0",
-            "INVOKEVIRTUAL Ljava/lang/Process;pid()J",
-            "LABEL RELEASE_PARAMETER",
-            "LRETURN",
-            "LOCALVARIABLE process [Ljava/lang/Process; METHOD_HEAD RELEASE_PARAMETER 0",
-            "MAXS 2 1"
-    })
-    @SuppressWarnings("unused")
-    private static long getPID0(Process process) {
-        throw new BytecodeImplError();
     }
 
     /**


### PR DESCRIPTION
@burningtnt 

首先，不要拿哈希值充当版本号。哈希值无法给维护者带来有意义的信息，让维护者更难去追踪库版本的变更。除非这个库只有你自己一个人用，不然请用一个有意义的版本号，就算想偷懒那最少也请在哈希前面附加上时间戳。

然后不要想性能想的入魔了。

如果能够在清理简化代码的同时带来性能提升，那自然是好的；如果为了优化需要让代码更复杂，那除非确认能带来用户有感知的改进，不然请确保代码依然有很高的可读性，并且要权衡为此变化付出的代价是否值得。不是只有对运行时性能的影响是代价，审查和测试付出的精力也是代价，后续的维护成本也是代价。在提交一项更改前，请先把收益和代价想清楚再说。

对于性能优化来说，如果是一秒会调用成千上万次的方法，那么能优化掉几毫秒的开销是很值得的；如果是像日志处理这样每秒最多可能调用几十次的方法，优化掉几毫秒的开销依然有用，但算不上那么重要；如果是整个程序周期里就调用几次的方法，尤其是那些比较少用还涉及到 IO 等重开销的功能，哪怕每次调用一次多花一两百毫秒都不会对用户体验造成多少影响，为了优化它提高维护成本很可能是不划算的。

`ManagedProcess::getPid()` 这个方法属于很少使用的功能，用到的地方还涉及 I/O，所以对开销的容忍程度很高。在这里，用反射查询并调用一次 `pid` 的时间大概是几十到几百微秒，远不到一毫秒，除非塞进循环里高频调用，否则对用户来说完全没有任何可感的区别。为了优化掉这微秒级别的开销，你在这里付出的代价是：

* 每个阅读 `ManagedProcess` 以及构建脚本源码的开发者都要额外去理解和学习这些非常规的代码的含义；
* 重构代码可能会破坏构建，需要花额外的精力额外维护构建脚本；如果构建前没有 clean，甚至还可能会在不破坏构建的情况下损坏功能；
* 对字节码进行修改可能会造成隐蔽的 BUG（尤其是与 Gradle 的交互可能会产生相当隐蔽的问题），DEBUG 时开发者不得不考虑更多；
* 维护构建脚本的成本更高，比如说假如未来需要在编译流程中添加更多操作，那么开发者可能还需要思考和维护这些操作的顺序。

相对于它带来的用户完全无法感知的优化，这些代价可谓相当高昂，这样做真的值得吗？

请各位明白，Zero Cost 并不值得不顾一切去追求，为了便于维护付出一些运行时成本是可以接受的。在做优化前也请先弄明白这些优化到底能带来多少改进，大部分人的直觉是不准确的，不经过实际测试很可能对操作开销有严重的误判。
