### PR TITLE
Adjust the order of sidebars in instance settings

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionPage.java
@@ -56,8 +56,8 @@ public class VersionPage extends DecoratorAnimatedPage implements DecoratorPage 
     private final ReadOnlyObjectWrapper<State> state = new ReadOnlyObjectWrapper<>();
     private final TabHeader tab;
     private final TabHeader.Tab<VersionSettingsPage> versionSettingsTab = new TabHeader.Tab<>("versionSettingsTab");
-    private final TabHeader.Tab<ModListPage> modListTab = new TabHeader.Tab<>("modListTab");
     private final TabHeader.Tab<InstallerListPage> installerListTab = new TabHeader.Tab<>("installerListTab");
+    private final TabHeader.Tab<ModListPage> modListTab = new TabHeader.Tab<>("modListTab");
     private final TabHeader.Tab<WorldListPage> worldListTab = new TabHeader.Tab<>("worldList");
     private final TransitionPane transitionPane = new TransitionPane();
     private final BooleanProperty currentVersionUpgradable = new SimpleBooleanProperty();
@@ -68,11 +68,11 @@ public class VersionPage extends DecoratorAnimatedPage implements DecoratorPage 
 
     {
         versionSettingsTab.setNodeSupplier(loadVersionFor(() -> new VersionSettingsPage(false)));
-        modListTab.setNodeSupplier(loadVersionFor(ModListPage::new));
         installerListTab.setNodeSupplier(loadVersionFor(InstallerListPage::new));
+        modListTab.setNodeSupplier(loadVersionFor(ModListPage::new));
         worldListTab.setNodeSupplier(loadVersionFor(WorldListPage::new));
 
-        tab = new TabHeader(versionSettingsTab, modListTab, installerListTab, worldListTab);
+        tab = new TabHeader(versionSettingsTab, installerListTab, modListTab, worldListTab);
 
         addEventHandler(Navigator.NavigationEvent.NAVIGATED, this::onNavigated);
 
@@ -128,10 +128,10 @@ public class VersionPage extends DecoratorAnimatedPage implements DecoratorPage 
 
         if (versionSettingsTab.isInitialized())
             versionSettingsTab.getNode().loadVersion(profile, version);
-        if (modListTab.isInitialized())
-            modListTab.getNode().loadVersion(profile, version);
         if (installerListTab.isInitialized())
             installerListTab.getNode().loadVersion(profile, version);
+        if (modListTab.isInitialized())
+            modListTab.getNode().loadVersion(profile, version);
         if (worldListTab.isInitialized())
             worldListTab.getNode().loadVersion(profile, version);
         currentVersionUpgradable.set(profile.getRepository().isModpack(version));
@@ -247,15 +247,6 @@ public class VersionPage extends DecoratorAnimatedPage implements DecoratorPage 
                 runInFX(() -> FXUtils.installFastTooltip(versionSettingsItem, i18n("settings.game")));
                 versionSettingsItem.setOnAction(e -> control.tab.select(control.versionSettingsTab));
 
-                AdvancedListItem modListItem = new AdvancedListItem();
-                modListItem.getStyleClass().add("navigation-drawer-item");
-                modListItem.setTitle(i18n("mods.manage"));
-                modListItem.setLeftGraphic(wrap(SVG.PUZZLE));
-                modListItem.setActionButtonVisible(false);
-                modListItem.activeProperty().bind(control.tab.getSelectionModel().selectedItemProperty().isEqualTo(control.modListTab));
-                runInFX(() -> FXUtils.installFastTooltip(modListItem, i18n("mods.manage")));
-                modListItem.setOnAction(e -> control.tab.select(control.modListTab));
-
                 AdvancedListItem installerListItem = new AdvancedListItem();
                 installerListItem.getStyleClass().add("navigation-drawer-item");
                 installerListItem.setTitle(i18n("settings.tabs.installers"));
@@ -264,6 +255,15 @@ public class VersionPage extends DecoratorAnimatedPage implements DecoratorPage 
                 installerListItem.activeProperty().bind(control.tab.getSelectionModel().selectedItemProperty().isEqualTo(control.installerListTab));
                 runInFX(() -> FXUtils.installFastTooltip(installerListItem, i18n("settings.tabs.installers")));
                 installerListItem.setOnAction(e -> control.tab.select(control.installerListTab));
+
+                AdvancedListItem modListItem = new AdvancedListItem();
+                modListItem.getStyleClass().add("navigation-drawer-item");
+                modListItem.setTitle(i18n("mods.manage"));
+                modListItem.setLeftGraphic(wrap(SVG.PUZZLE));
+                modListItem.setActionButtonVisible(false);
+                modListItem.activeProperty().bind(control.tab.getSelectionModel().selectedItemProperty().isEqualTo(control.modListTab));
+                runInFX(() -> FXUtils.installFastTooltip(modListItem, i18n("mods.manage")));
+                modListItem.setOnAction(e -> control.tab.select(control.modListTab));
 
                 AdvancedListItem worldListItem = new AdvancedListItem();
                 worldListItem.getStyleClass().add("navigation-drawer-item");
@@ -276,8 +276,8 @@ public class VersionPage extends DecoratorAnimatedPage implements DecoratorPage 
 
                 AdvancedListBox sideBar = new AdvancedListBox()
                         .add(versionSettingsItem)
-                        .add(modListItem)
                         .add(installerListItem)
+                        .add(modListItem)
                         .add(worldListItem);
                 VBox.setVgrow(sideBar, Priority.ALWAYS);
 


### PR DESCRIPTION
<details>
<summary>Before</summary>

![hmcl-instance-settings-sidebar-order-before](https://github.com/user-attachments/assets/99c01513-8af9-4d4d-b212-8dd324a32103)

</details>

<details>
<summary>After</summary>

![hmcl-instance-settings-sidebar-order-after](https://github.com/user-attachments/assets/3f79eeb2-d46c-4557-ad55-7285d0beed23)

</details>

A minor QOL change. Logically, instance settings and loader versions are the first things that an experienced Minecraft player would adjust. Also, the manage mods page is useless if no loaders are installed, so the loaders page should be prioritized higher.