### PR TITLE
Remove unnecessary translation check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,13 +87,6 @@ tasks.create("checkTranslations") {
             }
         }
 
-        zh_CN.forEach {
-            if (it.value.toString().contains("帐户")) {
-                project.logger.warn("The misspelled '帐户' in '${it.key}' should be replaced by '账户'")
-                success = false
-            }
-        }
-
         if (!success) {
             throw GradleException("Part of the translation is missing")
         }


### PR DESCRIPTION
I think it is more appropriate to check it when reviewing a PR, rather than hardcoding it into a build check.