### PR TITLE
使用 ByteArrayOutputBuffer 替代 ByteArrayOutputStream

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/AdvancedListBox.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/AdvancedListBox.java
@@ -24,6 +24,8 @@ import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import org.jackhuang.hmcl.ui.FXUtils;
+import org.jackhuang.hmcl.ui.SVG;
+import org.jackhuang.hmcl.ui.versions.VersionPage;
 
 import java.util.function.Consumer;
 
@@ -54,11 +56,36 @@ public class AdvancedListBox extends ScrollPane {
         return this;
     }
 
-    public AdvancedListBox addNavigationDrawerItem(Consumer<AdvancedListItem> fn) {
+    private AdvancedListItem createNavigationDrawerItem(String title, SVG leftGraphic) {
         AdvancedListItem item = new AdvancedListItem();
         item.getStyleClass().add("navigation-drawer-item");
         item.setActionButtonVisible(false);
-        fn.accept(item);
+        item.setTitle(title);
+        if (leftGraphic != null) {
+            item.setLeftGraphic(VersionPage.wrap(leftGraphic));
+        }
+        return item;
+    }
+
+    public AdvancedListBox addNavigationDrawerItem(String title, SVG leftGraphic, Runnable onAction) {
+        return addNavigationDrawerItem(title, leftGraphic, onAction, null);
+    }
+
+    public AdvancedListBox addNavigationDrawerItem(String title, SVG leftGraphic, Runnable onAction, Consumer<AdvancedListItem> initializer) {
+        AdvancedListItem item = createNavigationDrawerItem(title, leftGraphic);
+        if (onAction != null) {
+            item.setOnAction(e -> onAction.run());
+        }
+        if (initializer != null) {
+            initializer.accept(item);
+        }
+        return add(item);
+    }
+
+    public AdvancedListBox addNavigationDrawerTab(TabHeader tabHeader, TabControl.Tab<?> tab, String title, SVG leftGraphic) {
+        AdvancedListItem item = createNavigationDrawerItem(title, leftGraphic);
+        item.activeProperty().bind(tabHeader.getSelectionModel().selectedItemProperty().isEqualTo(tab));
+        item.setOnAction(e -> tabHeader.select(tab));
         return add(item);
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/DownloadPage.java
@@ -60,7 +60,6 @@ import java.util.concurrent.CancellationException;
 import java.util.function.Supplier;
 
 import static org.jackhuang.hmcl.ui.FXUtils.runInFX;
-import static org.jackhuang.hmcl.ui.versions.VersionPage.wrap;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
 public class DownloadPage extends DecoratorAnimatedPage implements DecoratorPage {
@@ -100,43 +99,16 @@ public class DownloadPage extends DecoratorAnimatedPage implements DecoratorPage
             transitionPane.setContent(newValue.getNode(), ContainerAnimations.FADE);
         });
 
-        {
-            AdvancedListBox sideBar = new AdvancedListBox()
-                    .startCategory(i18n("download.game").toUpperCase(Locale.ROOT))
-                    .addNavigationDrawerItem(item -> {
-                        item.setTitle(i18n("game"));
-                        item.setLeftGraphic(wrap(SVG.GAMEPAD));
-                        item.activeProperty().bind(tab.getSelectionModel().selectedItemProperty().isEqualTo(newGameTab));
-                        item.setOnAction(e -> tab.select(newGameTab));
-                    })
-                    .addNavigationDrawerItem(settingsItem -> {
-                        settingsItem.setTitle(i18n("modpack"));
-                        settingsItem.setLeftGraphic(wrap(SVG.PACK));
-                        settingsItem.activeProperty().bind(tab.getSelectionModel().selectedItemProperty().isEqualTo(modpackTab));
-                        settingsItem.setOnAction(e -> tab.select(modpackTab));
-                    })
-                    .startCategory(i18n("download.content").toUpperCase(Locale.ROOT))
-                    .addNavigationDrawerItem(item -> {
-                        item.setTitle(i18n("mods"));
-                        item.setLeftGraphic(wrap(SVG.PUZZLE));
-                        item.activeProperty().bind(tab.getSelectionModel().selectedItemProperty().isEqualTo(modTab));
-                        item.setOnAction(e -> tab.select(modTab));
-                    })
-                    .addNavigationDrawerItem(item -> {
-                        item.setTitle(i18n("resourcepack"));
-                        item.setLeftGraphic(wrap(SVG.TEXTURE_BOX));
-                        item.activeProperty().bind(tab.getSelectionModel().selectedItemProperty().isEqualTo(resourcePackTab));
-                        item.setOnAction(e -> tab.select(resourcePackTab));
-                    })
-                    .addNavigationDrawerItem(item -> {
-                        item.setTitle(i18n("world"));
-                        item.setLeftGraphic(wrap(SVG.EARTH));
-                        item.activeProperty().bind(tab.getSelectionModel().selectedItemProperty().isEqualTo(worldTab));
-                        item.setOnAction(e -> selectTabIfCurseForgeAvailable(worldTab));
-                    });
-            FXUtils.setLimitWidth(sideBar, 200);
-            setLeft(sideBar);
-        }
+        AdvancedListBox sideBar = new AdvancedListBox()
+                .startCategory(i18n("download.game").toUpperCase(Locale.ROOT))
+                .addNavigationDrawerTab(tab, newGameTab, i18n("game"), SVG.GAMEPAD)
+                .addNavigationDrawerTab(tab, modpackTab, i18n("modpack"), SVG.PACK)
+                .startCategory(i18n("download.content").toUpperCase(Locale.ROOT))
+                .addNavigationDrawerTab(tab, modTab, i18n("mods"), SVG.PUZZLE)
+                .addNavigationDrawerTab(tab, resourcePackTab, i18n("resourcepack"), SVG.TEXTURE_BOX)
+                .addNavigationDrawerTab(tab, worldTab, i18n("world"), SVG.EARTH);
+        FXUtils.setLimitWidth(sideBar, 200);
+        setLeft(sideBar);
 
         setCenter(transitionPane);
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/LauncherSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/LauncherSettingsPage.java
@@ -35,7 +35,6 @@ import org.jackhuang.hmcl.ui.versions.VersionSettingsPage;
 
 import java.util.Locale;
 
-import static org.jackhuang.hmcl.ui.versions.VersionPage.wrap;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
 public class LauncherSettingsPage extends DecoratorAnimatedPage implements DecoratorPage, PageAware {
@@ -69,61 +68,19 @@ public class LauncherSettingsPage extends DecoratorAnimatedPage implements Decor
             transitionPane.setContent(newValue.getNode(), ContainerAnimations.FADE);
         });
 
