### PR TITLE
预生成 openjfx-dependencies.json

### DIFF
--- a/HMCL/build.gradle.kts
+++ b/HMCL/build.gradle.kts
@@ -189,11 +189,6 @@ tasks.processResources {
         from(sourceSets["java11"].output)
     }
     dependsOn(tasks["java11Classes"])
-
-    into("assets") {
-        from(project.layout.buildDirectory.file("openjfx-dependencies.json"))
-    }
-    dependsOn(rootProject.tasks["generateOpenJFXDependencies"])
 }
 
 val makeExecutables = tasks.create("makeExecutables") {

--- a/HMCL/src/main/resources/assets/openjfx-dependencies.json
+++ b/HMCL/src/main/resources/assets/openjfx-dependencies.json
@@ -1,0 +1,314 @@
+{
+  "windows-x86": [
+    {
+      "module": "javafx.base",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-base",
+      "version": "19.0.2.1",
+      "classifier": "win-x86",
+      "sha1": "6c9ebafc7f9c4544d72fa5e306f4111e56b5db58"
+    },
+    {
+      "module": "javafx.graphics",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-graphics",
+      "version": "19.0.2.1",
+      "classifier": "win-x86",
+      "sha1": "a14a1fbe3a0dca81d99c53fd7be8e7c784a68afe"
+    },
+    {
+      "module": "javafx.controls",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-controls",
+      "version": "19.0.2.1",
+      "classifier": "win-x86",
+      "sha1": "7df1501701f9e9fbadab8ce55ef1dde128e2e88a"
+    }
+  ],
+  "windows-x86_64": [
+    {
+      "module": "javafx.base",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-base",
+      "version": "19.0.2.1",
+      "classifier": "win",
+      "sha1": "f33d0776b2b027c2ea9267c184f9048ef94c4deb"
+    },
+    {
+      "module": "javafx.graphics",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-graphics",
+      "version": "19.0.2.1",
+      "classifier": "win",
+      "sha1": "951ca77bd50ef4fd44f4b7fb1e38301088fde4e2"
+    },
+    {
+      "module": "javafx.controls",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-controls",
+      "version": "19.0.2.1",
+      "classifier": "win",
+      "sha1": "78ac7de48d0aac48e7d5282efc81bab7f337b587"
+    }
+  ],
+  "windows-arm64": [
+    {
+      "module": "javafx.base",
+      "groupId": "org.glavo.hmcl.openjfx",
+      "artifactId": "javafx-base",
+      "version": "18.0.2+1-arm64",
+      "classifier": "win",
+      "sha1": "4518a696b9d509dc09a7fe283452fce84a1686a8"
+    },
+    {
+      "module": "javafx.graphics",
+      "groupId": "org.glavo.hmcl.openjfx",
+      "artifactId": "javafx-graphics",
+      "version": "18.0.2+1-arm64",
+      "classifier": "win",
+      "sha1": "e19ba9aefc4bba8ff86dcdf416620b93b7bdea39"
+    },
+    {
+      "module": "javafx.controls",
+      "groupId": "org.glavo.hmcl.openjfx",
+      "artifactId": "javafx-controls",
+      "version": "18.0.2+1-arm64",
+      "classifier": "win",
+      "sha1": "0bf7380823bb8c420dd41837d2c71087b8953ec1"
+    }
+  ],
+  "osx-x86_64": [
+    {
+      "module": "javafx.base",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-base",
+      "version": "19.0.2.1",
+      "classifier": "mac",
+      "sha1": "73e422d8426aaa23e8c712b9f4d9bebf70d3bfb9"
+    },
+    {
+      "module": "javafx.graphics",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-graphics",
+      "version": "19.0.2.1",
+      "classifier": "mac",
+      "sha1": "6ab6f3e23421fcfa04e692d9d26a8f55a830c114"
+    },
+    {
+      "module": "javafx.controls",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-controls",
+      "version": "19.0.2.1",
+      "classifier": "mac",
+      "sha1": "b7786b1b63e741c0e234829825fae5fef9d96c31"
+    }
+  ],
+  "osx-arm64": [
+    {
+      "module": "javafx.base",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-base",
+      "version": "19.0.2.1",
+      "classifier": "mac-aarch64",
+      "sha1": "1d0d887c492330ed527b0614d115a4f32d2d05a4"
+    },
+    {
+      "module": "javafx.graphics",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-graphics",
+      "version": "19.0.2.1",
+      "classifier": "mac-aarch64",
+      "sha1": "64db28799e61e0f8f51e471c732599b2a6961803"
+    },
+    {
+      "module": "javafx.controls",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-controls",
+      "version": "19.0.2.1",
+      "classifier": "mac-aarch64",
+      "sha1": "3a14bd5f3ebe45d344c1f2bade0fe074e6ea2a83"
+    }
+  ],
+  "linux-x86_64": [
+    {
+      "module": "javafx.base",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-base",
+      "version": "19.0.2.1",
+      "classifier": "linux",
+      "sha1": "9e4ca5ce2b87c479d2cc445ff411a48aeae76936"
+    },
+    {
+      "module": "javafx.graphics",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-graphics",
+      "version": "19.0.2.1",
+      "classifier": "linux",
+      "sha1": "27c64e4e1569ddf198f28eda84cf8d014ab80693"
+    },
+    {
+      "module": "javafx.controls",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-controls",
+      "version": "19.0.2.1",
+      "classifier": "linux",
+      "sha1": "b5b2a8ead40bd43476740aa51697bb1cac23de5c"
+    }
+  ],
+  "linux-arm32": [
+    {
+      "module": "javafx.base",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-base",
+      "version": "19.0.2.1",
+      "classifier": "linux-arm32-monocle",
+      "sha1": "452f455d6948788c1e5350a41259eb8101d3f82a"
+    },
+    {
+      "module": "javafx.graphics",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-graphics",
+      "version": "19.0.2.1",
+      "classifier": "linux-arm32-monocle",
+      "sha1": "b45b33252e88263fe80a462a45828b4562c3c709"
+    },
+    {
+      "module": "javafx.controls",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-controls",
+      "version": "19.0.2.1",
+      "classifier": "linux-arm32-monocle",
+      "sha1": "e606c619fc493ecd18d281b0ded3aa38ba15a9e5"
+    }
+  ],
+  "linux-arm64": [
+    {
+      "module": "javafx.base",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-base",
+      "version": "19.0.2.1",
+      "classifier": "linux-aarch64",
+      "sha1": "1490bfe619e148b3d58746d43f549d697640c935"
+    },
+    {
+      "module": "javafx.graphics",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-graphics",
+      "version": "19.0.2.1",
+      "classifier": "linux-aarch64",
+      "sha1": "cad8004a87f57d9813c52985894ef15e8011baee"
+    },
+    {
+      "module": "javafx.controls",
+      "groupId": "org.openjfx",
+      "artifactId": "javafx-controls",
+      "version": "19.0.2.1",
+      "classifier": "linux-aarch64",
+      "sha1": "ccc33fc1fcbf46130346f4330d6d70b71bdec7d0"
+    }
+  ],
+  "linux-loongarch64": [
+    {
+      "module": "javafx.base",
+      "groupId": "org.glavo.hmcl.openjfx",
+      "artifactId": "javafx-base",
+      "version": "17.0.8-loongarch64",
+      "classifier": "linux",
+      "sha1": "9d692dfc79eb334a7b4bae922aa57cb3a437345e"
+    },
+    {
+      "module": "javafx.graphics",
+      "groupId": "org.glavo.hmcl.openjfx",
+      "artifactId": "javafx-graphics",
+      "version": "17.0.8-loongarch64",
+      "classifier": "linux",
+      "sha1": "7f241dc6adc8beddb776f453a3c63a5848d7b90b"
+    },
+    {
+      "module": "javafx.controls",
+      "groupId": "org.glavo.hmcl.openjfx",
+      "artifactId": "javafx-controls",
+      "version": "17.0.8-loongarch64",
+      "classifier": "linux",
+      "sha1": "1c8b0141bec93ed21d7c0e9a2f69a1c7e3c734d2"
+    }
+  ],
+  "linux-loongarch64_ow": [
+    {
+      "module": "javafx.base",
+      "groupId": "org.glavo.hmcl.openjfx",
+      "artifactId": "javafx-base",
+      "version": "19-ea+10-loongson64",
+      "classifier": "linux",
+      "sha1": "f90663ba93aef9f818236ce19ecfa33dca0ffe10"
+    },
+    {
+      "module": "javafx.graphics",
+      "groupId": "org.glavo.hmcl.openjfx",
+      "artifactId": "javafx-graphics",
+      "version": "19-ea+10-loongson64",
+      "classifier": "linux",
+      "sha1": "6ff76304d08bba093abfe7f4d50ce6a49279c87f"
+    },
+    {
+      "module": "javafx.controls",
+      "groupId": "org.glavo.hmcl.openjfx",
+      "artifactId": "javafx-controls",
+      "version": "19-ea+10-loongson64",
+      "classifier": "linux",
+      "sha1": "8a16096d42de70f2548f18840cdcd49a07fc1654"
+    }
+  ],
+  "linux-riscv64": [
+    {
+      "module": "javafx.base",
+      "groupId": "org.glavo.hmcl.openjfx",
+      "artifactId": "javafx-base",
+      "version": "19.0.2.1-riscv64",
+      "classifier": "linux",
+      "sha1": "e33c7e0bac2931a8f7a752bb74e4e4e535eec4ad"
+    },
+    {
+      "module": "javafx.graphics",
+      "groupId": "org.glavo.hmcl.openjfx",
+      "artifactId": "javafx-graphics",
+      "version": "19.0.2.1-riscv64",
+      "classifier": "linux",
+      "sha1": "ac4e5edd55d84da80f8fc2d81a4c9994296a6c09"
+    },
+    {
+      "module": "javafx.controls",
+      "groupId": "org.glavo.hmcl.openjfx",
+      "artifactId": "javafx-controls",
+      "version": "19.0.2.1-riscv64",
+      "classifier": "linux",
+      "sha1": "efe6a87ea24972d45f1931528f87e64a53bd2232"
+    }
+  ],
+  "freebsd-x86_64": [
+    {
+      "module": "javafx.base",
+      "groupId": "org.glavo.hmcl.openjfx",
+      "artifactId": "javafx-base",
+      "version": "14.0.2.1-freebsd",
+      "classifier": "freebsd",
+      "sha1": "7bac900f0ab0d4d6dcf178252cf37ee1e0470d40"
+    },
+    {
+      "module": "javafx.graphics",
+      "groupId": "org.glavo.hmcl.openjfx",
+      "artifactId": "javafx-graphics",
+      "version": "14.0.2.1-freebsd",
+      "classifier": "freebsd",
+      "sha1": "7773ce02d1dc29160801e4e077ed2a26e93bed13"
+    },
+    {
+      "module": "javafx.controls",
+      "groupId": "org.glavo.hmcl.openjfx",
+      "artifactId": "javafx-controls",
+      "version": "14.0.2.1-freebsd",
+      "classifier": "freebsd",
+      "sha1": "34a3dd3ccbc898bacfdcb3256cfb87ddc50621d3"
+    }
+  ]
+}

--- a/javafx.gradle.kts
+++ b/javafx.gradle.kts
@@ -27,7 +27,7 @@ data class Platform(
 
 val jfxModules = listOf("base", "graphics", "controls")
 val jfxMirrorRepos = listOf("https://mirrors.cloud.tencent.com/nexus/repository/maven-public")
-val jfxDependenciesFile = project("HMCL").layout.buildDirectory.file("openjfx-dependencies.json").get().asFile
+val jfxDependenciesFile = project.file("HMCL/src/main/resources/assets/openjfx-dependencies.json")
 val jfxPlatforms = listOf(
     Platform("windows-x86", "win-x86"),
     Platform("windows-x86_64", "win"),
@@ -86,8 +86,6 @@ if (!jfxInClasspath && JavaVersion.current() >= JavaVersion.VERSION_11) {
 }
 
 rootProject.tasks.create("generateOpenJFXDependencies") {
-    outputs.file(jfxDependenciesFile)
-
     doLast {
         val jfxDependencies = jfxPlatforms.associate { platform ->
             platform.name to jfxModules.map { module ->


### PR DESCRIPTION
我观察到每次新开一个分支并构建时，生成 `openjfx-dependencies.json` 总是花费不少时间。考虑到此文件修改不频繁，预生成它能够优化构建时的体验，也便于查看文件历史。