### PR TITLE
Revise zh_CN part 2

### DIFF
--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -444,7 +444,7 @@ game.crash.reason.mod_resolution_missing_minecraft=当前游戏由于模组和 M
 game.crash.reason.mod_resolution_mod_version=%1$s (版本号 %2$s)
 game.crash.reason.mod_resolution_mod_version.any=%1$s (任意版本)
 game.crash.reason.forge_repeat_installation=当前游戏由于 Forge 重复安装，无法继续运行。<a href="https://github.com/HMCL-dev/HMCL/issues/1880">此为已知问题</a>\n建议将日志上传并反馈至 GitHub，以便我们找到更多线索并修复此问题。\n目前你可以在“版本设置 → 自动安装”中卸载 Forge 并重新安装。
-game.crash.reason.optifine_repeat_installation=当前游戏由于 OptiFine 重复安装，无法继续运行。\n请删除模组目录下的 OptiFine 或前往“版本设置 → 自动安装”卸载安装的 OptiFine。
+game.crash.reason.optifine_repeat_installation=当前游戏由于 OptiFine 重复安装，无法继续运行。\n请删除模组文件夹下的 OptiFine 或前往“版本设置 → 自动安装”卸载安装的 OptiFine。
 game.crash.reason.forgemod_resolution=当前游戏由于模组依赖问题，无法继续运行。Forge/NeoForge 提供了如下信息：\n%1$s 
 game.crash.reason.forge_found_duplicate_mods=当前游戏由于模组重复安装，无法继续运行。Forge/NeoForge 提供了如下信息：\n%1$s 
 game.crash.reason.modmixin_failure=当前游戏由于某些模组注入失败，无法继续运行。\n这一般代表着该模组存在问题，或与当前环境不兼容。\n你可以查看日志寻找出错模组。
@@ -452,7 +452,7 @@ game.crash.reason.night_config_fixes=当前游戏由于 Night Config 库的一�
 game.crash.reason.forge_error=Forge/NeoForge 可能已经提供了错误信息。\n你可以查看日志，并根据错误报告中的日志信息进行对应处理。\n如果没有看到报错信息，可以查看错误报告了解错误具体是如何发生的。\n%1$s
 game.crash.reason.mod_resolution0=当前游戏由于一些模组出现问题，无法继续运行。\n你可以查看日志寻找出错模组。
 game.crash.reason.java_version_is_too_high=当前游戏由于 Java 虚拟机版本过高，无法继续运行。\n请在“(全局/版本特定) 游戏设置 → 游戏 Java”中改用较低版本的 Java，然后再启动游戏。\n如果没有，可以从 <a href="https://www.java.com/download/">java.com (Java 8)</a> 或 <a href="https://bell-sw.com/pages/downloads/#downloads">BellSoft Liberica Full JRE (Java 17)</a> 等平台下载、安装一个 (安装完后需重启启动器)。
-game.crash.reason.mod_name=当前游戏由于模组文件名称问题，无法继续运行。\n模组文件名称应只使用半角的大小写字母 (Aa~Zz)、数字 (0~9)、横线 (-)、下划线 (_)和点 (.)。\n请到模组目录中将所有不合规的模组文件名修改为上述合规字符。
+game.crash.reason.mod_name=当前游戏由于模组文件名称问题，无法继续运行。\n模组文件名称应只使用半角的大小写字母 (Aa~Zz)、数字 (0~9)、横线 (-)、下划线 (_)和点 (.)。\n请到模组文件夹中将所有不合规的模组文件名修改为上述合规字符。
 game.crash.reason.incomplete_forge_installation=当前游戏由于 Forge/NeoForge 安装不完整，无法继续运行。\n请在“版本设置 → 自动安装”中卸载 Forge 并重新安装。
 game.crash.reason.optifine_is_not_compatible_with_forge=当前游戏由于 OptiFine 与当前版本的 Forge 不兼容，导致游戏崩溃。\n点击 <a href="https://zkitefly.github.io/optifine-forge-support-list">此处</a> 查看 OptiFine 所兼容的 Forge 版本，并严格按照对应版本重新安装游戏或在“版本设置 → 自动安装”中更换版本。\n经测试，Forge 版本过高或过低都可能导致崩溃。
 game.crash.reason.mod_files_are_decompressed=当前游戏因为模组文件被解压了，无法继续运行。\n请直接把整个模组文件放进模组文件夹中即可。\n解压模组会导致游戏出错，请删除模组文件夹中已被解压的模组，然后再启动游戏。
@@ -470,9 +470,9 @@ game.crash.reason.resolution_too_high=当前游戏因为材质包分辨率过高
 game.crash.reason.stacktrace=原因未知，请点击日志按钮查看详细信息。\n下面是一些关键词，其中可能包含模组名称，你可以通过搜索的方式查找有关信息。\n%s
 game.crash.reason.too_old_java=当前游戏由于 Java 虚拟机版本过低，无法继续运行。\n你需要在“(全局/版本特定) 游戏设置 → 游戏 Java”中更换 Java %1$s 或更新版本的 Java 虚拟机，并重新启动游戏。如果没有下载安装，你可以点击 <a href="https://learn.microsoft.com/java/openjdk/download">此处</a> 下载 Microsoft JDK。
 game.crash.reason.unknown=原因未知，请点击日志按钮查看详细信息。
