### PR TITLE
Bump JavaFX to 17.0.13

### DIFF
--- a/HMCL/src/main/resources/assets/openjfx-dependencies.json
+++ b/HMCL/src/main/resources/assets/openjfx-dependencies.json
@@ -30,25 +30,25 @@
       "module": "javafx.base",
       "groupId": "org.openjfx",
       "artifactId": "javafx-base",
-      "version": "19.0.2.1",
+      "version": "17.0.13",
       "classifier": "win",
-      "sha1": "f33d0776b2b027c2ea9267c184f9048ef94c4deb"
+      "sha1": "ae86377359860449040372d3693bccf046148513"
     },
     {
       "module": "javafx.graphics",
       "groupId": "org.openjfx",
       "artifactId": "javafx-graphics",
-      "version": "19.0.2.1",
+      "version": "17.0.13",
       "classifier": "win",
-      "sha1": "951ca77bd50ef4fd44f4b7fb1e38301088fde4e2"
+      "sha1": "bc0055a059b201d6c0be2293ccf72b6d2874fd1c"
     },
     {
       "module": "javafx.controls",
       "groupId": "org.openjfx",
       "artifactId": "javafx-controls",
-      "version": "19.0.2.1",
+      "version": "17.0.13",
       "classifier": "win",
-      "sha1": "78ac7de48d0aac48e7d5282efc81bab7f337b587"
+      "sha1": "bcd765dca36fa9e5fb4c997491a2d908947603f5"
     }
   ],
   "windows-arm64": [
@@ -82,25 +82,25 @@
       "module": "javafx.base",
       "groupId": "org.openjfx",
       "artifactId": "javafx-base",
-      "version": "19.0.2.1",
+      "version": "17.0.13",
       "classifier": "mac",
-      "sha1": "73e422d8426aaa23e8c712b9f4d9bebf70d3bfb9"
+      "sha1": "e1744403a6691aaa6b65a7e9b4ff9aad98831bb1"
     },
     {
       "module": "javafx.graphics",
       "groupId": "org.openjfx",
       "artifactId": "javafx-graphics",
-      "version": "19.0.2.1",
+      "version": "17.0.13",
       "classifier": "mac",
-      "sha1": "6ab6f3e23421fcfa04e692d9d26a8f55a830c114"
+      "sha1": "dbe733470094abee56560067d0fea3ad24991d2b"
     },
     {
       "module": "javafx.controls",
       "groupId": "org.openjfx",
       "artifactId": "javafx-controls",
-      "version": "19.0.2.1",
+      "version": "17.0.13",
       "classifier": "mac",
-      "sha1": "b7786b1b63e741c0e234829825fae5fef9d96c31"
+      "sha1": "0d43a776d6c9e2622e3581ed04501e2cadcd6e65"
     }
   ],
   "osx-arm64": [
@@ -108,25 +108,25 @@
       "module": "javafx.base",
       "groupId": "org.openjfx",
       "artifactId": "javafx-base",
-      "version": "19.0.2.1",
+      "version": "17.0.13",
       "classifier": "mac-aarch64",
-      "sha1": "1d0d887c492330ed527b0614d115a4f32d2d05a4"
+      "sha1": "d4dc7d2864c07b56a27e39fa5691856ddccf0ba4"
     },
     {
       "module": "javafx.graphics",
       "groupId": "org.openjfx",
       "artifactId": "javafx-graphics",
-      "version": "19.0.2.1",
+      "version": "17.0.13",
       "classifier": "mac-aarch64",
-      "sha1": "64db28799e61e0f8f51e471c732599b2a6961803"
+      "sha1": "d6a49f19e90db56c134757d1bbab4935de075d45"
     },
     {
       "module": "javafx.controls",
       "groupId": "org.openjfx",
       "artifactId": "javafx-controls",
-      "version": "19.0.2.1",
+      "version": "17.0.13",
       "classifier": "mac-aarch64",
-      "sha1": "3a14bd5f3ebe45d344c1f2bade0fe074e6ea2a83"
+      "sha1": "ad564497edc49f7a6135c3b52d360962e19a2539"
     }
   ],
   "linux-x86_64": [
@@ -134,25 +134,25 @@
       "module": "javafx.base",
       "groupId": "org.openjfx",
       "artifactId": "javafx-base",
-      "version": "19.0.2.1",
+      "version": "17.0.13",
       "classifier": "linux",
-      "sha1": "9e4ca5ce2b87c479d2cc445ff411a48aeae76936"
+      "sha1": "875f02b498b00c9692f6ed0af3da373b1d07bf03"
     },
     {
       "module": "javafx.graphics",
       "groupId": "org.openjfx",
       "artifactId": "javafx-graphics",
-      "version": "19.0.2.1",
+      "version": "17.0.13",
       "classifier": "linux",
-      "sha1": "27c64e4e1569ddf198f28eda84cf8d014ab80693"
+      "sha1": "103f3bba5a177ba8912a92ef2ee0855de7ba050c"
     },
     {
       "module": "javafx.controls",
       "groupId": "org.openjfx",
       "artifactId": "javafx-controls",
-      "version": "19.0.2.1",
+      "version": "17.0.13",
       "classifier": "linux",
-      "sha1": "b5b2a8ead40bd43476740aa51697bb1cac23de5c"
+      "sha1": "940e9e05a974a3e484d5ec241d88a0c77ad013f2"
     }
   ],
   "linux-arm32": [

--- a/javafx.gradle.kts
+++ b/javafx.gradle.kts
@@ -4,11 +4,12 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.google.code.gson:gson:2.10.1")
+        classpath("com.google.code.gson:gson:2.11.0")
     }
 }
 
