### PR TITLE
Capitalize choose player dialog title text

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/CreateAccountPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/CreateAccountPane.java
@@ -65,6 +65,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -637,7 +638,7 @@ public class CreateAccountPane extends JFXDialogLayout implements DialogAware {
             StackPane.setAlignment(cancel, Pos.BOTTOM_RIGHT);
             cancel.setOnAction(e -> latch.countDown());
 
-            listBox.startCategory(i18n("account.choose"));
+            listBox.startCategory(i18n("account.choose").toUpperCase(Locale.ROOT));
 
             setCenter(listBox);
 


### PR DESCRIPTION
When you add an authlib-injector account (e.g. LittleSkin) to the HMCL, if the username is an email, and the account has multiple players, a dialog will appear for the user to choose a player. This PR forces the title text above this dialog to be uppercase to match the style elsewhere in the launcher.