### PR TITLE
尝试从候选源获取 AuthlibInjectorVersionInfo

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/authlibinjector/AuthlibInjectorDownloader.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/authlibinjector/AuthlibInjectorDownloader.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -111,10 +110,8 @@ public class AuthlibInjectorDownloader implements AuthlibInjectorArtifactProvide
     }
 
     private AuthlibInjectorVersionInfo getLatestArtifactInfo() throws IOException {
-        List<URL> urls = downloadProvider.get().injectURLWithCandidates(LATEST_BUILD_URL);
-
         IOException exception = null;
-        for (URL url : urls) {
+        for (URL url : downloadProvider.get().injectURLWithCandidates(LATEST_BUILD_URL)) {
             try {
                 return HttpRequest.GET(url.toExternalForm()).getJson(AuthlibInjectorVersionInfo.class);
             } catch (IOException | JsonParseException e) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/authlibinjector/AuthlibInjectorDownloader.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/authlibinjector/AuthlibInjectorDownloader.java
@@ -116,14 +116,14 @@ public class AuthlibInjectorDownloader implements AuthlibInjectorArtifactProvide
                 return HttpRequest.GET(url.toExternalForm()).getJson(AuthlibInjectorVersionInfo.class);
             } catch (IOException | JsonParseException e) {
                 if (exception == null) {
-                    exception = new IOException("Failed to download authlib-injector");
+                    exception = new IOException("Failed to fetch authlib-injector artifact info");
                 }
                 exception.addSuppressed(e);
             }
         }
 
         if (exception == null) {
-            exception = new IOException("No download providers available");
+            exception = new IOException("No authlib-injector download providers available");
         }
         throw exception;
     }


### PR DESCRIPTION
目前 HMCL 只会从首选下载源获取 `AuthlibInjectorVersionInfo`，这会导致开启自动选择下载源时只要访问 mcbbs 源失败就会直接失败，而不会尝试从官方源获取。