-game.crash.reason.unsatisfied_link_error=当前游戏由于缺少本地库，无法继续运行。\n这些本地库缺失：%1$s。\n如果你在“(全局/版本特定) 游戏设置 → 高级设置”中修改了本地库路径选项，请你修改回默认模式。\n如果你正在使用默认模式，请检查游戏目录路径是否只包含英文字母、数字和下划线，\n如果是，那么请检查是否为模组或 HMCL 导致了本地库缺失的问题。如果你确定是 HMCL 引起的，建议你向我们反馈。\n<b>对于 Windows 用户，你还可以尝试在“控制面板 → 时钟和区域 → 区域 → 管理 → 更改系统区域设置”中将“当前系统区域设置”修改为“中文(简体，中国大陆)”，并关闭“Beta 版：使用 Unicode UTF-8 提供全球语言支持”选项；</b>\n<b>或将游戏目录路径中的所有非英文字符的名称 (例如中文、空格等) 修改为英文字符。</b>\n如果你确实需要自定义本地库路径，你需要保证其中包含缺失的本地库！
+game.crash.reason.unsatisfied_link_error=当前游戏由于缺少本地库，无法继续运行。\n这些本地库缺失：%1$s。\n如果你在“(全局/版本特定) 游戏设置 → 高级设置”中修改了本地库路径选项，请你修改回默认模式。\n如果你正在使用默认模式，请检查游戏文件夹路径是否只包含英文字母、数字和下划线，\n如果是，那么请检查是否为模组或 HMCL 导致了本地库缺失的问题。如果你确定是 HMCL 引起的，建议你向我们反馈。\n<b>对于 Windows 用户，你还可以尝试在“控制面板 → 时钟和区域 → 区域 → 管理 → 更改系统区域设置”中将“当前系统区域设置”修改为“中文(简体，中国大陆)”，并关闭“Beta 版：使用 Unicode UTF-8 提供全球语言支持”选项；</b>\n<b>或将游戏文件夹路径中的所有非英文字符的名称 (例如中文、空格等) 修改为英文字符。</b>\n如果你确实需要自定义本地库路径，你需要保证其中包含缺失的本地库！
 game.crash.title=游戏意外退出
-game.directory=游戏目录路径
+game.directory=游戏文件夹路径
 game.version=游戏版本
 
 help=帮助

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -455,7 +455,7 @@ game.crash.reason.java_version_is_too_high=当前游戏由于 Java 虚拟机版�
 game.crash.reason.mod_name=当前游戏由于模组文件名称问题，无法继续运行。\n模组文件名称应只使用半角的大小写字母 (Aa~Zz)、数字 (0~9)、横线 (-)、下划线 (_)和点 (.)。\n请到模组文件夹中将所有不合规的模组文件名修改为上述合规字符。
 game.crash.reason.incomplete_forge_installation=当前游戏由于 Forge/NeoForge 安装不完整，无法继续运行。\n请在“版本设置 → 自动安装”中卸载 Forge 并重新安装。
 game.crash.reason.optifine_is_not_compatible_with_forge=当前游戏由于 OptiFine 与当前版本的 Forge 不兼容，导致游戏崩溃。\n点击 <a href="https://zkitefly.github.io/optifine-forge-support-list">此处</a> 查看 OptiFine 所兼容的 Forge 版本，并严格按照对应版本重新安装游戏或在“版本设置 → 自动安装”中更换版本。\n经测试，Forge 版本过高或过低都可能导致崩溃。
-game.crash.reason.mod_files_are_decompressed=当前游戏因为模组文件被解压了，无法继续运行。\n请直接把整个模组文件放进模组文件夹中即可。\n解压模组会导致游戏出错，请删除模组文件夹中已被解压的模组，然后再启动游戏。
+game.crash.reason.mod_files_are_decompressed=当前游戏由于模组文件被解压了，无法继续运行。\n请直接把整个模组文件放进模组文件夹中即可。\n解压模组会导致游戏出错，请删除模组文件夹中已被解压的模组，然后再启动游戏。
 game.crash.reason.shaders_mod=当前游戏由于同时安装了 OptiFine 和 Shaders 模组，无法继续运行。\n由于 OptiFine 已集成 Shaders 模组的功能，所以只需删除 Shaders 模组即可。
 game.crash.reason.rtss_forest_sodium=当前游戏由于 RivaTuner Statistics Server (RTSS) 与 Sodium 不兼容，导致游戏崩溃。\n点击 <a href="https://github.com/CaffeineMC/sodium-fabric/wiki/Known-Issues#rtss-incompatible">此处</a> 查看详情。
 game.crash.reason.too_many_mods_lead_to_exceeding_the_id_limit=当前游戏由于你所安装的模组过多，超出了游戏的 ID 限制，无法继续运行。\n请尝试安装 <a href="https://www.curseforge.com/minecraft/mc-mods/jeid">JEID</a> 等修复模组，或删除部分大型模组。
@@ -465,8 +465,8 @@ game.crash.reason.no_class_def_found_error=当前游戏由于代码不完整，�
 game.crash.reason.no_such_method_error=当前游戏由于代码不完整，无法继续运行。\n你的游戏可能缺失了某个模组，或者某些模组文件不完整，或者模组与游戏的版本不匹配。\n你可能需要重新安装游戏和模组，或寻求他人帮助。
 game.crash.reason.opengl_not_supported=当前游戏由于你的显卡驱动存在问题，无法继续运行。\n原因是 OpenGL 不受支持，你现在是否在远程桌面或者串流模式下？如果是，请直接使用原电脑启动游戏。\n或者尝试升级你的显卡驱动到最新版本后再尝试启动游戏。如果你的电脑存在独立显卡，你需要检查游戏是否使用集成/核心显卡启动，如果是，请尝试使用独立显卡启动 HMCL 与游戏。如果仍有问题，你可能需要考虑换一个新显卡或新电脑。
 game.crash.reason.openj9=当前游戏无法在 OpenJ9 虚拟机上运行，请你在“(全局/版本特定) 游戏设置 → 游戏 Java”中更换 Hotspot Java 虚拟机，并重新启动游戏。如果没有下载安装，你可以在网上自行下载。
-game.crash.reason.out_of_memory=当前游戏因为内存不足，无法继续运行。\n这可能是内存分配太小，或者模组数量过多导致的。\n你可以在全局（特定）游戏设置中调大游戏内存分配值以允许游戏在更大的内存下运行。\n如果仍然出现该错误，你可能需要换一台更好的电脑。
-game.crash.reason.resolution_too_high=当前游戏因为材质包分辨率过高，无法继续运行\n你可以更换一个分辨率更低的材质，或者更换一个显存更大的显卡。
+game.crash.reason.out_of_memory=当前游戏由于内存不足，无法继续运行。\n这可能是内存分配太小，或者模组数量过多导致的。\n你可以在全局（特定）游戏设置中调大游戏内存分配值以允许游戏在更大的内存下运行。\n如果仍然出现该错误，你可能需要换一台更好的电脑。
+game.crash.reason.resolution_too_high=当前游戏由于材质包分辨率过高，无法继续运行\n你可以更换一个分辨率更低的材质，或者更换一个显存更大的显卡。
 game.crash.reason.stacktrace=原因未知，请点击日志按钮查看详细信息。\n下面是一些关键词，其中可能包含模组名称，你可以通过搜索的方式查找有关信息。\n%s
 game.crash.reason.too_old_java=当前游戏由于 Java 虚拟机版本过低，无法继续运行。\n你需要在“(全局/版本特定) 游戏设置 → 游戏 Java”中更换 Java %1$s 或更新版本的 Java 虚拟机，并重新启动游戏。如果没有下载安装，你可以点击 <a href="https://learn.microsoft.com/java/openjdk/download">此处</a> 下载 Microsoft JDK。
 game.crash.reason.unknown=原因未知，请点击日志按钮查看详细信息。

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -403,79 +403,76 @@ folder.saves=存档文件夹
 folder.screenshots=截图文件夹
 
 game=游戏
