### PR TITLE
GitHub Action 使用 Java 8 构建 HMCL

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,11 +14,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: Set up JDK 8
       uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
-        java-version: '11'
+        java-version: 8
         java-package: 'jdk+fx'
     - name: Build with Gradle
       run: ./gradlew build --no-daemon

--- a/HMCLCore/build.gradle.kts
+++ b/HMCLCore/build.gradle.kts
@@ -14,4 +14,10 @@ dependencies {
     api("org.apache.commons:commons-compress:1.25.0")
     api("org.jsoup:jsoup:1.18.1")
     compileOnlyApi("org.jetbrains:annotations:24.1.0")
+
+    if (JavaVersion.current().isJava8) {
+        org.gradle.internal.jvm.Jvm.current().toolsJar?.let {
+            compileOnly(files(it))
+        }
+    }
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/game/CrashReportAnalyzer.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/game/CrashReportAnalyzer.java
@@ -113,7 +113,7 @@ public final class CrashReportAnalyzer {
         //https://github.com/HMCL-dev/HMCL/pull/2038
         MODMIXIN_FAILURE(Pattern.compile("(MixinApplyError|Mixin prepare failed |Mixin apply failed |mixin\\.injection\\.throwables\\.|\\.mixins\\.json\\] FAILED during \\))")),//ModMixin失败
         MIXIN_APPLY_MOD_FAILED(Pattern.compile("Mixin apply for mod (?<id>.*) failed"), "id"),//Mixin应用失败
-        FORGE_ERROR(Pattern.compile("An exception was thrown, the game will display an error screen and halt\\.(?<reason>(.*)[\\n\\r]*((.*)[\\n\\r]*)+)at "), "reason"),//Forge报错,Forge可能已经提供了错误信息
+        FORGE_ERROR(Pattern.compile("An exception was thrown, the game will display an error screen and halt\\.\\R*(?<reason>.*\\R*(\\s*at .*\\R)+)"), "reason"),//Forge报错,Forge可能已经提供了错误信息
         MOD_RESOLUTION0(Pattern.compile("(\tMod File:|-- MOD |\tFailure message:)")),
         FORGE_REPEAT_INSTALLATION(Pattern.compile("MultipleArgumentsForOptionException: Found multiple arguments for option (.*?), but you asked for only one")),//https://github.com/HMCL-dev/HMCL/issues/1880
         OPTIFINE_REPEAT_INSTALLATION(Pattern.compile("ResolutionException: Module optifine reads another module named optifine")),//Optifine 重复安装（及Mod文件夹有，自动安装也有）

--- a/HMCLCore/src/test/java/org/jackhuang/hmcl/game/CrashReportAnalyzerTest.java
+++ b/HMCLCore/src/test/java/org/jackhuang/hmcl/game/CrashReportAnalyzerTest.java
@@ -140,7 +140,8 @@ public class CrashReportAnalyzerTest {
                         "\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_131]\n" +
                         "\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_131]\n" +
                         "\tat java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_131]\n" +
-                        "\tat oolloo.jlw.Wrapper.invokeMain(Wrapper.java:58) [JavaWrapper.jar:?]\n").replaceAll("\\s+", ""),
+                        "\tat oolloo.jlw.Wrapper.invokeMain(Wrapper.java:58) [JavaWrapper.jar:?]\n" +
+                        "\tat oolloo.jlw.Wrapper.main(Wrapper.java:51) [JavaWrapper.jar:?]").replaceAll("\\s+", ""),
                 result.getMatcher().group("reason").replaceAll("\\s+", ""));
     }
 


### PR DESCRIPTION
 目前 HMCL 需要与 Java 8 兼容，并且黄鱼的 CI 服务器上仍在使用 Java 8 构建开发版和正式版的 HMCL。

本 PR 将 GitHub Action 调整为使用 Java 8 构建项目，这样能及时检测出代码中是否误用了高版本 Java/JavaFX 的 API，避免发布新版本时才构建失败。

此外本 PR 修复了一个会导致 Java 8 卡死的正则。