### PR TITLE
Fix: Cannot install modpacks with NeoForge for Minecraft 1.20.1.

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/neoforge/NeoForgeBMCLVersionList.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/neoforge/NeoForgeBMCLVersionList.java
@@ -26,6 +26,7 @@ import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.gson.Validation;
 import org.jackhuang.hmcl.util.io.HttpRequest;
+import org.jackhuang.hmcl.util.versioning.VersionNumber;
 
 import java.util.List;
 import java.util.Optional;
@@ -59,6 +60,15 @@ public final class NeoForgeBMCLVersionList extends VersionList<NeoForgeRemoteVer
     }
 
     @Override
+    public Optional<NeoForgeRemoteVersion> getVersion(String gameVersion, String remoteVersion) {
+        if (gameVersion.equals("1.20.1")) {
+            remoteVersion = NeoForgeRemoteVersion.fixInvalidVersion(remoteVersion);
+            remoteVersion = VersionNumber.compare(remoteVersion, "47.1.85") >= 0 ? "1.20.1-" + remoteVersion : remoteVersion;
+        }
+        return super.getVersion(gameVersion, remoteVersion);
+    }
+
+    @Override
     public CompletableFuture<?> refreshAsync(String gameVersion) {
         return CompletableFuture.completedFuture((Void) null)
                 .thenApplyAsync(wrap(unused -> HttpRequest.GET(apiRoot + "/neoforge/list/" + gameVersion).<List<NeoForgeVersion>>getJson(new TypeToken<List<NeoForgeVersion>>() {
@@ -87,12 +97,6 @@ public final class NeoForgeBMCLVersionList extends VersionList<NeoForgeRemoteVer
                 });
     }
 
-    @Override
-    public Optional<NeoForgeRemoteVersion> getVersion(String gameVersion, String remoteVersion) {
-        remoteVersion = StringUtils.substringAfter(remoteVersion, "-", remoteVersion);
-        return super.getVersion(gameVersion, remoteVersion);
-    }
-
     @Immutable
     private static final class NeoForgeVersion implements Validation {
         private final String rawVersion;
@@ -106,18 +110,6 @@ public final class NeoForgeBMCLVersionList extends VersionList<NeoForgeRemoteVer
             this.rawVersion = rawVersion;
             this.version = version;
             this.mcVersion = mcVersion;
-        }
-
-        public String getRawVersion() {
-            return this.rawVersion;
-        }
-
-        public String getVersion() {
-            return this.version;
-        }
-
-        public String getMcVersion() {
-            return this.mcVersion;
         }
 
         @Override

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/neoforge/NeoForgeOfficialVersionList.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/neoforge/NeoForgeOfficialVersionList.java
@@ -7,6 +7,7 @@ import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.io.HttpRequest;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static org.jackhuang.hmcl.util.Lang.wrap;
@@ -26,6 +27,17 @@ public final class NeoForgeOfficialVersionList extends VersionList<NeoForgeRemot
     private static final String OLD_URL = "https://maven.neoforged.net/api/maven/versions/releases/net/neoforged/forge";
 
     private static final String META_URL = "https://maven.neoforged.net/api/maven/versions/releases/net/neoforged/neoforge";
+
+    @Override
+    public Optional<NeoForgeRemoteVersion> getVersion(String gameVersion, String remoteVersion) {
+        if (gameVersion.equals("1.20.1")) {
+            remoteVersion = NeoForgeRemoteVersion.fixInvalidVersion(remoteVersion);
+            if (!remoteVersion.equals("47.1.82")) {
+                remoteVersion = "1.20.1-" + remoteVersion;
+            }
+        }
+        return super.getVersion(gameVersion, remoteVersion);
+    }
 
     @Override
     public CompletableFuture<?> refreshAsync() {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/neoforge/NeoForgeRemoteVersion.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/neoforge/NeoForgeRemoteVersion.java
@@ -17,4 +17,16 @@ public class NeoForgeRemoteVersion extends RemoteVersion {
     public Task<Version> getInstallTask(DefaultDependencyManager dependencyManager, Version baseVersion) {
         return new NeoForgeInstallTask(dependencyManager, baseVersion, this);
     }
+
+    public static String fixInvalidVersion(String version) {
+        if (version.startsWith("1.20.1-")) {
+            if (version.startsWith("forge-", "1.20.1-".length())) {
+                return version.substring("1.20.1-forge-".length());
+            } else {
+                return version.substring("1.20.1-".length());
+            }
+        } else {
+            return version;
+        }
+    }
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/multimc/MultiMCModpackExportTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/multimc/MultiMCModpackExportTask.java
@@ -77,9 +77,8 @@ public class MultiMCModpackExportTask extends Task<Void> {
             components.add(new MultiMCManifest.MultiMCManifestComponent(true, false, "net.minecraft", gameVersion));
             analyzer.getVersion(FORGE).ifPresent(forgeVersion ->
                     components.add(new MultiMCManifest.MultiMCManifestComponent(false, false, "net.minecraftforge", forgeVersion)));
-            // MultiMC hasn't supported NeoForge yet.
-            //  analyzer.getVersion(NEO_FORGE).ifPresent(neoForgeVersion ->
-            //          components.add(new MultiMCManifest.MultiMCManifestComponent(false, false, "net.neoforged", neoForgeVersion)));
+            analyzer.getVersion(NEO_FORGE).ifPresent(neoForgeVersion ->
+                    components.add(new MultiMCManifest.MultiMCManifestComponent(false, false, "net.neoforged", neoForgeVersion)));
             analyzer.getVersion(LITELOADER).ifPresent(liteLoaderVersion ->
                     components.add(new MultiMCManifest.MultiMCManifestComponent(false, false, "com.mumfrey.liteloader", liteLoaderVersion)));
             analyzer.getVersion(FABRIC).ifPresent(fabricVersion ->

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/multimc/MultiMCModpackInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/multimc/MultiMCModpackInstallTask.java
@@ -78,12 +78,11 @@ public final class MultiMCModpackInstallTask extends Task<Void> {
                     builder.version("forge", c.getVersion());
             });
 
-            // MultiMC hasn't supported NeoForge yet.
-            // Optional<MultiMCManifest.MultiMCManifestComponent> neoForge = manifest.getMmcPack().getComponents().stream().filter(e -> e.getUid().equals("net.neoforged")).findAny();
-            // neoForge.ifPresent(c -> {
-            //     if (c.getVersion() != null)
-            //         builder.version("neoforge", c.getVersion());
-            // });
+            Optional<MultiMCManifest.MultiMCManifestComponent> neoForge = manifest.getMmcPack().getComponents().stream().filter(e -> e.getUid().equals("net.neoforged")).findAny();
+            neoForge.ifPresent(c -> {
+                if (c.getVersion() != null)
+                    builder.version("neoforge", c.getVersion());
+            });
 
             Optional<MultiMCManifest.MultiMCManifestComponent> liteLoader = manifest.getMmcPack().getComponents().stream().filter(e -> e.getUid().equals("com.mumfrey.liteloader")).findAny();
             liteLoader.ifPresent(c -> {


### PR DESCRIPTION
1.20.1 的 NeoForge 版本号有好几种变化
在 HMCL 内部，均选取 47.1.* 和 NeoForge 版本号规范中敲定的形式
因此，在读取数据源时，需要做出转化

本 PR 补上了安装整合包时没有对各类版本号做出转化的 Bug

转化分为两步，先转换为 HMCL 内部 NeoForge 版本号
- 1.20.1-forge-47.1.58 -> 47.1.58
- 1.20.1-47.1.58 -> 47.1.58

再转换为 BMCL / NeoForge Maven 所支持的版本号
BMCL:
- 47.1.58 -> 1.20.1-47.1.58
- 47.1.81 -> 1.20.1-forge-47.1.81

NeoForge Maven:
- 47.1.84 -> 1.20.1-47.1.84
- 47.1.82 -> 47.1.82（特例，鬼知道为什么就这一个版本号这么特殊）