### PR TITLE
支持从当前路径加载字体

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Theme.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Theme.java
@@ -23,6 +23,7 @@ import com.google.gson.stream.JsonWriter;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.ObjectBinding;
 import javafx.scene.paint.Color;
+import javafx.scene.text.Font;
 import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.Logging;
 import org.jackhuang.hmcl.util.io.FileUtils;
@@ -30,8 +31,12 @@ import org.jackhuang.hmcl.util.io.IOUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
@@ -82,6 +87,30 @@ public class Theme {
         return cssCharset;
     }
 
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private static Optional<Font> font;
+
+    private static Optional<Font> tryLoadFont() {
+        //noinspection OptionalAssignedToNull
+        if (font != null) {
+            return font;
+        }
+
+        Path path = Paths.get("font.ttf");
+        if (!Files.isRegularFile(path)) {
+            path = Paths.get("font.otf");
+        }
+
+        if (Files.isRegularFile(path)) {
+            try {
+                return font = Optional.ofNullable(Font.loadFont(path.toAbsolutePath().toUri().toURL().toExternalForm(), 0));
+            } catch (MalformedURLException ignored) {
+            }
+        }
+
+        return font = Optional.empty();
+    }
+
     public static Theme getTheme() {
         Theme theme = config().getTheme();
         return theme == null ? BLUE : theme;
@@ -121,9 +150,24 @@ public class Theme {
         String css = "/assets/css/blue.css";
 
         String fontFamily = System.getProperty("hmcl.font.override", overrideFontFamily);
+        String fontStyle = null;
+        if (fontFamily == null) {
+            Optional<Font> font = tryLoadFont();
+            if (font.isPresent()) {
+                fontFamily = font.get().getFamily();
+                fontStyle = font.get().getStyle();
+            }
+        }
 
         if (fontFamily != null || !this.color.equalsIgnoreCase(BLUE.color)) {
             Color textFill = getForegroundColor();
+            String fontCss = "";
+            if (fontFamily != null) {
+                fontCss = "-fx-font-family: \"" + fontFamily + "\";";
+                if (fontStyle != null && !fontStyle.isEmpty())
+                    fontCss += " -fx-font-style: \"" + fontStyle + "\";";
+            }
+
             try {
                 File temp = File.createTempFile("hmcl", ".css");
                 String themeText = IOUtils.readFullyAsString(Theme.class.getResourceAsStream("/assets/css/custom.css"))
@@ -134,7 +178,7 @@ public class Theme {
                         .replace("%base-rippler-color%", String.format("rgba(%d, %d, %d, 0.3)", (int) Math.ceil(paint.getRed() * 256), (int) Math.ceil(paint.getGreen() * 256), (int) Math.ceil(paint.getBlue() * 256)))
                         .replace("%disabled-font-color%", String.format("rgba(%d, %d, %d, 0.7)", (int) Math.ceil(textFill.getRed() * 256), (int) Math.ceil(textFill.getGreen() * 256), (int) Math.ceil(textFill.getBlue() * 256)))
                         .replace("%font-color%", getColorDisplayName(getForegroundColor()))
-                        .replace("%font%", Optional.ofNullable(fontFamily).map(f -> "-fx-font-family: \"" + f + "\";").orElse(""));
+                        .replace("%font%", fontCss);
                 FileUtils.writeText(temp, themeText, getCssCharset());
                 temp.deleteOnExit();
                 css = temp.toURI().toString();


### PR DESCRIPTION
本 PR 使 HMCL 在未设置字体时会尝试从当前路径寻找 `font.ttf` 或 `font.otf` 并加载为默认字体。

这项功能的目的是：

* 使整合包作者能够更方便地定制 HMCL 界面字体
* 给界面乱码问题提供一个简单易操作的解决方案