-game.crash.feedback=<b>请不要将本界面截图给他人！</b>如果你要求助他人，请你点击左下角<b> 导出游戏崩溃信息 </b>后将导出的文件发送给他人以供分析。\n你可以点击下方的<b> 帮助 </b>前往交流群寻求帮助。
+game.crash.feedback=<b>请不要将本界面截图给他人！</b>如果你要向他人求助，请你点击左下角<b>“导出游戏崩溃信息”</b>后将导出的文件发送给他人以供分析。\n你可以点击下方的<b>“帮助”</b>前往交流群寻求帮助。
 game.crash.info=游戏信息
 game.crash.reason=崩溃原因
 game.crash.reason.analyzing=分析中……
-game.crash.reason.block=当前游戏因为某个方块不能正常工作，无法继续运行。\n你可以尝试通过 <a href="https://www.mcedit.net">MCEdit</a> 工具编辑存档删除该方块，或者直接删除相应的模组。\n方块类型：%1$s\n方块坐标：%2$s 
-game.crash.reason.bootstrap_failed=当前游戏因为模组 %1$s 错误，无法继续运行。\n你可以尝试删除或更新该模组以解决问题。
-game.crash.reason.mixin_apply_mod_failed=当前游戏因为 Mixin 无法应用 %1$s 模组，无法继续运行。\n你可以尝试删除或更新该 Mod 以解决问题。
-game.crash.reason.config=当前游戏因为无法解析模组配置文件，无法继续运行\n模组 %1$s 的配置文件 %2$s 无法被解析。
+game.crash.reason.block=当前游戏由于某个方块不能正常工作，无法继续运行。\n你可以尝试通过 <a href="https://www.mcedit.net">MCEdit</a> 工具编辑存档删除该方块，或者直接删除相应的模组。\n方块类型：%1$s\n方块坐标：%2$s 
+game.crash.reason.bootstrap_failed=当前游戏由于模组“%1$s”出现问题，无法继续运行。\n你可以尝试删除或更新该模组以解决问题。
+game.crash.reason.mixin_apply_mod_failed=当前游戏由于 Mixin 无法应用于“%1$s”模组，无法继续运行。\n你可以尝试删除或更新该模组以解决问题。
+game.crash.reason.config=当前游戏由于无法解析模组配置文件，无法继续运行。\n无法解析模组“%1$s”的配置文件“%2$s”。
 game.crash.reason.multiple=检测到多个原因：\n\n
-game.crash.reason.debug_crash=当前游戏因为手动触发崩溃，无法继续运行。\n事实上游戏并没有问题，问题都是你造成的！
-game.crash.reason.duplicated_mod=当前游戏因为模组 %1$s 重复安装，无法继续运行。\n%2$s\n每种模组只能安装一个，请你删除多余的模组再试。
-game.crash.reason.entity=当前游戏因为某个实体不能正常工作，无法继续运行。\n你可以尝试通过 <a href="https://www.mcedit.net">MCEdit</a> 工具编辑存档删除该实体，或者直接删除相应的模组。\n实体类型：%1$s\n实体坐标：%2$s 
-game.crash.reason.fabric_version_0_12=Fabric 0.12 及以上版本与当前已经安装的模组可能不兼容，你需要将 Fabric 降级至 0.11.7。
+game.crash.reason.debug_crash=当前游戏由于手动触发崩溃，无法继续运行。\n事实上游戏并没有问题，问题都是你造成的！
+game.crash.reason.duplicated_mod=当前游戏由于模组“%1$s”重复安装，无法继续运行。\n%2$s\n每种模组只能安装一个，请你删除多余的模组再试。
+game.crash.reason.entity=当前游戏由于某个实体不能正常工作，无法继续运行。\n你可以尝试通过 <a href="https://www.mcedit.net">MCEdit</a> 工具编辑存档删除该实体，或者直接删除相应的模组。\n实体类型：%1$s\n实体坐标：%2$s 
+game.crash.reason.fabric_version_0_12=Fabric Loader 0.12 及更高版本与当前已经安装的模组可能不兼容，你需要将 Fabric Loader 降级至 0.11.7。
 game.crash.reason.fabric_warnings=Fabric 提供了一些警告信息：\n%1$s