-        {
-            AdvancedListBox sideBar = new AdvancedListBox()
-                    .addNavigationDrawerItem(settingsItem -> {
-                        settingsItem.setTitle(i18n("settings.type.global.manage"));
-                        settingsItem.setLeftGraphic(wrap(SVG.GAMEPAD));
-                        settingsItem.activeProperty().bind(tab.getSelectionModel().selectedItemProperty().isEqualTo(gameTab));
-                        settingsItem.setOnAction(e -> tab.select(gameTab));
-                    })
-                    .addNavigationDrawerItem(javaItem -> {
-                        javaItem.setTitle(i18n("java.management"));
-                        javaItem.setLeftGraphic(wrap(SVG.WRENCH_OUTLINE));
-                        javaItem.activeProperty().bind(tab.getSelectionModel().selectedItemProperty().isEqualTo(javaManagementTab));
-                        javaItem.setOnAction(e -> tab.select(javaManagementTab));
-                    })
-                    .startCategory(i18n("launcher").toUpperCase(Locale.ROOT))
-                    .addNavigationDrawerItem(settingsItem -> {
-                        settingsItem.setTitle(i18n("settings.launcher.general"));
-                        settingsItem.setLeftGraphic(wrap(SVG.APPLICATION_OUTLINE));
-                        settingsItem.activeProperty().bind(tab.getSelectionModel().selectedItemProperty().isEqualTo(settingsTab));
-                        settingsItem.setOnAction(e -> tab.select(settingsTab));
-                    })
-                    .addNavigationDrawerItem(personalizationItem -> {
-                        personalizationItem.setTitle(i18n("settings.launcher.appearance"));
-                        personalizationItem.setLeftGraphic(wrap(SVG.STYLE_OUTLINE));
-                        personalizationItem.activeProperty().bind(tab.getSelectionModel().selectedItemProperty().isEqualTo(personalizationTab));
-                        personalizationItem.setOnAction(e -> tab.select(personalizationTab));
-                    })
-                    .addNavigationDrawerItem(downloadItem -> {
-                        downloadItem.setTitle(i18n("download"));
-                        downloadItem.setLeftGraphic(wrap(SVG.DOWNLOAD_OUTLINE));
-                        downloadItem.activeProperty().bind(tab.getSelectionModel().selectedItemProperty().isEqualTo(downloadTab));
-                        downloadItem.setOnAction(e -> tab.select(downloadTab));
-                    })
-                    .startCategory(i18n("help").toUpperCase(Locale.ROOT))
-                    .addNavigationDrawerItem(helpItem -> {
-                        helpItem.setTitle(i18n("help"));
-                        helpItem.setLeftGraphic(wrap(SVG.HELP_CIRCLE_OUTLINE));
-                        helpItem.activeProperty().bind(tab.getSelectionModel().selectedItemProperty().isEqualTo(helpTab));
-                        helpItem.setOnAction(e -> tab.select(helpTab));
-                    })
-                    .addNavigationDrawerItem(feedbackItem -> {
-                        feedbackItem.setTitle(i18n("feedback"));
-                        feedbackItem.setLeftGraphic(wrap(SVG.MESSAGE_ALERT_OUTLINE));
-                        feedbackItem.activeProperty().bind(tab.getSelectionModel().selectedItemProperty().isEqualTo(feedbackTab));
-                        feedbackItem.setOnAction(e -> tab.select(feedbackTab));
-                    })
-                    .addNavigationDrawerItem(aboutItem -> {
-                        aboutItem.setTitle(i18n("about"));
-                        aboutItem.setLeftGraphic(wrap(SVG.INFORMATION_OUTLINE));
-                        aboutItem.activeProperty().bind(tab.getSelectionModel().selectedItemProperty().isEqualTo(aboutTab));
-                        aboutItem.setOnAction(e -> tab.select(aboutTab));
-                    });
-            FXUtils.setLimitWidth(sideBar, 200);
-            setLeft(sideBar);
-        }
+        AdvancedListBox sideBar = new AdvancedListBox()
+                .addNavigationDrawerTab(tab, gameTab, i18n("settings.type.global.manage"), SVG.GAMEPAD)
+                .addNavigationDrawerTab(tab, javaManagementTab, i18n("java.management"), SVG.WRENCH_OUTLINE)
+                .startCategory(i18n("launcher").toUpperCase(Locale.ROOT))
+                .addNavigationDrawerTab(tab, settingsTab, i18n("settings.launcher.general"), SVG.APPLICATION_OUTLINE)
+                .addNavigationDrawerTab(tab, personalizationTab, i18n("settings.launcher.appearance"), SVG.STYLE_OUTLINE)
+                .addNavigationDrawerTab(tab, downloadTab, i18n("download"), SVG.DOWNLOAD_OUTLINE)
+                .startCategory(i18n("help").toUpperCase(Locale.ROOT))
+                .addNavigationDrawerTab(tab, helpTab, i18n("help"), SVG.HELP_CIRCLE_OUTLINE)
+                .addNavigationDrawerTab(tab, feedbackTab, i18n("feedback"), SVG.MESSAGE_ALERT_OUTLINE)
+                .addNavigationDrawerTab(tab, aboutTab, i18n("about"), SVG.INFORMATION_OUTLINE);
+        FXUtils.setLimitWidth(sideBar, 200);
+        setLeft(sideBar);
 
         setCenter(transitionPane);
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/GameListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/GameListPage.java
@@ -87,26 +87,10 @@ public class GameListPage extends DecoratorAnimatedPage implements DecoratorPage
             }
 
             AdvancedListBox bottomLeftCornerList = new AdvancedListBox()
