### PR TITLE
[Feature] 提供基于 GitHub Action 的仓库管理工具

### DIFF
--- a/.github/workflows/repository-management.yml
+++ b/.github/workflows/repository-management.yml
@@ -18,4 +18,5 @@ jobs:
           HMCL_TARGET_ID: ${{ github.event.comment.issue.number }}
           HMCL_TARGET_COMMAND: ${{ github.event.comment.body }}
         run: |
+          echo "Editing the title of issue $HMCL_TARGET_ID to ${HMCL_TARGET_COMMAND:18}"
           gh issue edit $HMCL_TARGET_ID --title "${HMCL_TARGET_COMMAND:18}" --repo $GITHUB_REPOSITORY

--- a/.github/workflows/repository-management.yml
+++ b/.github/workflows/repository-management.yml
@@ -18,4 +18,4 @@ jobs:
           HMCL_TARGET_ID: ${{ github.event.comment.id }}
           HMCL_TARGET_COMMAND: ${{ github.event.comment.body }}
         run: |
-          gh issue edit $HMCL_TARGET_ID --title "${HMCL_TARGET_COMMAND:18}"
+          gh issue edit $HMCL_TARGET_ID --title "${HMCL_TARGET_COMMAND:18}" --repo $GITHUB_REPOSITORY

--- a/.github/workflows/repository-management.yml
+++ b/.github/workflows/repository-management.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Rename the Issue or PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HMCL_TARGET_ID: ${{ github.event.comment.issue.number }}
+          HMCL_TARGET_ID: ${{ github.event.issue.number }}
           HMCL_TARGET_COMMAND: ${{ github.event.comment.body }}
         run: |
           echo "Editing the title of issue $HMCL_TARGET_ID to ${HMCL_TARGET_COMMAND:18}"

--- a/.github/workflows/repository-management.yml
+++ b/.github/workflows/repository-management.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
 
     steps:
       - name: Rename the Issue or PR

--- a/.github/workflows/repository-management.yml
+++ b/.github/workflows/repository-management.yml
@@ -1,0 +1,21 @@
+name: Repository Management Utils
+
+on:
+  issue_comment:
+    types: [ created, edited ]
+
+jobs:
+  process:
+    if: ${{ startsWith(github.event.comment.body, '/management title ') && contains(fromJSON('["COLLABORATOR", "MEMBER", "OWNER"]'), github.event.comment.author_association) }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Rename the Issue or PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HMCL_TARGET_ID: ${{ github.event.comment.id }}
+          HMCL_TARGET_COMMAND: ${{ github.event.comment.body }}
+        run: |
+          gh issue edit $HMCL_TARGET_ID --title "${HMCL_TARGET_COMMAND:18}"

--- a/.github/workflows/repository-management.yml
+++ b/.github/workflows/repository-management.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Rename the Issue or PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HMCL_TARGET_ID: ${{ github.event.comment.id }}
+          HMCL_TARGET_ID: ${{ github.event.comment.issue.number }}
           HMCL_TARGET_COMMAND: ${{ github.event.comment.body }}
         run: |
           gh issue edit $HMCL_TARGET_ID --title "${HMCL_TARGET_COMMAND:18}" --repo $GITHUB_REPOSITORY


### PR DESCRIPTION
目前 HMCL-dev 是免费组织，我们无法设置详细的权限配置来让组织成员能够修改 Issue / PR 的标题。
但目前 Issue 标题极其混乱，严重影响了查找和修复进程。

本 PR 引入了一套工具，组织的 Member / Collaborator / Owner 均可执行
```
/management title <New Title>
```
来设置该 Issue / Pull Request 的标题。

例：
- https://github.com/burningtnt/HMCL/issues/7
- https://github.com/burningtnt/HMCL/pull/8