### PR TITLE
优化 Java 下载功能

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/disco/DiscoFetchJavaListTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/disco/DiscoFetchJavaListTask.java
@@ -79,7 +79,7 @@ public final class DiscoFetchJavaListTask extends Task<TreeMap<Integer, DiscoJav
         TreeMap<Integer, DiscoJavaRemoteVersion> map = new TreeMap<>();
 
         for (DiscoJavaRemoteVersion version : result) {
-            if (!distribution.getApiParameter().equals(version.getDistribution()))
+            if (!distribution.testVersion(version))
                 continue;
 
             int jdkVersion = version.getJdkVersion();

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/disco/DiscoJavaDistribution.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/disco/DiscoJavaDistribution.java
@@ -54,8 +54,8 @@ public enum DiscoJavaDistribution implements JavaDistribution<DiscoJavaRemoteVer
             pair(OSX, EnumSet.of(X86_64, ARM64))),
     GRAALVM("GraalVM", "graalvm", "Oracle",
             EnumSet.of(JDK),
-            pair(WINDOWS, EnumSet.of(X86_64, X86)),
-            pair(LINUX, EnumSet.of(X86_64, X86, ARM64, ARM32, RISCV64, PPC64LE)),
+            pair(WINDOWS, EnumSet.of(X86_64)),
+            pair(LINUX, EnumSet.of(X86_64, ARM64)),
             pair(OSX, EnumSet.of(X86_64, ARM64)));
 
     public static DiscoJavaDistribution of(String name) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/disco/DiscoJavaDistribution.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/disco/DiscoJavaDistribution.java
@@ -46,7 +46,16 @@ public enum DiscoJavaDistribution implements JavaDistribution<DiscoJavaRemoteVer
             EnumSet.of(JDK, JRE, JDKFX, JREFX),
             pair(WINDOWS, EnumSet.of(X86_64, X86, ARM64)),
             pair(LINUX, EnumSet.of(X86_64, X86, ARM64, ARM32, RISCV64, PPC64LE)),
-            pair(OSX, EnumSet.of(X86_64, ARM64))),
+            pair(OSX, EnumSet.of(X86_64, ARM64))) {
+        @Override
+        public boolean testVersion(DiscoJavaRemoteVersion version) {
+            if (!super.testVersion(version))
+                return false;
+
+            String fileName = version.getFileName();
+            return !fileName.endsWith("-lite.tar.gz") && !fileName.endsWith("-lite.zip");
+        }
+    },
     ZULU("Zulu", "zulu", "Azul",
             EnumSet.of(JDK, JRE, JDKFX, JREFX),
             pair(WINDOWS, EnumSet.of(X86_64, X86, ARM64)),
@@ -112,5 +121,9 @@ public enum DiscoJavaDistribution implements JavaDistribution<DiscoJavaRemoteVer
     @Override
     public Task<TreeMap<Integer, DiscoJavaRemoteVersion>> getFetchJavaVersionsTask(DownloadProvider provider, Platform platform, JavaPackageType packageType) {
         return new DiscoFetchJavaListTask(provider, this, platform, packageType);
+    }
+
+    public boolean testVersion(DiscoJavaRemoteVersion version) {
+        return this.getApiParameter().equals(version.getDistribution());
     }
 }


### PR DESCRIPTION
* 修复 Java 下载窗口会在 GraalVM 尚未支持的平台展示 GraalVM 选项的问题
* 修复部分平台下载 Liberica JDK 会选择 lite jdk 的问题