### PR TITLE
Fix #3071: 在 HMCL 被终结时停止日志线程

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/Logger.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/Logger.java
@@ -111,14 +111,14 @@ public final class Logger {
         }
     }
 
-    private void onShutdown() {
+    private void onExit() {
         shutdown();
         try {
             loggerThread.join();
         } catch (InterruptedException ignored) {
         }
 
-        String caller = CLASS_NAME + ".onShutdown";
+        String caller = CLASS_NAME + ".onExit";
 
         if (logRetention > 0 && logFile != null) {
             List<Pair<Path, int[]>> list = new ArrayList<>();
@@ -259,7 +259,7 @@ public final class Logger {
         loggerThread.setName("HMCL Logger Thread");
         loggerThread.start();
 
-        Thread cleanerThread = new Thread(this::onShutdown);
+        Thread cleanerThread = new Thread(this::onExit);
         cleanerThread.setName("HMCL Logger Shutdown Hook");
         Runtime.getRuntime().addShutdownHook(cleanerThread);
     }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/Logger.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/Logger.java
@@ -112,6 +112,7 @@ public final class Logger {
     }
 
     private void onShutdown() {
+        shutdown();
         try {
             loggerThread.join();
         } catch (InterruptedException ignored) {


### PR DESCRIPTION
loggerThread.join()陷入死循环，因此设置等待时长来解决这个问题

100ms理论上足够计算机处理大部分日志指令了