-game.crash.reason.file_already_exists=当前游戏因为文件 %1$s 已经存在，无法继续运行。\n如果你认为这个文件可以删除，你可以在备份这个文件后尝试删除它，并重新启动游戏。
-game.crash.reason.file_changed=当前游戏因为文件校验失败，无法继续运行。\n如果你手动修改了 Minecraft.jar 文件，你需要回退修改，或者重新下载游戏。
-game.crash.reason.gl_operation_failure=当前游戏因为你使用的某些模组、光影包、材质包，无法继续运行。\n请先尝试禁用你所使用的模组/光影包/材质包再试。
-game.crash.reason.graphics_driver=当前游戏因为显卡驱动问题而崩溃，请尝试以下操作：\n\
-  - 如果你的电脑存在独立显卡，请尝试使用 独立显卡 而非 Intel 核显启动 HMCL 与游戏 <a href="https://www.bing.com/search?q=使用独立显卡运行Minecraft">详情</a> ；\n\
-  - <a href="https://minecrafthopper.net/help/pixel-format-not-accelerated/">尝试升级你的 显卡驱动 到最新版本</a>，或回退到出厂版本；\n\
-  - 如果你确实需要使用核芯显卡，请检查你的电脑的 CPU 是否是 Intel(R) Core(TM) 3000 系列或更旧的处理器，如果是，对于 Minecraft 1.16.5 及更旧版本，请你将游戏所使用的 Java 版本降级至 1.8.0_51 及以下版本 <a href="https://github.com/frekele/oracle-java/releases/8u51-b16">Java 1.8.0 历史版本</a> ，否则请跳过；\n\
-  - 在全局（特定）游戏设置，高级设置中打开“使用 OpenGL 软渲染器”（开启此选项后帧数会显著降低，仅推荐在以调试为目的或应急时开启）。\n\
+game.crash.reason.file_already_exists=当前游戏由于文件“%1$s”已经存在，无法继续运行。\n如果你认为这个文件可以删除，你可以在备份这个文件后尝试删除它，并重新启动游戏。
+game.crash.reason.file_changed=当前游戏由于文件校验失败，无法继续运行。\n如果你手动修改了 Minecraft.jar 文件，你需要回退修改，或者重新下载游戏。
+game.crash.reason.gl_operation_failure=当前游戏由于你使用的某些模组/光影包/资源包有问题，导致无法继续运行。\n请先尝试禁用你所使用的模组/光影包/资源包再试。
+game.crash.reason.graphics_driver=当前游戏由于显卡驱动问题而崩溃，请尝试以下操作：\n\
+  \  · 如果你的电脑存在独立显卡，请尝试使用独立显卡而非 Intel 核显启动 HMCL 与游戏；<a href="https://www.bing.com/search?q=使用独立显卡运行Minecraft">详情</a>\n\
+  \  · <a href="https://minecrafthopper.net/help/pixel-format-not-accelerated/">尝试升级你的显卡驱动到最新版本</a>，或回退到出厂版本；\n\
+  \  · 如果你确实需要使用核芯显卡，请检查你电脑的 CPU 是否为 Intel(R) Core(TM) 3000 系列或更旧的处理器。如果是，对于 Minecraft 1.16.5 及更旧版本，请你将游戏所使用的 Java 降级至 1.8.0_51 及更低版本，否则请跳过；<a href="https://github.com/frekele/oracle-java/releases/8u51-b16">Java 1.8.0 历史版本</a>\n\
   如果仍有问题，你可能需要考虑换一张新显卡或一台新电脑。
