### PR TITLE
支持 Forge 官方源

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/MojangDownloadProvider.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/MojangDownloadProvider.java
@@ -19,7 +19,7 @@ package org.jackhuang.hmcl.download;
 
 import org.jackhuang.hmcl.download.fabric.FabricAPIVersionList;
 import org.jackhuang.hmcl.download.fabric.FabricVersionList;
-import org.jackhuang.hmcl.download.forge.ForgeBMCLVersionList;
+import org.jackhuang.hmcl.download.forge.ForgeVersionList;
 import org.jackhuang.hmcl.download.game.GameVersionList;
 import org.jackhuang.hmcl.download.liteloader.LiteLoaderVersionList;
 import org.jackhuang.hmcl.download.neoforge.NeoForgeOfficialVersionList;
@@ -35,7 +35,7 @@ public class MojangDownloadProvider implements DownloadProvider {
     private final GameVersionList game;
     private final FabricVersionList fabric;
     private final FabricAPIVersionList fabricApi;
-    private final ForgeBMCLVersionList forge;
+    private final ForgeVersionList forge;
     private final NeoForgeOfficialVersionList neoforge;
     private final LiteLoaderVersionList liteLoader;
     private final OptiFineBMCLVersionList optifine;
@@ -49,7 +49,7 @@ public class MojangDownloadProvider implements DownloadProvider {
         this.game = new GameVersionList(this);
         this.fabric = new FabricVersionList(this);
         this.fabricApi = new FabricAPIVersionList(this);
-        this.forge = new ForgeBMCLVersionList(apiRoot);
+        this.forge = new ForgeVersionList(this);
         this.neoforge = new NeoForgeOfficialVersionList(this);
         this.liteLoader = new LiteLoaderVersionList(this);
         this.optifine = new OptiFineBMCLVersionList(apiRoot);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeVersionList.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeVersionList.java
@@ -53,7 +53,7 @@ public final class ForgeVersionList extends VersionList<ForgeRemoteVersion> {
 
     @Override
     public CompletableFuture<?> refreshAsync() {
-        return HttpRequest.GET(FORGE_LIST).getJsonAsync(ForgeVersionRoot.class)
+        return HttpRequest.GET(downloadProvider.injectURL(FORGE_LIST)).getJsonAsync(ForgeVersionRoot.class)
                 .thenAcceptAsync(root -> {
                     lock.writeLock().lock();
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeVersionList.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeVersionList.java
@@ -43,9 +43,17 @@ public final class ForgeVersionList extends VersionList<ForgeRemoteVersion> {
         return false;
     }
 
+    private static String toLookupVersion(String gameVersion) {
+        return "1.7.10-pre4".equals(gameVersion) ? "1.7.10_pre4" : gameVersion;
+    }
+
+    private static String fromLookupVersion(String lookupVersion) {
+        return "1.7.10_pre4".equals(lookupVersion) ? "1.7.10-pre4" : lookupVersion;
+    }
+
     @Override
     public CompletableFuture<?> refreshAsync() {
-        return HttpRequest.GET(downloadProvider.injectURL(FORGE_LIST)).getJsonAsync(ForgeVersionRoot.class)
+        return HttpRequest.GET(FORGE_LIST).getJsonAsync(ForgeVersionRoot.class)
                 .thenAcceptAsync(root -> {
                     lock.writeLock().lock();
 
@@ -55,7 +63,7 @@ public final class ForgeVersionList extends VersionList<ForgeRemoteVersion> {
                         versions.clear();
 
                         for (Map.Entry<String, int[]> entry : root.getGameVersions().entrySet()) {
-                            String gameVersion = VersionNumber.normalize(entry.getKey());
+                            String gameVersion = fromLookupVersion(VersionNumber.normalize(entry.getKey()));
                             for (int v : entry.getValue()) {
                                 ForgeVersion version = root.getNumber().get(v);
                                 if (version == null)
@@ -72,7 +80,7 @@ public final class ForgeVersionList extends VersionList<ForgeRemoteVersion> {
                                 if (jar == null)
                                     continue;
                                 versions.put(gameVersion, new ForgeRemoteVersion(
-                                        version.getGameVersion(), version.getVersion(), null, Collections.singletonList(jar)
+                                        toLookupVersion(version.getGameVersion()), version.getVersion(), null, Collections.singletonList(jar)
                                 ));
                             }
                         }
@@ -82,5 +90,5 @@ public final class ForgeVersionList extends VersionList<ForgeRemoteVersion> {
                 });
     }
 
-    public static final String FORGE_LIST = "https://files.minecraftforge.net/maven/net/minecraftforge/forge/json";
+    public static final String FORGE_LIST = "https://zkitefly.github.io/forge-maven-metadata/list.json";
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeVersionList.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeVersionList.java
@@ -53,7 +53,7 @@ public final class ForgeVersionList extends VersionList<ForgeRemoteVersion> {
 
     @Override
     public CompletableFuture<?> refreshAsync() {
-        return HttpRequest.GET(downloadProvider.injectURL(FORGE_LIST)).getJsonAsync(ForgeVersionRoot.class)
+        return HttpRequest.GET(FORGE_LIST).getJsonAsync(ForgeVersionRoot.class)
                 .thenAcceptAsync(root -> {
                     lock.writeLock().lock();
 


### PR DESCRIPTION
使用了 https://github.com/zkitefly/forge-maven-metadata 的 https://zkitefly.github.io/forge-maven-metadata/list.json

该 json 格式根据 [https://bmclapi.bangbang93.com/maven/net/minecraftforge/forge/json](https://bmclapi.bangbang93.com/maven/net/minecraftforge/forge/json) 和代码必要参数


https://github.com/user-attachments/assets/e2f0d0d2-9ef1-4be8-b3ad-bea48ee68613

![image](https://github.com/user-attachments/assets/97343736-8ae0-4ac7-9779-e2c034380f56)

**由于目前 BMCLAPI 队国外 IP 进行封禁，需要增加 Forge 官方源减少国外玩家所受到的影响**

顺便合并一下 https://github.com/HMCL-dev/HMCL/pull/2719 吧