### PR TITLE
[提案] 提升超时时间至 16s

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/NetworkUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/NetworkUtils.java
@@ -34,7 +34,7 @@ import static org.jackhuang.hmcl.util.StringUtils.*;
 public final class NetworkUtils {
     public static final String PARAMETER_SEPARATOR = "&";
     public static final String NAME_VALUE_SEPARATOR = "=";
-    private static final int TIME_OUT = 8000;
+    private static final int TIME_OUT = 16000;
 
     private NetworkUtils() {
     }


### PR DESCRIPTION
如题。接用户反馈，近期中国大陆地区 CurseForge / Modrinth 连接情况进一步下降，因此需要提升超时时间。

本更改将在 PR Collection 通过用户群测试后决定其必要性