-game.crash.reason.macos_failed_to_find_service_port_for_display=当前游戏因为 Apple silicon 平台下初始化 OpenGL 窗口失败，无法继续运行。\n对于该问题，HMCL 暂无直接性的解决方案。请您尝试任意打开一个浏览器并全屏，然后再回到 HMCL 启动游戏，在弹出游戏窗口前<b>迅速切回浏览器页面</b>，等待游戏窗口出现后再切回游戏窗口。
-game.crash.reason.illegal_access_error=当前游戏因为某些模组的问题，无法继续运行。\n如果你认识：%1$s，你可以更新或删除对应模组再试。
-game.crash.reason.install_mixinbootstrap=当前游戏因为缺失 MixinBootstrap，无法继续运行。\n你可以尝试安装 <a href="https://www.curseforge.com/minecraft/mc-mods/mixinbootstrap">MixinBootstrap</a> 解决该问题。若安装后崩溃，尝试在该模组的文件名前加入英文“!”尝试解决。
-game.crash.reason.need_jdk11=当前游戏因为 Java 虚拟机版本不合适，无法继续运行。\n你需要下载安装 <a href="https://bell-sw.com/pages/downloads/#downloads">Java 11</a>，并在全局（特定）游戏设置中将 Java 设置为 11 开头的版本。
-game.crash.reason.jdk_9=当前游戏因为 Java 版本过高，无法继续运行。\n你需要下载安装 <a href="https://bell-sw.com/pages/downloads/#downloads">Java 8</a>，并在全局（特定）游戏设置中将 Java 设置为 1.8 的版本。
-game.crash.reason.jvm_32bit=当前游戏因为内存分配过大，超过了 32 位 Java 内存限制，无法继续运行。\n如果你的电脑是 64 位系统，请下载安装并更换 64 位 Java。<a href="https://bell-sw.com/pages/downloads/#downloads">下载 Java</a>\n如果你的电脑是 32 位系统，你或许可以重新安装 64 位系统，或换一台新电脑。\n或者，你可以关闭游戏内存的自动分配，并且把内存限制调节为 1024 MB 或以下。
-game.crash.reason.loading_crashed_forge=当前游戏因为模组 %1$s (%2$s) 错误，无法继续运行。\n你可以尝试删除或更新该模组以解决问题。
-game.crash.reason.loading_crashed_fabric=当前游戏因为模组 %1$s 错误，无法继续运行。\n你可以尝试删除或更新该模组以解决问题。
-game.crash.reason.memory_exceeded=当前游戏因为分配的内存过大，无法继续运行。\n该问题是由于系统页面文件太小导致的。\n你需要在全局（特定）游戏设置中关闭游戏内存的自动分配，并将游戏内存调低至游戏能正常启动为止。\n你还可以尝试将 虚拟内存 设置调整至「自动管理所有驱动器分页文件大小」，<a href="https://docs.hmcl.net/assets/img/hmcl/自动管理所有驱动器分页文件大小.webp">详情</a>。
-game.crash.reason.mac_jdk_8u261=当前游戏因为你所使用的 Forge 或 OptiFine 与 Java 冲突崩溃。\n请尝试更新 Forge 和 OptiFine，或使用 Java 8u251 及更早版本启动。
-game.crash.reason.mod=当前游戏因为 %1$s 的问题，无法继续运行。\n你可以更新或删除已经安装的 %1$s 再试。
-game.crash.reason.mod_resolution=当前游戏因为 Mod 依赖问题，无法继续运行。Fabric 提供了如下信息：\n%1$s 
-game.crash.reason.mod_resolution_collection=当前游戏因为前置 Mod 版本不匹配，无法继续运行。\n%1$s 需要前置 Mod：%2$s 才能继续运行。\n这表示你需要更新或降级前置。你可以到下载页的模组下载，或到网上下载 %3$s。
-game.crash.reason.mod_resolution_conflict=当前游戏因为 Mod 冲突，无法继续运行。\n%1$s 与 %2$s 不能兼容。
-game.crash.reason.mod_resolution_missing=当前游戏因为缺少 Mod 前置，无法继续运行。\n%1$s 需要前置 Mod：%2$s 才能继续运行。\n这表示你少安装了 Mod，或该 Mod 版本不够。你可以到下载页的模组下载，或到网上下载 %3$s。
-game.crash.reason.mod_resolution_missing_minecraft=当前游戏因为 Mod 和 Minecraft 游戏版本不匹配，无法继续运行。\n%1$s 需要 Minecraft %2$s 才能运行。\n如果你要继续使用你已经安装的 Mod，你可以选择安装对应的 Minecraft 版本；如果你要继续使用当前 Minecraft 版本，你需要安装对应版本的 Mod。
+game.crash.reason.macos_failed_to_find_service_port_for_display=当前游戏由于 Apple Silicon 平台下初始化 OpenGL 窗口失败，无法继续运行。\n对于该问题，HMCL 暂无直接性的解决方案。请你尝试任意打开一个浏览器并全屏，然后再回到 HMCL 启动游戏，在弹出游戏窗口前<b>迅速切回浏览器页面</b>，等待游戏窗口出现后再切回游戏窗口。
+game.crash.reason.illegal_access_error=当前游戏由于某些模组的问题，无法继续运行。\n如果你认识“%1$s”，你可以更新或删除对应模组再试。
+game.crash.reason.install_mixinbootstrap=当前游戏由于缺失 MixinBootstrap，无法继续运行。\n你可以尝试安装 <a href="https://www.curseforge.com/minecraft/mc-mods/mixinbootstrap">MixinBootstrap</a> 解决该问题。若安装后崩溃，尝试在该模组的文件名前加入半角感叹号 (!) 尝试解决。
+game.crash.reason.need_jdk11=当前游戏由于 Java 虚拟机版本不合适，无法继续运行。\n你需要下载安装 <a href="https://bell-sw.com/pages/downloads/#downloads">Java 11</a>，并在“(全局/版本特定) 游戏设置 → 游戏 Java”中将 Java 设置为 11 开头的版本。
+game.crash.reason.jdk_9=当前游戏由于 Java 版本过高，无法继续运行。\n你需要下载安装 <a href="https://bell-sw.com/pages/downloads/#downloads">Java 8</a>，并在“(全局/版本特定) 游戏设置 → 游戏 Java”中将 Java 设置为 1.8 的版本。
+game.crash.reason.jvm_32bit=当前游戏由于内存分配过大，超过了 32 位 Java 内存限制，无法继续运行。\n如果你的电脑是 64 位系统，请下载安装并更换 64 位 Java。<a href="https://bell-sw.com/pages/downloads/#downloads">下载 Java</a>\n如果你的电脑是 32 位系统，你或许可以重新安装 64 位系统，或换一台新电脑。\n或者，你可以在“(全局/版本特定) 游戏设置 → 游戏内存”中关闭“自动分配内存”，并且把内存限制调节为 1024 MB 或以下。
+game.crash.reason.loading_crashed_forge=当前游戏由于模组“%1$s (%2$s)”错误，无法继续运行。\n你可以尝试删除或更新该模组以解决问题。
+game.crash.reason.loading_crashed_fabric=当前游戏由于模组“%1$s”错误，无法继续运行。\n你可以尝试删除或更新该模组以解决问题。
+game.crash.reason.memory_exceeded=当前游戏由于分配的内存过大，无法继续运行。\n该问题是由于系统页面文件太小导致的。\n你需要在全局（特定）游戏设置中关闭游戏内存的自动分配，并将游戏内存调低至游戏能正常启动为止。\n你还可以尝试将 虚拟内存 设置调整至「自动管理所有驱动器分页文件大小」，<a href="https://docs.hmcl.net/assets/img/hmcl/自动管理所有驱动器分页文件大小.webp">详情</a>。
+game.crash.reason.mac_jdk_8u261=当前游戏由于你所使用的 Forge/OptiFine 与 Java 冲突而崩溃。\n请尝试更新 Forge/OptiFine，或使用 Java 8u251 及更早版本启动。
+game.crash.reason.mod=当前游戏由于“%1$s”的问题，无法继续运行。\n你可以更新或删除已经安装的“%1$s”再试。
+game.crash.reason.mod_resolution=当前游戏由于模组依赖问题，无法继续运行。Fabric 提供了如下信息：\n%1$s 
+game.crash.reason.mod_resolution_collection=当前游戏由于前置模组版本不匹配，无法继续运行。\n“%1$s”需要前置模组“%2$s”才能继续运行。\n这表示你需要更新或降级前置。你可以前往“下载 → 模组”页面下载，或到网上下载“%3$s”。
+game.crash.reason.mod_resolution_conflict=当前游戏由于模组冲突，无法继续运行。\n“%1$s”与“%2$s”不兼容。
+game.crash.reason.mod_resolution_missing=当前游戏由于缺少前置模组，无法继续运行。\n“%1$s”需要前置模组“%2$s”才能继续运行。\n这表示你少安装了模组，或该模组版本不够。你可以前往“下载 → 模组”页面下载，或到网上下载“%3$s”。
+game.crash.reason.mod_resolution_missing_minecraft=当前游戏由于模组和 Minecraft 游戏版本不匹配，无法继续运行。\n“%1$s”需要 Minecraft %2$s 才能运行。\n如果你要继续使用你已经安装的模组，你可以选择安装对应的 Minecraft 版本；如果你要继续使用当前 Minecraft 版本，你需要安装对应版本的模组。
 game.crash.reason.mod_resolution_mod_version=%1$s (版本号 %2$s)
 game.crash.reason.mod_resolution_mod_version.any=%1$s (任意版本)
