### PR TITLE
修复 #3080 微软账户无法正确读取 Token 过期时间的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/microsoft/MicrosoftSession.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/microsoft/MicrosoftSession.java
@@ -18,8 +18,8 @@
 package org.jackhuang.hmcl.auth.microsoft;
 
 import org.jackhuang.hmcl.auth.AuthInfo;
-import org.jackhuang.hmcl.util.logging.Logger;
 import org.jackhuang.hmcl.util.gson.UUIDTypeAdapter;
+import org.jackhuang.hmcl.util.logging.Logger;
 
 import java.util.Map;
 import java.util.UUID;
@@ -87,7 +87,7 @@ public class MicrosoftSession {
                 .orElseThrow(() -> new IllegalArgumentException("accessToken is missing"));
         String refreshToken = tryCast(storage.get("refreshToken"), String.class)
                 .orElseThrow(() -> new IllegalArgumentException("refreshToken is missing"));
-        Long notAfter = tryCast(storage.get("notAfter"), Long.class).orElse(0L);
+        Long notAfter = tryCast(storage.get("notAfter"), Number.class).map(Number::longValue).orElse(0L);
         String userId = tryCast(storage.get("userid"), String.class)
                 .orElseThrow(() -> new IllegalArgumentException("userid is missing"));
         return new MicrosoftSession(tokenType, accessToken, notAfter, refreshToken, new User(userId), new GameProfile(uuid, name));


### PR DESCRIPTION
Fix #3080

Gson 默认将该值反序列化为 Double