### PR TITLE
Fix alignment of host and port in proxy settings

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.ui.main;
 
 import com.jfoenix.controls.*;
-import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
@@ -204,7 +203,6 @@ public class DownloadSettingsPage extends StackPane {
                         Label host = new Label(i18n("settings.launcher.proxy.host"));
                         GridPane.setRowIndex(host, 1);
                         GridPane.setColumnIndex(host, 0);
-                        GridPane.setHalignment(host, HPos.RIGHT);
                         gridPane.getChildren().add(host);
                     }
 
@@ -220,7 +218,6 @@ public class DownloadSettingsPage extends StackPane {
                         Label port = new Label(i18n("settings.launcher.proxy.port"));
                         GridPane.setRowIndex(port, 2);
                         GridPane.setColumnIndex(port, 0);
-                        GridPane.setHalignment(port, HPos.RIGHT);
                         gridPane.getChildren().add(port);
                     }
 


### PR DESCRIPTION
Only it is aligned to the right… looks weird, does not it? This PR fixes that.

<details>
<summary>Wrong align</summary>

![wrong-align](https://github.com/user-attachments/assets/046937e9-8a25-44ca-a0df-f51ee124cd50)

</details>