-val jfxVersion = "19.0.2.1"
+val jfxVersion = "17.0.13"
+val oldJfxVersion = "19.0.2.1"
 
 data class Platform(
     val name: String,
@@ -29,14 +30,14 @@ val jfxModules = listOf("base", "graphics", "controls")
 val jfxMirrorRepos = listOf("https://mirrors.cloud.tencent.com/nexus/repository/maven-public")
 val jfxDependenciesFile = project.file("HMCL/src/main/resources/assets/openjfx-dependencies.json")
 val jfxPlatforms = listOf(
-    Platform("windows-x86", "win-x86"),
+    Platform("windows-x86", "win-x86", version = oldJfxVersion),
     Platform("windows-x86_64", "win"),
     Platform("windows-arm64", "win", groupId = "org.glavo.hmcl.openjfx", version = "18.0.2+1-arm64"),
     Platform("osx-x86_64", "mac"),
     Platform("osx-arm64", "mac-aarch64"),
     Platform("linux-x86_64", "linux"),
-    Platform("linux-arm32", "linux-arm32-monocle"),
-    Platform("linux-arm64", "linux-aarch64"),
+    Platform("linux-arm32", "linux-arm32-monocle", version = oldJfxVersion),
+    Platform("linux-arm64", "linux-aarch64", version = oldJfxVersion),
     Platform("linux-loongarch64", "linux", groupId = "org.glavo.hmcl.openjfx", version = "17.0.8-loongarch64"),
     Platform("linux-loongarch64_ow", "linux", groupId = "org.glavo.hmcl.openjfx", version = "19-ea+10-loongson64"),
     Platform("linux-riscv64", "linux", groupId = "org.glavo.hmcl.openjfx", version = "19.0.2.1-riscv64"),


### PR DESCRIPTION
在 Windows x86-64，Linux x86-64，macOS x86-64/arm64 平台将自动下载的 JavaFX 版本从 19.0.2.1 更新至 17.0.13。

此次更新带来了以下值得注意的优化和修复：

* JDK-8281327: JavaFX does not support fonts installed per-user on Windows 10/11
* JDK-8181084: JavaFX show big icons in system menu on macOS with Retina display
* JDK-8251240: Menus inaccessible on Linux with i3 wm


