### PR TITLE
Revert "Bump commons-compress to 1.27.1"

### DIFF
--- a/HMCLCore/build.gradle.kts
+++ b/HMCLCore/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     api("org.jenkins-ci:constant-pool-scanner:1.2")
     api("com.github.steveice10:opennbt:1.5")
     api("org.nanohttpd:nanohttpd:2.3.1")
-    api("org.apache.commons:commons-compress:1.27.1")
+    api("org.apache.commons:commons-compress:1.25.0")
     api("org.jsoup:jsoup:1.18.1")
     compileOnlyApi("org.jetbrains:annotations:24.1.0")
 


### PR DESCRIPTION
commons-compress 1.26.0 引入了 commons-codec、commons-io 和 commons-lang3 作为依赖项，使 HMCL 体积明显增加，但并没有明显的收益，所以暂时还原至 1.25.0。未来我可能考虑维护 commons-compress 的[一个更干净的 fork](https://github.com/Glavo/kala-compress)。