-                    .addNavigationDrawerItem(installNewGameItem -> {
-                        installNewGameItem.setTitle(i18n("install.new_game"));
-                        installNewGameItem.setLeftGraphic(VersionPage.wrap(SVG.PLUS_CIRCLE_OUTLINE));
-                        installNewGameItem.setOnAction(e -> Versions.addNewGame());
-                    })
-                    .addNavigationDrawerItem(installModpackItem -> {
-                        installModpackItem.setTitle(i18n("install.modpack"));
-                        installModpackItem.setLeftGraphic(VersionPage.wrap(SVG.PACK));
-                        installModpackItem.setOnAction(e -> Versions.importModpack());
-                    })
-                    .addNavigationDrawerItem(refreshItem -> {
-                        refreshItem.setTitle(i18n("button.refresh"));
-                        refreshItem.setLeftGraphic(VersionPage.wrap(SVG.REFRESH));
-                        refreshItem.setOnAction(e -> gameList.refreshList());
-                    })
-                    .addNavigationDrawerItem(globalManageItem -> {
-                        globalManageItem.setTitle(i18n("settings.type.global.manage"));
-                        globalManageItem.setLeftGraphic(VersionPage.wrap(SVG.GEAR_OUTLINE));
-                        globalManageItem.setOnAction(e -> modifyGlobalGameSettings());
-                    });
+                    .addNavigationDrawerItem(i18n("install.new_game"), SVG.PLUS_CIRCLE_OUTLINE, Versions::addNewGame)
+                    .addNavigationDrawerItem(i18n("install.modpack"), SVG.PACK, Versions::importModpack)
+                    .addNavigationDrawerItem(i18n("button.refresh"), SVG.REFRESH, gameList::refreshList)
+                    .addNavigationDrawerItem(i18n("settings.type.global.manage"), SVG.GEAR_OUTLINE, this::modifyGlobalGameSettings);
             FXUtils.setLimitHeight(bottomLeftCornerList, 40 * 4 + 12 * 2);
             setLeft(pane, bottomLeftCornerList);
         }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionPage.java
