### PR TITLE
Fix #2690: 修复自动选择下载源功能

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/DownloadProviders.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/DownloadProviders.java
@@ -78,7 +78,7 @@ public final class DownloadProviders {
 
         AdaptedDownloadProvider fileProvider = new AdaptedDownloadProvider();
         fileProvider.setDownloadProviderCandidates(Arrays.asList(MCBBS, BMCLAPI, MOJANG));
-        BalancedDownloadProvider balanced = new BalancedDownloadProvider(Arrays.asList(MCBBS, BMCLAPI, MOJANG));
+        BalancedDownloadProvider balanced = new BalancedDownloadProvider(MOJANG, MCBBS, BMCLAPI);
 
         providersById = mapOf(
                 pair("official", new AutoDownloadProvider(MOJANG, fileProvider)),


### PR DESCRIPTION
现在 HMCL 在开启自动选择下载源（平衡）模式的情况下，每次读取版本列表时都会同时尝试从官方源、mcbbs 源和 BMCL 源获取，并在其中之一失败时失败。现在由于 mcbbs 源离线，开启自动选择下载源时已经完全无法正确获取版本列表。

本 PR 修复了获取版本列表的逻辑，按照 官方源 -> mcbbs 源 -> BMCL 源 的顺序依次获取，当且仅当从前一个源获取失败时才会尝试下一个源，这样能够保证只要能正常访问任何一个源都能得到结果，也避免对 BMCL 产生不必要的压力。