### PR TITLE
在游戏安装界面隐藏不可用的模组管理器

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
@@ -40,10 +40,6 @@ import org.jackhuang.hmcl.ui.construct.RipplerContainer;
 import org.jackhuang.hmcl.util.i18n.I18n;
 import org.jackhuang.hmcl.util.versioning.VersionNumber;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import static org.jackhuang.hmcl.download.LibraryAnalyzer.LibraryType.*;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
@@ -206,7 +206,7 @@ public class InstallerItem extends Control {
             if (gameVersion == null) {
                this.libraries = new InstallerItem[]{game, forge, neoForge, liteLoader, optiFine, fabric, fabricApi, quilt, quiltApi};
             } else if (VersionNumber.compare(gameVersion, "1.13") < 0) {
-                this.libraries = new InstallerItem[]{game, forge, liteLoader, optiFine, fabric, fabricApi, quilt, quiltApi};
+                this.libraries = new InstallerItem[]{game, forge, liteLoader, optiFine};
             } else {
                 this.libraries = new InstallerItem[]{game, forge, neoForge, optiFine, fabric, fabricApi, quilt, quiltApi};
             }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
@@ -200,7 +200,7 @@ public class InstallerItem extends Control {
 
 
             if (gameVersion == null) {
-               this.libraries = new InstallerItem[]{game, forge, neoForge, liteLoader, optiFine, fabric, fabricApi, quilt, quiltApi};
+                this.libraries = new InstallerItem[]{game, forge, neoForge, liteLoader, optiFine, fabric, fabricApi, quilt, quiltApi};
             } else if (VersionNumber.compare(gameVersion, "1.13") < 0) {
                 this.libraries = new InstallerItem[]{game, forge, liteLoader, optiFine};
             } else {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
@@ -38,6 +38,11 @@ import org.jackhuang.hmcl.setting.Theme;
 import org.jackhuang.hmcl.setting.VersionIconType;
 import org.jackhuang.hmcl.ui.construct.RipplerContainer;
 import org.jackhuang.hmcl.util.i18n.I18n;
+import org.jackhuang.hmcl.util.versioning.VersionNumber;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.jackhuang.hmcl.download.LibraryAnalyzer.LibraryType.*;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
@@ -121,7 +126,7 @@ public class InstallerItem extends Control {
         return new InstallerItemSkin(this);
     }
 
-    public static class InstallerItemGroup {
+    public final static class InstallerItemGroup {
         public final InstallerItem game = new InstallerItem(MINECRAFT);
         public final InstallerItem fabric = new InstallerItem(FABRIC);
         public final InstallerItem fabricApi = new InstallerItem(FABRIC_API);
@@ -132,7 +137,9 @@ public class InstallerItem extends Control {
         public final InstallerItem quilt = new InstallerItem(QUILT);
         public final InstallerItem quiltApi = new InstallerItem(QUILT_API);
 
-        public InstallerItemGroup() {
+        private final InstallerItem[] libraries;
+
+        public InstallerItemGroup(String gameVersion) {
             forge.incompatibleLibraryName.bind(Bindings.createStringBinding(() -> {
                 if (fabric.libraryVersion.get() != null) return FABRIC.getPatchId();
                 if (quilt.libraryVersion.get() != null) return QUILT.getPatchId();
@@ -194,10 +201,19 @@ public class InstallerItem extends Control {
                 if (quilt.libraryVersion.get() == null) return QUILT.getPatchId();
                 else return null;
             }, quilt.libraryVersion));
+
+
+            if (gameVersion == null) {
+               this.libraries = new InstallerItem[]{game, forge, neoForge, liteLoader, optiFine, fabric, fabricApi, quilt, quiltApi};
+            } else if (VersionNumber.compare(gameVersion, "1.13") < 0) {
+                this.libraries = new InstallerItem[]{game, forge, liteLoader, optiFine, fabric, fabricApi, quilt, quiltApi};
+            } else {
+                this.libraries = new InstallerItem[]{game, forge, neoForge, optiFine, fabric, fabricApi, quilt, quiltApi};
+            }
         }
 
         public InstallerItem[] getLibraries() {
-            return new InstallerItem[]{game, forge, neoForge, liteLoader, optiFine, fabric, fabricApi, quilt, quiltApi};
+            return libraries;
         }
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java
@@ -48,12 +48,13 @@ import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 public class InstallersPage extends Control implements WizardPage {
     protected final WizardController controller;
 
-    protected InstallerItem.InstallerItemGroup group = new InstallerItem.InstallerItemGroup();
+    protected InstallerItem.InstallerItemGroup group;
     protected JFXTextField txtName = new JFXTextField();
     protected BooleanProperty installable = new SimpleBooleanProperty();
 
     public InstallersPage(WizardController controller, HMCLGameRepository repository, String gameVersion, DownloadProvider downloadProvider) {
         this.controller = controller;
+        this.group = new InstallerItem.InstallerItemGroup(gameVersion);
 
         txtName.getValidators().addAll(
                 new RequiredValidator(),
@@ -152,14 +153,22 @@ public class InstallersPage extends Control implements WizardPage {
             }
 
             {
-                FlowPane libraryPane = new FlowPane(control.group.getLibraries());
+                InstallerItem[] libraries = control.group.getLibraries();
+
+                FlowPane libraryPane = new FlowPane(libraries);
                 libraryPane.setVgap(16);
                 libraryPane.setHgap(16);
-                ScrollPane scrollPane = new ScrollPane(libraryPane);
-                scrollPane.setFitToWidth(true);
-                scrollPane.setFitToHeight(true);
-                BorderPane.setMargin(scrollPane, new Insets(16, 0, 16, 0));
-                root.setCenter(scrollPane);
+
+                if (libraries.length <= 8) {
+                    BorderPane.setMargin(libraryPane, new Insets(16, 0, 16, 0));
+                    root.setCenter(libraryPane);
+                } else {
+                    ScrollPane scrollPane = new ScrollPane(libraryPane);
+                    scrollPane.setFitToWidth(true);
+                    scrollPane.setFitToHeight(true);
+                    BorderPane.setMargin(scrollPane, new Insets(16, 0, 16, 0));
+                    root.setCenter(scrollPane);
+                }
             }
 
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/InstallerListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/InstallerListPage.java
@@ -84,7 +84,7 @@ public class InstallerListPage extends ListPageBase<InstallerItem> implements Ve
 
             itemsProperty().clear();
 
-            InstallerItem.InstallerItemGroup group = new InstallerItem.InstallerItemGroup();
+            InstallerItem.InstallerItemGroup group = new InstallerItem.InstallerItemGroup(gameVersion);
 
             // Conventional libraries: game, fabric, forge, neoforge, liteloader, optifine
             for (InstallerItem installerItem : group.getLibraries()) {


### PR DESCRIPTION
本 PR 为 Minecraft 1.13+ 隐藏 liteloader 的安装选项，为 1.12.2 以及更早版本隐藏 NeoForge、Fabric 以及 Quilt 的安装选项，以避免安装界面不得不出现滚动条。