### PR TITLE
Download source and thread setting titles i18n key

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
@@ -100,7 +100,7 @@ public class DownloadSettingsPage extends StackPane {
                 downloadSource.getChildren().setAll(chooseWrapper, versionListSourcePane, downloadSourcePane);
             }
 
-            content.getChildren().addAll(ComponentList.createComponentListTitle(i18n("settings.launcher.version_list_source")), downloadSource);
+            content.getChildren().addAll(ComponentList.createComponentListTitle(i18n("settings.launcher.download_source")), downloadSource);
         }
 
         {
@@ -158,7 +158,7 @@ public class DownloadSettingsPage extends StackPane {
                 }
             }
 
-            content.getChildren().addAll(ComponentList.createComponentListTitle(i18n("download")), downloadThreads);
+            content.getChildren().addAll(ComponentList.createComponentListTitle(i18n("settings.launcher.download.threads")), downloadThreads);
         }
 
         {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
@@ -158,7 +158,7 @@ public class DownloadSettingsPage extends StackPane {
                 }
             }
 
-            content.getChildren().addAll(ComponentList.createComponentListTitle(i18n("settings.launcher.download.threads")), downloadThreads);
+            content.getChildren().addAll(ComponentList.createComponentListTitle(i18n("download")), downloadThreads);
         }
 
         {


### PR DESCRIPTION
<details>
<summary>Before</summary>

![disappropriate-key](https://github.com/user-attachments/assets/ddb81236-93a8-4eba-b0a3-22b9ba47441c)

</details>

The titles of these two settings are obviously inappropriate - this PR changes them to the appropriate i18n key.