### PR TITLE
使用 TypeToken 替代 Type

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLModpackInstallTask.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLModpackInstallTask.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.game;
 
 import com.google.gson.JsonParseException;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.download.DefaultDependencyManager;
 import org.jackhuang.hmcl.download.LibraryAnalyzer;
 import org.jackhuang.hmcl.mod.MinecraftInstanceTask;
@@ -67,8 +66,7 @@ public final class HMCLModpackInstallTask extends Task<Void> {
         ModpackConfiguration<Modpack> config = null;
         try {
             if (json.exists()) {
-                config = JsonUtils.GSON.fromJson(FileUtils.readText(json), new TypeToken<ModpackConfiguration<Modpack>>() {
-                }.getType());
+                config = JsonUtils.GSON.fromJson(FileUtils.readText(json), ModpackConfiguration.typeOf(Modpack.class));
 
                 if (!HMCLModpackProvider.INSTANCE.getName().equals(config.getType()))
                     throw new IllegalArgumentException("Version " + name + " is not a HMCL modpack. Cannot update this version.");

--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/ModpackHelper.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/ModpackHelper.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.game;
 
 import com.google.gson.JsonParseException;
-import com.google.gson.reflect.TypeToken;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.jackhuang.hmcl.mod.*;
 import org.jackhuang.hmcl.mod.curse.CurseModpackProvider;
@@ -141,8 +140,7 @@ public final class ModpackHelper {
             throw new FileNotFoundException(file.getPath());
         else
             try {
-                return JsonUtils.GSON.fromJson(FileUtils.readText(file), new TypeToken<ModpackConfiguration<?>>() {
-                }.getType());
+                return JsonUtils.GSON.fromJson(FileUtils.readText(file), ModpackConfiguration.class);
             } catch (JsonParseException e) {
                 throw new IOException("Malformed modpack configuration");
             }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/java/JavaManifest.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/java/JavaManifest.java
@@ -19,7 +19,6 @@ package org.jackhuang.hmcl.java;
 
 import com.google.gson.*;
 import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.util.platform.Architecture;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 import org.jackhuang.hmcl.util.platform.Platform;
@@ -28,6 +27,8 @@ import org.jetbrains.annotations.Nullable;
 import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.Optional;
+
+import static org.jackhuang.hmcl.util.gson.JsonUtils.mapTypeOf;
 
 /**
  * @author Glavo
@@ -63,8 +64,7 @@ public final class JavaManifest {
 
     public static final class Serializer implements JsonSerializer<JavaManifest>, JsonDeserializer<JavaManifest> {
 
-        private static final Type LOCAL_FILES_TYPE = new TypeToken<Map<String, JavaLocalFiles.Local>>() {
-        }.getType();
+        private static final Type LOCAL_FILES_TYPE = mapTypeOf(String.class, JavaLocalFiles.Local.class).getType();
 
         @Override
         public JsonElement serialize(JavaManifest src, Type typeOfSrc, JsonSerializationContext context) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Accounts.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Accounts.java
@@ -17,7 +17,6 @@
  */
 package org.jackhuang.hmcl.setting;
 
-import com.google.gson.reflect.TypeToken;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.property.ObjectProperty;
@@ -55,6 +54,8 @@ import static org.jackhuang.hmcl.ui.FXUtils.onInvalidating;
 import static org.jackhuang.hmcl.util.Lang.immutableListOf;
 import static org.jackhuang.hmcl.util.Lang.mapOf;
 import static org.jackhuang.hmcl.util.Pair.pair;
+import static org.jackhuang.hmcl.util.gson.JsonUtils.listTypeOf;
+import static org.jackhuang.hmcl.util.gson.JsonUtils.mapTypeOf;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 import static org.jackhuang.hmcl.util.logging.Logger.LOG;
 
@@ -171,14 +172,11 @@ public final class Accounts {
             config().getAccountStorages().setAll(portable);
     }
 
-    @SuppressWarnings("unchecked")
     private static void loadGlobalAccountStorages() {
         Path globalAccountsFile = Metadata.HMCL_DIRECTORY.resolve("accounts.json");
         if (Files.exists(globalAccountsFile)) {
             try (Reader reader = Files.newBufferedReader(globalAccountsFile)) {
-                globalAccountStorages.setAll((List<Map<Object, Object>>)
-                        Config.CONFIG_GSON.fromJson(reader, new TypeToken<List<Map<Object, Object>>>() {
-                        }.getType()));
+                globalAccountStorages.setAll(Config.CONFIG_GSON.fromJson(reader, listTypeOf(mapTypeOf(Object.class, Object.class))));
             } catch (Throwable e) {
                 LOG.warning("Failed to load global accounts", e);
             }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/HelpPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/HelpPage.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.ui.main;
 
 import com.google.gson.annotations.SerializedName;
-import com.google.gson.reflect.TypeToken;
 import javafx.geometry.Insets;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.VBox;
@@ -34,6 +33,7 @@ import org.jackhuang.hmcl.util.io.HttpRequest;
 import java.util.Collections;
 import java.util.List;
 
+import static org.jackhuang.hmcl.util.gson.JsonUtils.listTypeOf;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
 public class HelpPage extends SpinnerPane {
@@ -63,8 +63,7 @@ public class HelpPage extends SpinnerPane {
 
     private void loadHelp() {
         showSpinner();
-        Task.<List<HelpCategory>>supplyAsync(() -> HttpRequest.GET("https://docs.hmcl.net/index.json").getJson(new TypeToken<List<HelpCategory>>() {
-        }.getType()))
+        Task.supplyAsync(() -> HttpRequest.GET("https://docs.hmcl.net/index.json").getJson(listTypeOf(HelpCategory.class)))
                 .thenAcceptAsync(Schedulers.javafx(), helpCategories -> {
                     for (HelpCategory category : helpCategories) {
                         ComponentList categoryPane = new ComponentList();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/NativePatcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/NativePatcher.java
@@ -17,7 +17,6 @@
  */
 package org.jackhuang.hmcl.util;
 
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.game.*;
 import org.jackhuang.hmcl.setting.VersionSetting;
 import org.jackhuang.hmcl.util.gson.JsonUtils;
@@ -34,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.jackhuang.hmcl.util.gson.JsonUtils.mapTypeOf;
 import static org.jackhuang.hmcl.util.logging.Logger.LOG;
 
 /**
@@ -51,9 +51,7 @@ public final class NativePatcher {
         return natives.computeIfAbsent(platform, p -> {
             //noinspection ConstantConditions
             try (Reader reader = new InputStreamReader(NativePatcher.class.getResourceAsStream("/assets/natives.json"), StandardCharsets.UTF_8)) {
-                Map<String, Map<String, Library>> natives = JsonUtils.GSON.fromJson(reader, new TypeToken<Map<String, Map<String, Library>>>() {
-                }.getType());
-
+                Map<String, Map<String, Library>> natives = JsonUtils.GSON.fromJson(reader, mapTypeOf(String.class, mapTypeOf(String.class, Library.class)));
                 return natives.getOrDefault(p.toString(), Collections.emptyMap());
             } catch (IOException e) {
                 LOG.warning("Failed to load native library list", e);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/SelfDependencyPatcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/SelfDependencyPatcher.java
@@ -42,7 +42,6 @@
 package org.jackhuang.hmcl.util;
 
 import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.Main;
 import org.jackhuang.hmcl.ui.SwingUtils;
 import org.jackhuang.hmcl.util.io.ChecksumMismatchException;
@@ -68,6 +67,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toSet;
 import static org.jackhuang.hmcl.Metadata.HMCL_DIRECTORY;
+import static org.jackhuang.hmcl.util.gson.JsonUtils.listTypeOf;
+import static org.jackhuang.hmcl.util.gson.JsonUtils.mapTypeOf;
 import static org.jackhuang.hmcl.util.logging.Logger.LOG;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
@@ -104,11 +105,11 @@ public final class SelfDependencyPatcher {
         private static final Path DEPENDENCIES_DIR_PATH = HMCL_DIRECTORY.resolve("dependencies").resolve(Platform.getPlatform().toString()).resolve("openjfx");
 
         static List<DependencyDescriptor> readDependencies() {
-            ArrayList<DependencyDescriptor> dependencies;
+            List<DependencyDescriptor> dependencies;
             //noinspection ConstantConditions
             try (Reader reader = new InputStreamReader(SelfDependencyPatcher.class.getResourceAsStream(DEPENDENCIES_LIST_FILE), UTF_8)) {
-                Map<String, ArrayList<DependencyDescriptor>> allDependencies =
-                        new Gson().fromJson(reader, new TypeToken<Map<String, ArrayList<DependencyDescriptor>>>(){}.getType());
+                Map<String, List<DependencyDescriptor>> allDependencies =
+                        new Gson().fromJson(reader, mapTypeOf(String.class, listTypeOf(DependencyDescriptor.class)));
                 dependencies = allDependencies.get(Platform.getPlatform().toString());
             } catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/SelfDependencyPatcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/SelfDependencyPatcher.java
@@ -44,6 +44,7 @@ package org.jackhuang.hmcl.util;
 import com.google.gson.Gson;
 import org.jackhuang.hmcl.Main;
 import org.jackhuang.hmcl.ui.SwingUtils;
+import org.jackhuang.hmcl.util.gson.JsonUtils;
 import org.jackhuang.hmcl.util.io.ChecksumMismatchException;
 import org.jackhuang.hmcl.util.io.IOUtils;
 import org.jackhuang.hmcl.util.io.JarUtils;
@@ -109,7 +110,7 @@ public final class SelfDependencyPatcher {
             //noinspection ConstantConditions
             try (Reader reader = new InputStreamReader(SelfDependencyPatcher.class.getResourceAsStream(DEPENDENCIES_LIST_FILE), UTF_8)) {
                 Map<String, List<DependencyDescriptor>> allDependencies =
-                        new Gson().fromJson(reader, mapTypeOf(String.class, listTypeOf(DependencyDescriptor.class)));
+                        JsonUtils.GSON.fromJson(reader, mapTypeOf(String.class, listTypeOf(DependencyDescriptor.class)));
                 dependencies = allDependencies.get(Platform.getPlatform().toString());
             } catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/SelfDependencyPatcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/SelfDependencyPatcher.java
@@ -41,7 +41,6 @@
  */
 package org.jackhuang.hmcl.util;
 
-import com.google.gson.Gson;
 import org.jackhuang.hmcl.Main;
 import org.jackhuang.hmcl.ui.SwingUtils;
 import org.jackhuang.hmcl.util.gson.JsonUtils;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/offline/YggdrasilServer.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/offline/YggdrasilServer.java
@@ -17,7 +17,6 @@
  */
 package org.jackhuang.hmcl.auth.offline;
 
-import com.google.gson.reflect.TypeToken;
 import org.glavo.png.javafx.PNGJavaFXUtils;
 import org.jackhuang.hmcl.auth.yggdrasil.GameProfile;
 import org.jackhuang.hmcl.auth.yggdrasil.TextureModel;
@@ -38,6 +37,7 @@ import java.util.stream.Stream;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.jackhuang.hmcl.util.Lang.mapOf;
 import static org.jackhuang.hmcl.util.Pair.pair;
+import static org.jackhuang.hmcl.util.gson.JsonUtils.listTypeOf;
 
 public class YggdrasilServer extends HttpServer {
 
@@ -81,8 +81,7 @@ public class YggdrasilServer extends HttpServer {
     }
 
     private Response profiles(Request request) throws IOException {
-        List<String> names = JsonUtils.fromNonNullJsonFully(request.getSession().getInputStream(), new TypeToken<List<String>>() {
-        }.getType());
+        List<String> names = JsonUtils.fromNonNullJsonFully(request.getSession().getInputStream(), listTypeOf(String.class));
         return ok(names.stream().distinct()
                 .map(this::findCharacterByName)
                 .flatMap(Lang::toStream)

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/fabric/FabricVersionList.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/fabric/FabricVersionList.java
@@ -17,7 +17,6 @@
  */
 package org.jackhuang.hmcl.download.fabric;
 
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.download.DownloadProvider;
 import org.jackhuang.hmcl.download.VersionList;
 import org.jackhuang.hmcl.util.gson.JsonUtils;
@@ -25,13 +24,13 @@ import org.jackhuang.hmcl.util.io.NetworkUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import static org.jackhuang.hmcl.util.Lang.wrap;
+import static org.jackhuang.hmcl.util.gson.JsonUtils.listTypeOf;
 
 public final class FabricVersionList extends VersionList<FabricRemoteVersion> {
     private final DownloadProvider downloadProvider;
@@ -69,8 +68,8 @@ public final class FabricVersionList extends VersionList<FabricRemoteVersion> {
 
     private List<String> getGameVersions(String metaUrl) throws IOException {
         String json = NetworkUtils.doGet(downloadProvider.injectURLWithCandidates(metaUrl));
-        return JsonUtils.GSON.<ArrayList<GameVersion>>fromJson(json, new TypeToken<ArrayList<GameVersion>>() {
-        }.getType()).stream().map(GameVersion::getVersion).collect(Collectors.toList());
+        return JsonUtils.GSON.fromJson(json, listTypeOf(GameVersion.class))
+                .stream().map(GameVersion::getVersion).collect(Collectors.toList());
     }
 
     private static String getLaunchMetaUrl(String gameVersion, String loaderVersion) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeBMCLVersionList.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeBMCLVersionList.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.download.forge;
 
 import com.google.gson.JsonParseException;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.download.VersionList;
 import org.jackhuang.hmcl.util.Immutable;
 import org.jackhuang.hmcl.util.Lang;
@@ -40,6 +39,7 @@ import java.util.concurrent.CompletableFuture;
 import static org.jackhuang.hmcl.util.Lang.mapOf;
 import static org.jackhuang.hmcl.util.Lang.wrap;
 import static org.jackhuang.hmcl.util.Pair.pair;
+import static org.jackhuang.hmcl.util.gson.JsonUtils.listTypeOf;
 import static org.jackhuang.hmcl.util.logging.Logger.LOG;
 
 public final class ForgeBMCLVersionList extends VersionList<ForgeRemoteVersion> {
@@ -87,11 +87,9 @@ public final class ForgeBMCLVersionList extends VersionList<ForgeRemoteVersion> 
         String lookupVersion = toLookupVersion(gameVersion);
 
         return CompletableFuture.completedFuture(null)
-                .thenApplyAsync(wrap(unused -> HttpRequest.GET(apiRoot + "/forge/minecraft/" + lookupVersion).<List<ForgeVersion>>getJson(new TypeToken<List<ForgeVersion>>() {
-                }.getType())))
+                .thenApplyAsync(wrap(unused -> HttpRequest.GET(apiRoot + "/forge/minecraft/" + lookupVersion).getJson(listTypeOf(ForgeVersion.class))))
                 .thenAcceptAsync(forgeVersions -> {
                     lock.writeLock().lock();
-
                     try {
                         versions.clear(gameVersion);
                         if (forgeVersions == null) return;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/mojang/MojangJavaDownloads.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/mojang/MojangJavaDownloads.java
@@ -19,13 +19,15 @@ package org.jackhuang.hmcl.download.java.mojang;
 
 import com.google.gson.*;
 import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.game.DownloadInfo;
 import org.jackhuang.hmcl.util.Immutable;
 
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
+
+import static org.jackhuang.hmcl.util.gson.JsonUtils.listTypeOf;
+import static org.jackhuang.hmcl.util.gson.JsonUtils.mapTypeOf;
 
 @JsonAdapter(MojangJavaDownloads.Adapter.class)
 public class MojangJavaDownloads {
@@ -49,8 +51,7 @@ public class MojangJavaDownloads {
 
         @Override
         public MojangJavaDownloads deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-            return new MojangJavaDownloads(context.deserialize(json, new TypeToken<Map<String, Map<String, List<JavaDownload>>>>() {
-            }.getType()));
+            return new MojangJavaDownloads(context.deserialize(json, mapTypeOf(String.class, mapTypeOf(String.class, listTypeOf(JavaDownload.class))).getType()));
         }
     }
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/neoforge/NeoForgeBMCLVersionList.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/neoforge/NeoForgeBMCLVersionList.java
@@ -19,18 +19,17 @@ package org.jackhuang.hmcl.download.neoforge;
 
 import com.google.gson.JsonParseException;
 import com.google.gson.annotations.SerializedName;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.download.VersionList;
 import org.jackhuang.hmcl.util.Immutable;
 import org.jackhuang.hmcl.util.gson.Validation;
 import org.jackhuang.hmcl.util.io.HttpRequest;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static org.jackhuang.hmcl.util.Lang.wrap;
+import static org.jackhuang.hmcl.util.gson.JsonUtils.listTypeOf;
 
 public final class NeoForgeBMCLVersionList extends VersionList<NeoForgeRemoteVersion> {
     private final String apiRoot;
@@ -68,8 +67,7 @@ public final class NeoForgeBMCLVersionList extends VersionList<NeoForgeRemoteVer
     @Override
     public CompletableFuture<?> refreshAsync(String gameVersion) {
         return CompletableFuture.completedFuture((Void) null)
-                .thenApplyAsync(wrap(unused -> HttpRequest.GET(apiRoot + "/neoforge/list/" + gameVersion).<List<NeoForgeVersion>>getJson(new TypeToken<List<NeoForgeVersion>>() {
-                }.getType())))
+                .thenApplyAsync(wrap(unused -> HttpRequest.GET(apiRoot + "/neoforge/list/" + gameVersion).getJson(listTypeOf(NeoForgeVersion.class))))
                 .thenAcceptAsync(neoForgeVersions -> {
                     lock.writeLock().lock();
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/optifine/OptiFineBMCLVersionList.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/optifine/OptiFineBMCLVersionList.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.download.optifine;
 
 import com.google.gson.annotations.SerializedName;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.download.VersionList;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.io.HttpRequest;
@@ -26,9 +25,10 @@ import org.jackhuang.hmcl.util.versioning.VersionNumber;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+
+import static org.jackhuang.hmcl.util.gson.JsonUtils.listTypeOf;
 
 /**
  * @author huangyuhui
@@ -72,8 +72,7 @@ public final class OptiFineBMCLVersionList extends VersionList<OptiFineRemoteVer
 
     @Override
     public CompletableFuture<?> refreshAsync() {
-        return HttpRequest.GET(apiRoot + "/optifine/versionlist").<List<OptiFineVersion>>getJsonAsync(new TypeToken<List<OptiFineVersion>>() {
-        }.getType()).thenAcceptAsync(root -> {
+        return HttpRequest.GET(apiRoot + "/optifine/versionlist").getJsonAsync(listTypeOf(OptiFineVersion.class)).thenAcceptAsync(root -> {
             lock.writeLock().lock();
 
             try {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/quilt/QuiltVersionList.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/quilt/QuiltVersionList.java
@@ -17,7 +17,6 @@
  */
 package org.jackhuang.hmcl.download.quilt;
 
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.download.DownloadProvider;
 import org.jackhuang.hmcl.download.VersionList;
 import org.jackhuang.hmcl.util.gson.JsonUtils;
@@ -25,13 +24,13 @@ import org.jackhuang.hmcl.util.io.NetworkUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import static org.jackhuang.hmcl.util.Lang.wrap;
+import static org.jackhuang.hmcl.util.gson.JsonUtils.listTypeOf;
 
 public final class QuiltVersionList extends VersionList<QuiltRemoteVersion> {
     private final DownloadProvider downloadProvider;
@@ -69,8 +68,8 @@ public final class QuiltVersionList extends VersionList<QuiltRemoteVersion> {
 
     private List<String> getGameVersions(String metaUrl) throws IOException {
         String json = NetworkUtils.doGet(downloadProvider.injectURLWithCandidates(metaUrl));
-        return JsonUtils.GSON.<ArrayList<GameVersion>>fromJson(json, new TypeToken<ArrayList<GameVersion>>() {
-        }.getType()).stream().map(GameVersion::getVersion).collect(Collectors.toList());
+        return JsonUtils.GSON.fromJson(json, listTypeOf(GameVersion.class))
+                .stream().map(GameVersion::getVersion).collect(Collectors.toList());
     }
 
     private static String getLaunchMetaUrl(String gameVersion, String loaderVersion) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/game/DefaultGameRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/game/DefaultGameRepository.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.game;
 
 import com.google.gson.JsonParseException;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.download.MaintainTask;
 import org.jackhuang.hmcl.download.game.VersionJsonSaveTask;
 import org.jackhuang.hmcl.event.*;
@@ -499,18 +498,16 @@ public class DefaultGameRepository implements GameRepository {
      * read modpack configuration for a version.
      *
      * @param version version installed as modpack
-     * @param <M>     manifest type of ModpackConfiguration
      * @return modpack configuration object, or null if this version is not a modpack.
      * @throws VersionNotFoundException if version does not exist.
      * @throws IOException              if an i/o error occurs.
      */
     @Nullable
-    public <M> ModpackConfiguration<M> readModpackConfiguration(String version) throws IOException, VersionNotFoundException {
+    public ModpackConfiguration<?> readModpackConfiguration(String version) throws IOException, VersionNotFoundException {
         if (!hasVersion(version)) throw new VersionNotFoundException(version);
         File file = getModpackConfiguration(version);
         if (!file.exists()) return null;
-        return JsonUtils.GSON.fromJson(FileUtils.readText(file), new TypeToken<ModpackConfiguration<M>>() {
-        }.getType());
+        return JsonUtils.GSON.fromJson(FileUtils.readText(file), ModpackConfiguration.class);
     }
 
     public boolean isModpack(String version) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/game/RuledArgument.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/game/RuledArgument.java
@@ -19,12 +19,13 @@ package org.jackhuang.hmcl.game;
 
 import com.google.gson.*;
 import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.util.Immutable;
 
 import java.lang.reflect.Type;
 import java.util.*;
 import java.util.stream.Collectors;
+
+import static org.jackhuang.hmcl.util.gson.JsonUtils.listTypeOf;
 
 /**
  *
@@ -86,8 +87,7 @@ public class RuledArgument implements Argument {
         public RuledArgument deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
             JsonObject obj = json.getAsJsonObject();
 
-            List<CompatibilityRule> rules = context.deserialize(obj.get("rules"), new TypeToken<List<CompatibilityRule>>() {
-            }.getType());
+            List<CompatibilityRule> rules = context.deserialize(obj.get("rules"), listTypeOf(CompatibilityRule.class).getType());
 
             JsonElement valuesElement;
             if (obj.has("values")) {
@@ -102,8 +102,7 @@ public class RuledArgument implements Argument {
             if (valuesElement.isJsonPrimitive()) {
                 values = Collections.singletonList(valuesElement.getAsString());
             } else {
-                values = context.deserialize(valuesElement, new TypeToken<List<String>>() {
-                }.getType());
+                values = context.deserialize(valuesElement, listTypeOf(String.class).getType());
             }
 
             return new RuledArgument(rules, values);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModpackConfiguration.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModpackConfiguration.java
@@ -18,6 +18,7 @@
 package org.jackhuang.hmcl.mod;
 
 import com.google.gson.JsonParseException;
+import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.util.Immutable;
 import org.jackhuang.hmcl.util.gson.Validation;
 import org.jetbrains.annotations.Nullable;
@@ -28,6 +29,11 @@ import java.util.List;
 
 @Immutable
 public final class ModpackConfiguration<T> implements Validation {
+
+    @SuppressWarnings("unchecked")
+    public static <T> TypeToken<ModpackConfiguration<T>> typeOf(Class<T> clazz) {
+        return (TypeToken<ModpackConfiguration<T>>) TypeToken.getParameterized(ModpackConfiguration.class, clazz);
+    }
 
     private final T manifest;
     private final String type;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseForgeRemoteModRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseForgeRemoteModRepository.java
@@ -278,7 +278,7 @@ public final class CurseForgeRemoteModRepository implements RemoteModRepository 
         }
     }
 
-    private static final class Response<T> {
+    public static class Response<T> {
 
         @SuppressWarnings("unchecked")
         public static <T> TypeToken<Response<T>> typeOf(Class<T> responseType) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseForgeRemoteModRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseForgeRemoteModRepository.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 
 import static org.jackhuang.hmcl.util.Lang.mapOf;
 import static org.jackhuang.hmcl.util.Pair.pair;
+import static org.jackhuang.hmcl.util.gson.JsonUtils.listTypeOf;
 
 public final class CurseForgeRemoteModRepository implements RemoteModRepository {
 
@@ -113,8 +114,7 @@ public final class CurseForgeRemoteModRepository implements RemoteModRepository 
                         pair("index", Integer.toString(pageOffset * pageSize)),
                         pair("pageSize", Integer.toString(pageSize)))
                 .header("X-API-KEY", apiKey)
-                .getJson(new TypeToken<Response<List<CurseAddon>>>() {
-                }.getType());
+                .getJson(Response.typeOf(listTypeOf(CurseAddon.class)));
         if (searchFilter.isEmpty()) {
             return new SearchResult(response.getData().stream().map(CurseAddon::toMod), calculateTotalPages(response, pageSize));
         }
@@ -163,8 +163,7 @@ public final class CurseForgeRemoteModRepository implements RemoteModRepository 
         Response<FingerprintMatchesResult> response = HttpRequest.POST(PREFIX + "/v1/fingerprints/432")
                 .json(mapOf(pair("fingerprints", Collections.singletonList(hash))))
                 .header("X-API-KEY", apiKey)
-                .getJson(new TypeToken<Response<FingerprintMatchesResult>>() {
-                }.getType());
+                .getJson(Response.typeOf(FingerprintMatchesResult.class));
 
         if (response.getData().getExactMatches() == null || response.getData().getExactMatches().isEmpty()) {
             return Optional.empty();
@@ -177,8 +176,7 @@ public final class CurseForgeRemoteModRepository implements RemoteModRepository 
     public RemoteMod getModById(String id) throws IOException {
         Response<CurseAddon> response = HttpRequest.GET(PREFIX + "/v1/mods/" + id)
                 .header("X-API-KEY", apiKey)
-                .getJson(new TypeToken<Response<CurseAddon>>() {
-                }.getType());
+                .getJson(Response.typeOf(CurseAddon.class));
         return response.data.toMod();
     }
 
@@ -186,8 +184,7 @@ public final class CurseForgeRemoteModRepository implements RemoteModRepository 
     public RemoteMod.File getModFile(String modId, String fileId) throws IOException {
         Response<CurseAddon.LatestFile> response = HttpRequest.GET(String.format("%s/v1/mods/%s/files/%s", PREFIX, modId, fileId))
                 .header("X-API-KEY", apiKey)
-                .getJson(new TypeToken<Response<CurseAddon.LatestFile>>() {
-                }.getType());
+                .getJson(Response.typeOf(CurseAddon.LatestFile.class));
         return response.getData().toVersion().getFile();
     }
 
@@ -196,16 +193,14 @@ public final class CurseForgeRemoteModRepository implements RemoteModRepository 
         Response<List<CurseAddon.LatestFile>> response = HttpRequest.GET(PREFIX + "/v1/mods/" + id + "/files",
                         pair("pageSize", "10000"))
                 .header("X-API-KEY", apiKey)
-                .getJson(new TypeToken<Response<List<CurseAddon.LatestFile>>>() {
-                }.getType());
+                .getJson(Response.typeOf(listTypeOf(CurseAddon.LatestFile.class)));
         return response.getData().stream().map(CurseAddon.LatestFile::toVersion);
     }
 
     public List<CurseAddon.Category> getCategoriesImpl() throws IOException {
         Response<List<CurseAddon.Category>> categories = HttpRequest.GET(PREFIX + "/v1/categories", pair("gameId", "432"))
                 .header("X-API-KEY", apiKey)
-                .getJson(new TypeToken<Response<List<CurseAddon.Category>>>() {
-                }.getType());
+                .getJson(Response.typeOf(listTypeOf(CurseAddon.Category.class)));
         return reorganizeCategories(categories.getData(), section);
     }
 
@@ -283,7 +278,18 @@ public final class CurseForgeRemoteModRepository implements RemoteModRepository 
         }
     }
 
-    public static class Response<T> {
+    private static final class Response<T> {
+
+        @SuppressWarnings("unchecked")
+        public static <T> TypeToken<Response<T>> typeOf(Class<T> responseType) {
+            return (TypeToken<Response<T>>) TypeToken.getParameterized(Response.class, responseType);
+        }
+
+        @SuppressWarnings("unchecked")
+        public static <T> TypeToken<Response<T>> typeOf(TypeToken<T> responseType) {
+            return (TypeToken<Response<T>>) TypeToken.getParameterized(Response.class, responseType.getType());
+        }
+
         private final T data;
         private final Pagination pagination;
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseInstallTask.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.mod.curse;
 
 import com.google.gson.JsonParseException;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.download.DefaultDependencyManager;
 import org.jackhuang.hmcl.download.GameBuilder;
 import org.jackhuang.hmcl.game.DefaultGameRepository;
@@ -99,8 +98,7 @@ public final class CurseInstallTask extends Task<Void> {
         ModpackConfiguration<CurseManifest> config = null;
         try {
             if (json.exists()) {
-                config = JsonUtils.GSON.fromJson(FileUtils.readText(json), new TypeToken<ModpackConfiguration<CurseManifest>>() {
-                }.getType());
+                config = JsonUtils.GSON.fromJson(FileUtils.readText(json), ModpackConfiguration.typeOf(CurseManifest.class));
 
                 if (!CurseModpackProvider.INSTANCE.getName().equals(config.getType()))
                     throw new IllegalArgumentException("Version " + name + " is not a Curse modpack. Cannot update this version.");

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackCompletionTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackCompletionTask.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.mod.mcbbs;
 
 import com.google.gson.JsonParseException;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.download.DefaultDependencyManager;
 import org.jackhuang.hmcl.game.DefaultGameRepository;
 import org.jackhuang.hmcl.mod.ModManager;
@@ -88,8 +87,7 @@ public class McbbsModpackCompletionTask extends CompletableFutureTask<Void> {
             if (configuration == null) {
                 // Load configuration from disk
                 try {
-                    configuration = JsonUtils.fromNonNullJson(FileUtils.readText(configurationFile), new TypeToken<ModpackConfiguration<McbbsModpackManifest>>() {
-                    }.getType());
+                    configuration = JsonUtils.fromNonNullJson(FileUtils.readText(configurationFile), ModpackConfiguration.typeOf(McbbsModpackManifest.class));
                 } catch (IOException | JsonParseException e) {
                     throw new IOException("Malformed modpack configuration");
                 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackLocalInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackLocalInstallTask.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.mod.mcbbs;
 
 import com.google.gson.JsonParseException;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.download.DefaultDependencyManager;
 import org.jackhuang.hmcl.download.GameBuilder;
 import org.jackhuang.hmcl.game.DefaultGameRepository;
@@ -80,8 +79,7 @@ public class McbbsModpackLocalInstallTask extends Task<Void> {
         ModpackConfiguration<McbbsModpackManifest> config = null;
         try {
             if (json.exists()) {
-                config = JsonUtils.GSON.fromJson(FileUtils.readText(json), new TypeToken<ModpackConfiguration<McbbsModpackManifest>>() {
-                }.getType());
+                config = JsonUtils.GSON.fromJson(FileUtils.readText(json), ModpackConfiguration.typeOf(McbbsModpackManifest.class));
 
                 if (!McbbsModpackProvider.INSTANCE.getName().equals(config.getType()))
                     throw new IllegalArgumentException("Version " + name + " is not a Mcbbs modpack. Cannot update this version.");

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackProvider.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackProvider.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.mod.mcbbs;
 
 import com.google.gson.JsonParseException;
-import com.google.gson.reflect.TypeToken;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.jackhuang.hmcl.download.DefaultDependencyManager;
@@ -56,8 +55,7 @@ public final class McbbsModpackProvider implements ModpackProvider {
 
     @Override
     public void injectLaunchOptions(String modpackConfigurationJson, LaunchOptions.Builder builder) {
-        ModpackConfiguration<McbbsModpackManifest> config = JsonUtils.GSON.fromJson(modpackConfigurationJson, new TypeToken<ModpackConfiguration<McbbsModpackManifest>>() {
-        }.getType());
+        ModpackConfiguration<McbbsModpackManifest> config = JsonUtils.GSON.fromJson(modpackConfigurationJson, ModpackConfiguration.typeOf(McbbsModpackManifest.class));
 
         if (!getName().equals(config.getType())) {
             throw new IllegalArgumentException("Incorrect manifest type, actual=" + config.getType() + ", expected=" + getName());

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackRemoteInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackRemoteInstallTask.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.mod.mcbbs;
 
 import com.google.gson.JsonParseException;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.download.DefaultDependencyManager;
 import org.jackhuang.hmcl.download.GameBuilder;
 import org.jackhuang.hmcl.game.DefaultGameRepository;
@@ -66,8 +65,7 @@ public class McbbsModpackRemoteInstallTask extends Task<Void> {
         ModpackConfiguration<McbbsModpackManifest> config = null;
         try {
             if (json.exists()) {
-                config = JsonUtils.GSON.fromJson(FileUtils.readText(json), new TypeToken<ModpackConfiguration<McbbsModpackManifest>>() {
-                }.getType());
+                config = JsonUtils.GSON.fromJson(FileUtils.readText(json), ModpackConfiguration.typeOf(McbbsModpackManifest.class));
 
                 if (!MODPACK_TYPE.equals(config.getType()))
                     throw new IllegalArgumentException("Version " + name + " is not a Mcbbs modpack. Cannot update this version.");

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modinfo/ForgeOldModMetadata.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modinfo/ForgeOldModMetadata.java
@@ -19,7 +19,6 @@ package org.jackhuang.hmcl.mod.modinfo;
 
 import com.google.gson.JsonParseException;
 import com.google.gson.annotations.SerializedName;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.mod.LocalModFile;
 import org.jackhuang.hmcl.mod.ModLoaderType;
 import org.jackhuang.hmcl.mod.ModManager;
@@ -33,6 +32,8 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+
+import static org.jackhuang.hmcl.util.gson.JsonUtils.listTypeOf;
 
 /**
  *
@@ -125,9 +126,7 @@ public final class ForgeOldModMetadata {
         Path mcmod = fs.getPath("mcmod.info");
         if (Files.notExists(mcmod))
             throw new IOException("File " + modFile + " is not a Forge mod.");
-        List<ForgeOldModMetadata> modList = JsonUtils.GSON.fromJson(FileUtils.readText(mcmod),
-                new TypeToken<List<ForgeOldModMetadata>>() {
-                }.getType());
+        List<ForgeOldModMetadata> modList = JsonUtils.GSON.fromJson(FileUtils.readText(mcmod), listTypeOf(ForgeOldModMetadata.class));
         if (modList == null || modList.isEmpty())
             throw new IOException("Mod " + modFile + " `mcmod.info` is malformed..");
         ForgeOldModMetadata metadata = modList.get(0);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthInstallTask.java
@@ -18,12 +18,10 @@
 package org.jackhuang.hmcl.mod.modrinth;
 
 import com.google.gson.JsonParseException;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.download.DefaultDependencyManager;
 import org.jackhuang.hmcl.download.GameBuilder;
 import org.jackhuang.hmcl.game.DefaultGameRepository;
 import org.jackhuang.hmcl.mod.*;
-import org.jackhuang.hmcl.mod.curse.CurseManifest;
 import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.util.gson.JsonUtils;
 import org.jackhuang.hmcl.util.io.FileUtils;
@@ -95,8 +93,7 @@ public class ModrinthInstallTask extends Task<Void> {
         ModpackConfiguration<ModrinthManifest> config = null;
         try {
             if (json.exists()) {
-                config = JsonUtils.GSON.fromJson(FileUtils.readText(json), new TypeToken<ModpackConfiguration<CurseManifest>>() {
-                }.getType());
+                config = JsonUtils.GSON.fromJson(FileUtils.readText(json), ModpackConfiguration.typeOf(ModrinthManifest.class));
 
                 if (!ModrinthModpackProvider.INSTANCE.getName().equals(config.getType()))
                     throw new IllegalArgumentException("Version " + name + " is not a Modrinth modpack. Cannot update this version.");

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java
@@ -39,6 +39,7 @@ import java.util.stream.Stream;
 
 import static org.jackhuang.hmcl.util.Lang.mapOf;
 import static org.jackhuang.hmcl.util.Pair.pair;
+import static org.jackhuang.hmcl.util.gson.JsonUtils.listTypeOf;
 
 public final class ModrinthRemoteModRepository implements RemoteModRepository {
     public static final ModrinthRemoteModRepository MODS = new ModrinthRemoteModRepository("mod");
@@ -93,8 +94,7 @@ public final class ModrinthRemoteModRepository implements RemoteModRepository {
                 pair("index", convertSortType(sort))
         );
         Response<ProjectSearchResult> response = HttpRequest.GET(NetworkUtils.withQuery(PREFIX + "/v2/search", query))
-                .getJson(new TypeToken<Response<ProjectSearchResult>>() {
-                }.getType());
+                .getJson(Response.typeOf(ProjectSearchResult.class));
         return new SearchResult(response.getHits().stream().map(ProjectSearchResult::toMod), (int) Math.ceil((double) response.totalHits / pageSize));
     }
 
@@ -132,13 +132,12 @@ public final class ModrinthRemoteModRepository implements RemoteModRepository {
     public Stream<RemoteMod.Version> getRemoteVersionsById(String id) throws IOException {
         id = StringUtils.removePrefix(id, "local-");
         List<ProjectVersion> versions = HttpRequest.GET(PREFIX + "/v2/project/" + id + "/version")
-                .getJson(new TypeToken<List<ProjectVersion>>() {
-                }.getType());
+                .getJson(listTypeOf(ProjectVersion.class));
         return versions.stream().map(ProjectVersion::toVersion).flatMap(Lang::toStream);
     }
 
     public List<Category> getCategoriesImpl() throws IOException {
-        List<Category> categories = HttpRequest.GET(PREFIX + "/v2/tag/category").getJson(new TypeToken<List<Category>>() {}.getType());
+        List<Category> categories = HttpRequest.GET(PREFIX + "/v2/tag/category").getJson(listTypeOf(Category.class));
         return categories.stream().filter(category -> category.getProjectType().equals(projectType)).collect(Collectors.toList());
     }
 
@@ -695,7 +694,13 @@ public final class ModrinthRemoteModRepository implements RemoteModRepository {
         }
     }
 
-    public static class Response<T> {
+    public static final class Response<T> {
+
+        @SuppressWarnings("unchecked")
+        public static <T> TypeToken<Response<T>> typeOf(Class<T> responseType) {
+            return (TypeToken<Response<T>>) TypeToken.getParameterized(Response.class, responseType);
+        }
+
         private final int offset;
 
         private final int limit;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java
@@ -694,7 +694,7 @@ public final class ModrinthRemoteModRepository implements RemoteModRepository {
         }
     }
 
-    public static final class Response<T> {
+    public static class Response<T> {
 
         @SuppressWarnings("unchecked")
         public static <T> TypeToken<Response<T>> typeOf(Class<T> responseType) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/multimc/MultiMCModpackInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/multimc/MultiMCModpackInstallTask.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.mod.multimc;
 
 import com.google.gson.JsonParseException;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.download.DefaultDependencyManager;
 import org.jackhuang.hmcl.download.GameBuilder;
 import org.jackhuang.hmcl.game.Arguments;
@@ -128,8 +127,7 @@ public final class MultiMCModpackInstallTask extends Task<Void> {
         ModpackConfiguration<MultiMCInstanceConfiguration> config = null;
         try {
             if (json.exists()) {
-                config = JsonUtils.GSON.fromJson(FileUtils.readText(json), new TypeToken<ModpackConfiguration<MultiMCInstanceConfiguration>>() {
-                }.getType());
+                config = JsonUtils.GSON.fromJson(FileUtils.readText(json), ModpackConfiguration.typeOf(MultiMCInstanceConfiguration.class));
 
                 if (!MultiMCModpackProvider.INSTANCE.getName().equals(config.getType()))
                     throw new IllegalArgumentException("Version " + name + " is not a MultiMC modpack. Cannot update this version.");

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackCompletionTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackCompletionTask.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.mod.server;
 
 import com.google.gson.JsonParseException;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.download.DefaultDependencyManager;
 import org.jackhuang.hmcl.download.GameBuilder;
 import org.jackhuang.hmcl.game.DefaultGameRepository;
@@ -66,8 +65,7 @@ public class ServerModpackCompletionTask extends Task<Void> {
             try {
                 File manifestFile = repository.getModpackConfiguration(version);
                 if (manifestFile.exists()) {
-                    this.manifest = JsonUtils.GSON.fromJson(FileUtils.readText(manifestFile), new TypeToken<ModpackConfiguration<ServerModpackManifest>>() {
-                    }.getType());
+                    this.manifest = JsonUtils.GSON.fromJson(FileUtils.readText(manifestFile), ModpackConfiguration.typeOf(ServerModpackManifest.class));
                 }
             } catch (Exception e) {
                 LOG.warning("Unable to read Server modpack manifest.json", e);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackLocalInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackLocalInstallTask.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.mod.server;
 
 import com.google.gson.JsonParseException;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.download.DefaultDependencyManager;
 import org.jackhuang.hmcl.download.GameBuilder;
 import org.jackhuang.hmcl.game.DefaultGameRepository;
@@ -72,8 +71,7 @@ public class ServerModpackLocalInstallTask extends Task<Void> {
         ModpackConfiguration<ServerModpackManifest> config = null;
         try {
             if (json.exists()) {
-                config = JsonUtils.GSON.fromJson(FileUtils.readText(json), new TypeToken<ModpackConfiguration<ServerModpackManifest>>() {
-                }.getType());
+                config = JsonUtils.GSON.fromJson(FileUtils.readText(json), ModpackConfiguration.typeOf(ServerModpackManifest.class));
 
                 if (!ServerModpackProvider.INSTANCE.getName().equals(config.getType()))
                     throw new IllegalArgumentException("Version " + name + " is not a Server modpack. Cannot update this version.");

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackRemoteInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackRemoteInstallTask.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.mod.server;
 
 import com.google.gson.JsonParseException;
-import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.download.DefaultDependencyManager;
 import org.jackhuang.hmcl.download.GameBuilder;
 import org.jackhuang.hmcl.game.DefaultGameRepository;
@@ -63,11 +62,10 @@ public class ServerModpackRemoteInstallTask extends Task<Void> {
                 repository.removeVersionFromDisk(name);
         });
 
-        ModpackConfiguration<ServerModpackManifest> config = null;
+        ModpackConfiguration<ServerModpackManifest> config;
         try {
             if (json.exists()) {
-                config = JsonUtils.GSON.fromJson(FileUtils.readText(json), new TypeToken<ModpackConfiguration<ServerModpackManifest>>() {
-                }.getType());
+                config = JsonUtils.GSON.fromJson(FileUtils.readText(json), ModpackConfiguration.typeOf(ServerModpackManifest.class));
 
                 if (!MODPACK_TYPE.equals(config.getType()))
                     throw new IllegalArgumentException("Version " + name + " is not a Server modpack. Cannot update this version.");

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/gson/JsonUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/gson/JsonUtils.java
@@ -27,14 +27,16 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
  * @author yushijinhun
  */
+@SuppressWarnings("unchecked")
 public final class JsonUtils {
 
     public static final Gson GSON = defaultGsonBuilder().create();
@@ -48,13 +50,29 @@ public final class JsonUtils {
     private JsonUtils() {
     }
 
+    public static <T> TypeToken<List<T>> listTypeOf(Class<T> elementType) {
+        return (TypeToken<List<T>>) TypeToken.getParameterized(List.class, elementType);
+    }
+
+    public static <T> TypeToken<List<T>> listTypeOf(TypeToken<T> elementType) {
+        return (TypeToken<List<T>>) TypeToken.getParameterized(List.class, elementType.getType());
+    }
+
+    public static <K, V> TypeToken<Map<K, V>> mapTypeOf(Class<K> keyType, Class<V> valueType) {
+        return (TypeToken<Map<K, V>>) TypeToken.getParameterized(Map.class, keyType, valueType);
+    }
+
+    public static <K, V> TypeToken<Map<K, V>> mapTypeOf(Class<K> keyType, TypeToken<V> valueType) {
+        return (TypeToken<Map<K, V>>) TypeToken.getParameterized(Map.class, keyType, valueType.getType());
+    }
+
     public static <T> T fromJsonFully(InputStream json, Class<T> classOfT) throws IOException, JsonParseException {
         try (InputStreamReader reader = new InputStreamReader(json, StandardCharsets.UTF_8)) {
             return GSON.fromJson(reader, classOfT);
         }
     }
 
-    public static <T> T fromJsonFully(InputStream json, Type type) throws IOException, JsonParseException {
+    public static <T> T fromJsonFully(InputStream json, TypeToken<T> type) throws IOException, JsonParseException {
         try (InputStreamReader reader = new InputStreamReader(json, StandardCharsets.UTF_8)) {
             return GSON.fromJson(reader, type);
         }
@@ -62,13 +80,6 @@ public final class JsonUtils {
 
     public static <T> T fromNonNullJson(String json, Class<T> classOfT) throws JsonParseException {
         T parsed = GSON.fromJson(json, classOfT);
-        if (parsed == null)
-            throw new JsonParseException("Json object cannot be null.");
-        return parsed;
-    }
-
-    public static <T> T fromNonNullJson(String json, Type type) throws JsonParseException {
-        T parsed = GSON.fromJson(json, type);
         if (parsed == null)
             throw new JsonParseException("Json object cannot be null.");
         return parsed;
@@ -90,7 +101,7 @@ public final class JsonUtils {
         }
     }
 
-    public static <T> T fromNonNullJsonFully(InputStream json, Type type) throws IOException, JsonParseException {
+    public static <T> T fromNonNullJsonFully(InputStream json, TypeToken<T> type) throws IOException, JsonParseException {
         try (InputStreamReader reader = new InputStreamReader(json, StandardCharsets.UTF_8)) {
             T parsed = GSON.fromJson(reader, type);
             if (parsed == null)
@@ -107,7 +118,7 @@ public final class JsonUtils {
         }
     }
 
-    public static <T> T fromMaybeMalformedJson(String json, Type type) throws JsonParseException {
+    public static <T> T fromMaybeMalformedJson(String json, TypeToken<T> type) throws JsonParseException {
         try {
             return GSON.fromJson(json, type);
         } catch (JsonSyntaxException e) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/HttpRequest.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/HttpRequest.java
@@ -18,6 +18,7 @@
 package org.jackhuang.hmcl.util.io;
 
 import com.google.gson.JsonParseException;
+import com.google.gson.reflect.TypeToken;
 import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.util.Pair;
 import org.jackhuang.hmcl.util.function.ExceptionalBiConsumer;
@@ -26,7 +27,6 @@ import org.jackhuang.hmcl.util.gson.JsonUtils;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -101,7 +101,7 @@ public abstract class HttpRequest {
         return JsonUtils.fromNonNullJson(getString(), typeOfT);
     }
 
-    public <T> T getJson(Type type) throws IOException, JsonParseException {
+    public <T> T getJson(TypeToken<T> type) throws IOException, JsonParseException {
         return JsonUtils.fromNonNullJson(getString(), type);
     }
 
@@ -109,7 +109,7 @@ public abstract class HttpRequest {
         return getStringAsync().thenApplyAsync(jsonString -> JsonUtils.fromNonNullJson(jsonString, typeOfT));
     }
 
-    public <T> CompletableFuture<T> getJsonAsync(Type type) {
+    public <T> CompletableFuture<T> getJsonAsync(TypeToken<T> type) {
         return getStringAsync().thenApplyAsync(jsonString -> JsonUtils.fromNonNullJson(jsonString, type));
     }
 

--- a/HMCLCore/src/test/java/org/jackhuang/hmcl/util/gson/JsonUtilsTest.java
+++ b/HMCLCore/src/test/java/org/jackhuang/hmcl/util/gson/JsonUtilsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Hello Minecraft! Launcher
+ * Copyright (C) 2024 huangyuhui <huanghongxun2008@126.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.jackhuang.hmcl.util.gson;
+
+import com.google.gson.reflect.TypeToken;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.jackhuang.hmcl.util.gson.JsonUtils.listTypeOf;
+import static org.jackhuang.hmcl.util.gson.JsonUtils.mapTypeOf;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Glavo
+ */
+public class JsonUtilsTest {
+
+    @Test
+    public void testGetTypeToken() {
+        assertEquals(new TypeToken<List<Object>>(){}, listTypeOf(Object.class));
+        assertEquals(new TypeToken<List<String>>(){}, listTypeOf(String.class));
+        assertEquals(new TypeToken<List<Map<String, Integer>>>(){}, listTypeOf(mapTypeOf(String.class, Integer.class)));
+        assertEquals(new TypeToken<List<Map<String, List<Integer>>>>(){}, listTypeOf(mapTypeOf(String.class, listTypeOf(Integer.class))));
+    }
+}


### PR DESCRIPTION
本 PR 将尽可能地使用 `com.google.gson.reflect.TypeToken` 替代了 `java.lang.reflect.Type`，原因是：

* `TypeToken` 带有类型参数，能够减少代码中的强制类型转换，更加简洁且安全
  * 得益于此，我检查到 https://github.com/HMCL-dev/HMCL/blob/541f2e26199dae5cdf2bff42ebc3ce1a5c5a665d/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthInstallTask.java#L95-L99 这里存在一处类型不匹配的 BUG（`config` 本应为 `ModpackConfiguration<ModrinthManifest>`，但反序列化时所用的类型为 `ModpackConfiguration<CurseManifest>`）
* GSON 内部在使用 `TypeToken` 表示类型，直接使用 `TypeToken` 能减少一次 `Type` 到 `TypeToken` 的转换

此外，本 PR 还创建了一些用于构造 `TypeToken` 的工厂方法，尽可能避免了使用匿名内部类获取 `TypeToken`。这样做减少了大量匿名内部类，从而使 HMCL Jar 减小了约 24KiB，而且能够让代码风格更美观，不需要因为匿名内部类而不得不折行。