### PR TITLE
默认不进行降级更新

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/RemoteVersion.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/RemoteVersion.java
@@ -38,10 +38,11 @@ public class RemoteVersion {
             String jarHash = Optional.ofNullable(response.get("jarsha1")).map(JsonElement::getAsString).orElse(null);
             String packXZUrl = Optional.ofNullable(response.get("packxz")).map(JsonElement::getAsString).orElse(null);
             String packXZHash = Optional.ofNullable(response.get("packxzsha1")).map(JsonElement::getAsString).orElse(null);
+            boolean force = Optional.ofNullable(response.get("force")).map(JsonElement::getAsBoolean).orElse(false);
             if (Pack200Utils.isSupported() && packXZUrl != null && packXZHash != null) {
-                return new RemoteVersion(channel, version, packXZUrl, Type.PACK_XZ, new IntegrityCheck("SHA-1", packXZHash));
+                return new RemoteVersion(channel, version, packXZUrl, Type.PACK_XZ, new IntegrityCheck("SHA-1", packXZHash), force);
             } else if (jarUrl != null && jarHash != null) {
-                return new RemoteVersion(channel, version, jarUrl, Type.JAR, new IntegrityCheck("SHA-1", jarHash));
+                return new RemoteVersion(channel, version, jarUrl, Type.JAR, new IntegrityCheck("SHA-1", jarHash), force);
             } else {
                 throw new IOException("No download url is available");
             }
@@ -55,13 +56,15 @@ public class RemoteVersion {
     private final String url;
     private final Type type;
     private final IntegrityCheck integrityCheck;
+    private final boolean force;
 
-    public RemoteVersion(UpdateChannel channel, String version, String url, Type type, IntegrityCheck integrityCheck) {
+    public RemoteVersion(UpdateChannel channel, String version, String url, Type type, IntegrityCheck integrityCheck, boolean force) {
         this.channel = channel;
         this.version = version;
         this.url = url;
         this.type = type;
         this.integrityCheck = integrityCheck;
+        this.force = force;
     }
 
     public UpdateChannel getChannel() {
@@ -82,6 +85,10 @@ public class RemoteVersion {
 
     public IntegrityCheck getIntegrityCheck() {
         return integrityCheck;
+    }
+
+    public boolean isForce() {
+        return force;
     }
 
     @Override

--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateChecker.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateChecker.java
@@ -24,6 +24,7 @@ import javafx.beans.property.*;
 import javafx.beans.value.ObservableBooleanValue;
 import org.jackhuang.hmcl.Metadata;
 import org.jackhuang.hmcl.util.io.NetworkUtils;
+import org.jackhuang.hmcl.util.versioning.VersionNumber;
 
 import java.io.IOException;
 import java.util.logging.Level;
@@ -42,10 +43,12 @@ public final class UpdateChecker {
                 RemoteVersion latest = latestVersion.get();
                 if (latest == null || isDevelopmentVersion(Metadata.VERSION)) {
                     return false;
-                } else {
+                } else if (latest.isForce() || latest.getChannel() != UpdateChannel.getChannel()) {
                     // We can update from development version to stable version,
                     // which can be downgrading.
                     return !latest.getVersion().equals(Metadata.VERSION);
+                } else {
+                    return VersionNumber.compare(Metadata.VERSION, latest.getVersion()) < 0;
                 }
             },
             latestVersion);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateChecker.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateChecker.java
@@ -43,9 +43,10 @@ public final class UpdateChecker {
                 RemoteVersion latest = latestVersion.get();
                 if (latest == null || isDevelopmentVersion(Metadata.VERSION)) {
                     return false;
-                } else if (latest.isForce() || latest.getChannel() != UpdateChannel.getChannel()) {
-                    // We can update from development version to stable version,
-                    // which can be downgrading.
+                } else if (latest.isForce()
+                        || Metadata.isNightly()
+                        || latest.getChannel() == UpdateChannel.NIGHTLY
+                        || latest.getChannel() != UpdateChannel.getChannel()) {
                     return !latest.getVersion().equals(Metadata.VERSION);
                 } else {
                     return VersionNumber.compare(Metadata.VERSION, latest.getVersion()) < 0;


### PR DESCRIPTION
目前 HMCL 默认支持降级更新，这导致每布新版本后但更新源暂未更新时的这段时间里用户会接收到降级更新提示，每次新版本发布时都会有手动下载的用户对此表示困惑。

参见发布计划的提案 ( https://github.com/HMCL-dev/HMCL/discussions/2860 )，我希望未来每次发布新版本后推迟两天再进行推送，这段空隙可以让我们进行更充分的测试和准备，但这样会导致虚假降级提示的影响范围更大。

为了解决此问题，我提议进行此更改：默认情况下，只有在 HMCL 切换更新源时才会进行降级更新；如果我们需要强制用户进行降级，应当在更新 JSON 中添加 `"force": true` 字段进行强制推送。