### PR TITLE
更新 GitHub Action 脚本

### DIFF
--- a/.github/workflows/build-launcher.yml
+++ b/.github/workflows/build-launcher.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Get short SHA
         run: echo "SHORT_SHA=$("${{ github.sha }}".SubString(0, 7))" >> $env:GITHUB_ENV
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: HMCLauncher-${{ env.SHORT_SHA }}
           path: HMCLauncher/Release/HMCLauncher.exe

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -4,13 +4,11 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '11'

--- a/.github/workflows/check-translations.yml
+++ b/.github/workflows/check-translations.yml
@@ -4,13 +4,11 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '11'

--- a/.github/workflows/check-update.yml
+++ b/.github/workflows/check-update.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.repository_owner == 'HMCL-dev' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Fetch tags
         run: git fetch --all --tags
       - name: Install tools

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: '11'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Get short SHA
       run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: HMCL-${{ env.SHORT_SHA }}
         path: HMCL/build/libs


### PR DESCRIPTION
通过更新 `actions/checkout`、`actions/setup-java` 以及 `actions/upload-artifact` 至 v4 避免 Node.js 16 的弃用警告。