-game.crash.reason.forge_repeat_installation=当前游戏因为 Forge 重复安装，无法继续运行。<a href="https://github.com/HMCL-dev/HMCL/issues/1880">此为已知问题</a>\n建议将日志上传反馈至 GitHub ，以便我们找到更多线索并修复此问题。\n目前你可以到 自动安装 里头卸载 Forge 并重新安装。
-game.crash.reason.optifine_repeat_installation=当前游戏因为 Optifine 重复安装，无法继续运行。\n请删除 Mod 文件夹下的 Optifine 或前往 游戏管理-自动安装 卸载自动安装的 Optifine。
-game.crash.reason.forgemod_resolution=当前游戏因为模组依赖问题，无法继续运行。Forge 提供了如下信息：\n%1$s 
-game.crash.reason.forge_found_duplicate_mods=当前游戏因为模组重复问题，无法继续运行。Forge 提供了如下信息：\n%1$s 
-game.crash.reason.modmixin_failure=当前游戏因为某些 Mod 注入失败，无法继续运行。\n这一般代表着该 Mod 存在 Bug，或与当前环境不兼容。\n你可以查看日志寻找出错模组。
-game.crash.reason.night_config_fixes=当前游戏因为 Night Config 库的一些问题，无法继续运行。\n你可以尝试安装 <a href="https://www.curseforge.com/minecraft/mc-mods/night-config-fixes">Night Config Fixes</a> 模组，这或许能帮助你解决这个问题。\n了解更多，可访问该模组的 <a href="https://www.github.com/Fuzss/nightconfigfixes">GitHub 仓库</a>。
-game.crash.reason.forge_error=Forge 可能已经提供了错误信息。\n你可以查看日志，并根据错误报告中的日志信息进行对应处。\n如果没有看到报错信息，可以查看错误报告了解错误具体是如何发生的。\n%1$s
-game.crash.reason.mod_resolution0=当前游戏因为一些模组出现问题，无法继续运行。\n你可以查看日志寻找出错模组。
-game.crash.reason.fabric_reports_an_error_and_gives_a_solution=Fabric 可能已经提供了错误信息。\n你可以查看日志，并根据错误报告中的日志信息进行对应处。\n如果没有看到报错信息，可以查看错误报告了解错误具体是如何发生的。
-game.crash.reason.java_version_is_too_high=当前游戏因为 Java 虚拟机版本过高，无法继续运行。\n请在全局（特定）游戏设置的 Java 路径选项卡中改用较低版本的 Java，然后再启动游戏。\n如果没有，可以从 <a href="https://www.java.com/download/">java.com（Java8）</a> 或 <a href="https://bell-sw.com/pages/downloads/#downloads">BellSoft Liberica Full JRE（Java17）</a> 等平台下载、安装一个（安装完后需重启启动器）。
-game.crash.reason.mod_name=当前游戏因为模组文件名称问题，无法继续运行。\n模组文件名称应只使用英文全半角的大小写字母（Aa~Zz）、数字（0~9）、横线（-）、下划线（_）和点（.）。\n请到模组文件夹中将所有不合规的模组文件名称添加一个上述的合规的字符。
-game.crash.reason.incomplete_forge_installation=当前游戏因为 Forge / NeoForge 安装不完整，无法继续运行。\n请在 版本设置 - 自动安装 中卸载 Forge 并重新安装。
-game.crash.reason.optifine_is_not_compatible_with_forge=当前游戏因为 OptiFine 与当前版本的 Forge 不兼容，导致了游戏崩溃。\n点击 <a href="https://zkitefly.github.io/optifine-forge-support-list">此处</a> 查看 OptiFine 所兼容的 Forge 版本，并严格按照对应版本重新安装游戏或在 版本设置 - 自动安装 中更换版本。\n经测试，Forge 版本过高或过低都可能导致崩溃。 
-game.crash.reason.mod_files_are_decompressed=当前游戏因为模组文件被解压了，无法继续运行。\n请直接把整个模组文件放进模组文件夹中即可。\n解压模组会导致游戏出错，请删除模组文件夹中已被解压的模组，然后再启动游戏。 
-game.crash.reason.shaders_mod=当前游戏因为同时安装了 OptiFine 和 Shaders 模组，无法继续运行。\n因为 OptiFine 已集成 Shaders 模组的功能，只需删除 Shaders 模组即可。
-game.crash.reason.rtss_forest_sodium=当前游戏因为 RivaTuner Statistics Server (RTSS) 与 Sodium 不兼容，导致了游戏崩溃。\n点击 <a href="https://github.com/CaffeineMC/sodium-fabric/wiki/Known-Issues#rtss-incompatible">此处</a> 查看详情。
-game.crash.reason.too_many_mods_lead_to_exceeding_the_id_limit=当前游戏因为您所安装的模组过多，超出了游戏的 ID 限制，无法继续运行。\n请尝试安装 <a href="https://www.curseforge.com/minecraft/mc-mods/jeid">JEID</a> 等修复模组，或删除部分大型模组。
-game.crash.reason.optifine_causes_the_world_to_fail_to_load=当前游戏可能因为 OptiFine ，无法继续运行。\n该问题只在特定 OptiFine 版本中出现，你可以尝试在 版本设置 - 自动安装 中更换 OptiFine 的版本。 
-game.crash.reason.modlauncher_8=当前游戏因为您所使用的 Forge 版本与当前使用的 Java 冲突崩溃，请尝试更新 Forge 到 36.2.26 或更高版本或换用版本低于 1.8.0.320 的 Java，<a href="https://bell-sw.com/pages/downloads/?version=java-8&package=jre-full">Liberica JDK 8u312+7</a>。
-game.crash.reason.no_class_def_found_error=当前游戏因为代码不完整，无法继续运行。\n你的游戏可能缺失了某个模组，或者某些模组文件不完整，或者模组与游戏的版本不匹配。\n你可能需要重新安装游戏和模组，或请求他人帮助。\n缺失：\n%1$s 
-game.crash.reason.no_such_method_error=当前游戏因为代码不完整，无法继续运行。\n你的游戏可能缺失了某个模组，或者某些模组文件不完整，或者模组与游戏的版本不匹配。\n你可能需要重新安装游戏和模组，或请求他人帮助。 
-game.crash.reason.opengl_not_supported=当前游戏因为你的显卡驱动存在问题，无法继续运行。\n原因是 OpenGL 不受支持，你现在是否在远程桌面或者串流模式下？如果是，请直接使用原电脑启动游戏。\n或者尝试升级你的显卡驱动到最新版本后再尝试启动游戏。如果你的电脑存在独立显卡，你需要检查游戏是否使用集成/核心显卡启动，如果是，请尝试使用独立显卡启动 HMCL 与游戏。如果仍有问题，你可能需要考虑换一个新显卡或新电脑。 
-game.crash.reason.openj9=当前游戏无法运行在 OpenJ9 虚拟机上，请你在全局（特定）游戏设置中更换 Hotspot Java 虚拟机，并重新启动游戏。如果没有下载安装，你可以在网上自行下载。 
-game.crash.reason.out_of_memory=当前游戏因为内存不足，无法继续运行。\n这可能是内存分配太小，或者模组数量过多导致的。\n你可以在全局（特定）游戏设置中调大游戏内存分配值以允许游戏在更大的内存下运行。\n如果仍然出现该错误，你可能需要换一台更好的电脑。 
-game.crash.reason.resolution_too_high=当前游戏因为材质包分辨率过高，无法继续运行\n你可以更换一个分辨率更低的材质，或者更换一个显存更大的显卡。 
+game.crash.reason.forge_repeat_installation=当前游戏由于 Forge 重复安装，无法继续运行。<a href="https://github.com/HMCL-dev/HMCL/issues/1880">此为已知问题</a>\n建议将日志上传并反馈至 GitHub，以便我们找到更多线索并修复此问题。\n目前你可以在“版本设置 → 自动安装”中卸载 Forge 并重新安装。
+game.crash.reason.optifine_repeat_installation=当前游戏由于 OptiFine 重复安装，无法继续运行。\n请删除模组目录下的 OptiFine 或前往“版本设置 → 自动安装”卸载安装的 OptiFine。
+game.crash.reason.forgemod_resolution=当前游戏由于模组依赖问题，无法继续运行。Forge/NeoForge 提供了如下信息：\n%1$s 
+game.crash.reason.forge_found_duplicate_mods=当前游戏由于模组重复安装，无法继续运行。Forge/NeoForge 提供了如下信息：\n%1$s 
+game.crash.reason.modmixin_failure=当前游戏由于某些模组注入失败，无法继续运行。\n这一般代表着该模组存在问题，或与当前环境不兼容。\n你可以查看日志寻找出错模组。
+game.crash.reason.night_config_fixes=当前游戏由于 Night Config 库的一些问题，无法继续运行。\n你可以尝试安装 <a href="https://www.curseforge.com/minecraft/mc-mods/night-config-fixes">Night Config Fixes</a> 模组，这或许能帮助你解决这个问题。\n更多详情，可访问该模组的 <a href="https://github.com/Fuzss/nightconfigfixes">GitHub 仓库</a>。
+game.crash.reason.forge_error=Forge/NeoForge 可能已经提供了错误信息。\n你可以查看日志，并根据错误报告中的日志信息进行对应处理。\n如果没有看到报错信息，可以查看错误报告了解错误具体是如何发生的。\n%1$s
+game.crash.reason.mod_resolution0=当前游戏由于一些模组出现问题，无法继续运行。\n你可以查看日志寻找出错模组。
+game.crash.reason.java_version_is_too_high=当前游戏由于 Java 虚拟机版本过高，无法继续运行。\n请在“(全局/版本特定) 游戏设置 → 游戏 Java”中改用较低版本的 Java，然后再启动游戏。\n如果没有，可以从 <a href="https://www.java.com/download/">java.com (Java 8)</a> 或 <a href="https://bell-sw.com/pages/downloads/#downloads">BellSoft Liberica Full JRE (Java 17)</a> 等平台下载、安装一个 (安装完后需重启启动器)。
+game.crash.reason.mod_name=当前游戏由于模组文件名称问题，无法继续运行。\n模组文件名称应只使用半角的大小写字母 (Aa~Zz)、数字 (0~9)、横线 (-)、下划线 (_)和点 (.)。\n请到模组目录中将所有不合规的模组文件名修改为上述合规字符。
+game.crash.reason.incomplete_forge_installation=当前游戏由于 Forge/NeoForge 安装不完整，无法继续运行。\n请在“版本设置 → 自动安装”中卸载 Forge 并重新安装。
+game.crash.reason.optifine_is_not_compatible_with_forge=当前游戏由于 OptiFine 与当前版本的 Forge 不兼容，导致游戏崩溃。\n点击 <a href="https://zkitefly.github.io/optifine-forge-support-list">此处</a> 查看 OptiFine 所兼容的 Forge 版本，并严格按照对应版本重新安装游戏或在“版本设置 → 自动安装”中更换版本。\n经测试，Forge 版本过高或过低都可能导致崩溃。
+game.crash.reason.mod_files_are_decompressed=当前游戏因为模组文件被解压了，无法继续运行。\n请直接把整个模组文件放进模组文件夹中即可。\n解压模组会导致游戏出错，请删除模组文件夹中已被解压的模组，然后再启动游戏。
+game.crash.reason.shaders_mod=当前游戏由于同时安装了 OptiFine 和 Shaders 模组，无法继续运行。\n由于 OptiFine 已集成 Shaders 模组的功能，所以只需删除 Shaders 模组即可。
+game.crash.reason.rtss_forest_sodium=当前游戏由于 RivaTuner Statistics Server (RTSS) 与 Sodium 不兼容，导致游戏崩溃。\n点击 <a href="https://github.com/CaffeineMC/sodium-fabric/wiki/Known-Issues#rtss-incompatible">此处</a> 查看详情。
+game.crash.reason.too_many_mods_lead_to_exceeding_the_id_limit=当前游戏由于你所安装的模组过多，超出了游戏的 ID 限制，无法继续运行。\n请尝试安装 <a href="https://www.curseforge.com/minecraft/mc-mods/jeid">JEID</a> 等修复模组，或删除部分大型模组。
+game.crash.reason.optifine_causes_the_world_to_fail_to_load=当前游戏可能由于 OptiFine 而无法继续运行。\n该问题只在特定 OptiFine 版本中出现，你可以尝试在“版本设置 → 自动安装”中更换 OptiFine 的版本。
+game.crash.reason.modlauncher_8=当前游戏由于你所使用的 Forge 版本与当前使用的 Java 冲突而崩溃，请尝试更新 Forge 到 36.2.26 或更高版本或换用版本低于 1.8.0.320 的 Java。<a href="https://bell-sw.com/pages/downloads/?version=java-8&package=jre-full">Liberica JDK 8u312+7</a>
+game.crash.reason.no_class_def_found_error=当前游戏由于代码不完整，无法继续运行。\n你的游戏可能缺失了某个模组，或者某些模组文件不完整，或者模组与游戏的版本不匹配。\n你可能需要重新安装游戏和模组，或寻求他人帮助。\n缺失：\n%1$s 
+game.crash.reason.no_such_method_error=当前游戏由于代码不完整，无法继续运行。\n你的游戏可能缺失了某个模组，或者某些模组文件不完整，或者模组与游戏的版本不匹配。\n你可能需要重新安装游戏和模组，或寻求他人帮助。
+game.crash.reason.opengl_not_supported=当前游戏由于你的显卡驱动存在问题，无法继续运行。\n原因是 OpenGL 不受支持，你现在是否在远程桌面或者串流模式下？如果是，请直接使用原电脑启动游戏。\n或者尝试升级你的显卡驱动到最新版本后再尝试启动游戏。如果你的电脑存在独立显卡，你需要检查游戏是否使用集成/核心显卡启动，如果是，请尝试使用独立显卡启动 HMCL 与游戏。如果仍有问题，你可能需要考虑换一个新显卡或新电脑。
+game.crash.reason.openj9=当前游戏无法在 OpenJ9 虚拟机上运行，请你在“(全局/版本特定) 游戏设置 → 游戏 Java”中更换 Hotspot Java 虚拟机，并重新启动游戏。如果没有下载安装，你可以在网上自行下载。
+game.crash.reason.out_of_memory=当前游戏因为内存不足，无法继续运行。\n这可能是内存分配太小，或者模组数量过多导致的。\n你可以在全局（特定）游戏设置中调大游戏内存分配值以允许游戏在更大的内存下运行。\n如果仍然出现该错误，你可能需要换一台更好的电脑。
+game.crash.reason.resolution_too_high=当前游戏因为材质包分辨率过高，无法继续运行\n你可以更换一个分辨率更低的材质，或者更换一个显存更大的显卡。
 game.crash.reason.stacktrace=原因未知，请点击日志按钮查看详细信息。\n下面是一些关键词，其中可能包含模组名称，你可以通过搜索的方式查找有关信息。\n%s