@@ -308,25 +308,14 @@ public class VersionPage extends DecoratorAnimatedPage implements DecoratorPage 
                 );
 
                 AdvancedListBox toolbar = new AdvancedListBox()
-                        .addNavigationDrawerItem(upgradeItem -> {
-                            upgradeItem.setTitle(i18n("version.update"));
-                            upgradeItem.setLeftGraphic(wrap(SVG.UPDATE));
+                        .addNavigationDrawerItem(i18n("version.update"), SVG.UPDATE, control::updateGame, upgradeItem -> {
                             upgradeItem.visibleProperty().bind(control.currentVersionUpgradable);
-                            upgradeItem.setOnAction(e -> control.updateGame());
                         })
-                        .addNavigationDrawerItem(testGameItem -> {
-                            testGameItem.setTitle(i18n("version.launch.test"));
-                            testGameItem.setLeftGraphic(wrap(SVG.ROCKET_LAUNCH_OUTLINE));
-                            testGameItem.setOnAction(e -> control.testGame());
-                        })
-                        .addNavigationDrawerItem(browseMenuItem -> {
-                            browseMenuItem.setTitle(i18n("settings.game.exploration"));
-                            browseMenuItem.setLeftGraphic(wrap(SVG.FOLDER_OUTLINE));
+                        .addNavigationDrawerItem(i18n("version.launch.test"), SVG.ROCKET_LAUNCH_OUTLINE, control::testGame)
+                        .addNavigationDrawerItem(i18n("settings.game.exploration"), SVG.FOLDER_OUTLINE, null, browseMenuItem -> {
                             browseMenuItem.setOnAction(e -> browsePopup.show(browseMenuItem, JFXPopup.PopupVPosition.BOTTOM, JFXPopup.PopupHPosition.LEFT, browseMenuItem.getWidth(), 0));
                         })
-                        .addNavigationDrawerItem(managementItem -> {
-                            managementItem.setTitle(i18n("settings.game.management"));
-                            managementItem.setLeftGraphic(wrap(SVG.WRENCH_OUTLINE));
+                        .addNavigationDrawerItem(i18n("settings.game.management"), SVG.WRENCH_OUTLINE, null, managementItem -> {
                             managementItem.setOnAction(e -> managementPopup.show(managementItem, JFXPopup.PopupVPosition.BOTTOM, JFXPopup.PopupHPosition.LEFT, managementItem.getWidth(), 0));
                         });
                 toolbar.getStyleClass().add("advanced-list-box-clear-padding");


### PR DESCRIPTION
本 PR 中创建了一个新的工具类 `ByteArrayOutputBuffer` 用于替代 `ByteArrayOutputStream`。

相比原始的 `ByteArrayOutputStream`，`ByteArrayOutputBuffer` 新增以下功能：

* 能够直接利用内部数组从 `InputStream` 中读取数据，避免创建额外的临时数组和二次数据拷贝；
* 公开内部数组，允许在已知安全的情况下直接复用该数组。
