### PR TITLE
add: linux search potential java executables path

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/JavaVersion.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/JavaVersion.java
@@ -329,6 +329,7 @@ public final class JavaVersion {
                 javaExecutables.add(listDirectory(Paths.get("/usr/java")).map(JavaVersion::getExecutable)); // Oracle RPMs
                 javaExecutables.add(listDirectory(Paths.get("/usr/lib/jvm")).map(JavaVersion::getExecutable)); // General locations
                 javaExecutables.add(listDirectory(Paths.get("/usr/lib32/jvm")).map(JavaVersion::getExecutable)); // General locations
+                javaExecutables.add(listDirectory(Paths.get("/usr/lib64/jvm")).map(JavaVersion::getExecutable)); // General locations
                 break;
 
             case OSX:


### PR DESCRIPTION
openSUSE 的 jdk 安装目录是在 `/usr/lib64/jvm` 中的