### PR TITLE
修复无法寻找所有 Homebrew 安装的 openjdk 的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/JavaVersion.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/JavaVersion.java
@@ -345,8 +345,15 @@ public final class JavaVersion {
                 javaExecutables.add(Stream.of(Paths.get("/Applications/Xcode.app/Contents/Applications/Application Loader.app/Contents/MacOS/itms/java/bin/java")));
                 // Homebrew
                 javaExecutables.add(Stream.of(Paths.get("/opt/homebrew/opt/java/bin/java")));
-                javaExecutables.add(listDirectory(Paths.get("/opt/homebrew/Cellar/openjdk"))
-                        .map(JavaVersion::getExecutable));
+                javaExecutables.add(Files.list(Paths.get("/opt/homebrew/Cellar"))
+                        .filter(dir -> dir.getFileName().toString().startsWith("openjdk"))
+                        .flatMap(dir -> {
+                            try {
+                                return listDirectory(dir).map(JavaVersion::getExecutable);
+                            } catch (IOException e) {
+                                return Stream.empty();
+                            }
+                        }));
                 break;
 
             default:


### PR DESCRIPTION
Homebrew安装指定openjdk版本时，/opt/homebrew/Cellar下的软件包路径会带有"@版本号"后缀，因此指定检索/opt/homebrew/Cellar/openjdk只能找到最新的openjdk。将检索逻辑更改为检查/opt/homebrew/Cellar下所有"openjdk"开头的子目录。