### PR TITLE
Fix #3099 修复自动安装选项卡重新选择版本（Minecraft版本和模组加载器版本）的按钮消失的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
@@ -299,7 +299,7 @@ public class InstallerItem extends Control {
                     control.upgradable));
             arrowButton.getStyleClass().add("toggle-icon4");
             arrowButton.visibleProperty().bind(Bindings.createBooleanBinding(
-                    () -> control.installable.get() && control.libraryVersion.get() == null && control.incompatibleLibraryName.get() == null,
+                    () -> control.installable.get() && control.incompatibleLibraryName.get() == null,
                     control.installable, control.libraryVersion, control.incompatibleLibraryName
             ));
             arrowButton.managedProperty().bind(arrowButton.visibleProperty());


### PR DESCRIPTION
Fix #3099