-game.crash.reason.too_old_java=当前游戏因为 Java 虚拟机版本过低，无法继续运行。\n你需要在全局（特定）游戏设置中更换 Java %1$s 或更新版本的 Java 虚拟机，并重新启动游戏。如果没有下载安装，你可以点击 <a href="https://bell-sw.com/pages/downloads/#downloads">此处</a> 下载 Liberica JDK。
+game.crash.reason.too_old_java=当前游戏由于 Java 虚拟机版本过低，无法继续运行。\n你需要在“(全局/版本特定) 游戏设置 → 游戏 Java”中更换 Java %1$s 或更新版本的 Java 虚拟机，并重新启动游戏。如果没有下载安装，你可以点击 <a href="https://learn.microsoft.com/java/openjdk/download">此处</a> 下载 Microsoft JDK。
 game.crash.reason.unknown=原因未知，请点击日志按钮查看详细信息。
-game.crash.reason.unsatisfied_link_error=当前游戏因为缺少本地库，无法继续运行。\n这些本地库缺失：%1$s。\n如果你在全局（特定）游戏设置中修改了本地库路径选项，请你修改回预设模式。\n如果你正在使用预设模式，请检查游戏路径是否只包含英文大小写字母，数字，下划线，\n如果是，那么请检查是否是由于模组或者 HMCL 导致了本地库缺失的问题。如果你确定是 HMCL 引起的，建议你向我们反馈。\n<b>你可以尝试在控制在 控制面板 时钟和区域 区域 管理 更改系统区域设置 中将 当前系统区域设置选项卡修改为：中文（简体，中国），并且把 使用Unicode UTF-8提供全球语言支持 关闭；</b>\n<b>或将游戏路径中的所有 非英文字符的名称 修改为 英文字符（例如中文，空格等）</b>\n如果你确实需要自定义本地库路径，你需要保证其中包含缺失的本地库！ 
-game.crash.reason.failed_to_load_a_library=当前游戏因为加载本地库失败，无法继续运行。\n如果你在全局（特定）游戏设置中修改了本地库路径选项，请你修改回预设模式。\n如果已经在预设模式下，请检查本地库缺失是否是 Mod 引起的，或由 HMCL 引起的。如果你确定是 HMCL 引起的，建议你向我们反馈。\n<b>你可以尝试在控制在 控制面板 时钟和区域 区域 管理 更改系统区域设置 中将 当前系统区域设置选项卡修改为：中文（简体，中国），并且把 使用Unicode UTF-8提供全球语言支持 关闭；</b>\n<b>或将游戏路径中的所有 非英文字符的名称 修改为 英文字符（例如中文，空格等）</b>\n如果你确实需要自定义本地库路径，你需要保证其中包含缺失的本地库！ 
+game.crash.reason.unsatisfied_link_error=当前游戏由于缺少本地库，无法继续运行。\n这些本地库缺失：%1$s。\n如果你在“(全局/版本特定) 游戏设置 → 高级设置”中修改了本地库路径选项，请你修改回默认模式。\n如果你正在使用默认模式，请检查游戏目录路径是否只包含英文字母、数字和下划线，\n如果是，那么请检查是否为模组或 HMCL 导致了本地库缺失的问题。如果你确定是 HMCL 引起的，建议你向我们反馈。\n<b>对于 Windows 用户，你还可以尝试在“控制面板 → 时钟和区域 → 区域 → 管理 → 更改系统区域设置”中将“当前系统区域设置”修改为“中文(简体，中国大陆)”，并关闭“Beta 版：使用 Unicode UTF-8 提供全球语言支持”选项；</b>\n<b>或将游戏目录路径中的所有非英文字符的名称 (例如中文、空格等) 修改为英文字符。</b>\n如果你确实需要自定义本地库路径，你需要保证其中包含缺失的本地库！
 game.crash.title=游戏意外退出
-game.directory=游戏路径
+game.directory=游戏目录路径
 game.version=游戏版本
 
 help=帮助


### PR DESCRIPTION
Content of `game.crash.reason`

Removed `game.crash.reason.failed_to_load_a_library` and `game.crash.reason.fabric_reports_an_error_and_gives_a_solution` as they were not used.

`- 在全局（特定）游戏设置，高级设置中打开“使用 OpenGL 软渲染器”（开启此选项后帧数会显著降低，仅推荐在以调试为目的或应急时开启）。`

This is inconsistent with the actual situation, so it is removed.

*The diff view on GitHub looks weird, and I am not sure why.*

Others:
- #3343
- #3348
- #3349