### PR TITLE
优化 Java 下载功能

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/JavaPackageType.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/JavaPackageType.java
@@ -21,10 +21,10 @@ package org.jackhuang.hmcl.download.java;
  * @author Glavo
  */
 public enum JavaPackageType {
-    JDK(true, false),
     JRE(false, false),
-    JDKFX(true, true),
-    JREFX(false, true);
+    JDK(true, false),
+    JREFX(false, true),
+    JDKFX(true, true);
 
     private final boolean jdk;
     private final boolean javafx;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/disco/DiscoJavaDistribution.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/disco/DiscoJavaDistribution.java
@@ -43,7 +43,7 @@ public enum DiscoJavaDistribution implements JavaDistribution<DiscoJavaRemoteVer
             pair(WINDOWS, EnumSet.of(X86_64, X86, ARM64)),
             pair(LINUX, EnumSet.of(X86_64, X86, ARM64, ARM32, RISCV64, PPC64, PPC64LE, S390X, SPARCV9)),
             pair(OSX, EnumSet.of(X86_64, ARM64))),
-    LIBERICA("Liberica", "liberica", "BellSoft",
+    LIBERICA("BellSoft Liberica", "liberica", "BellSoft",
             EnumSet.of(JDK, JRE, JDKFX, JREFX),
             pair(WINDOWS, EnumSet.of(X86_64, X86, ARM64)),
             pair(LINUX, EnumSet.of(X86_64, X86, ARM64, ARM32, RISCV64, PPC64LE)),
@@ -57,12 +57,12 @@ public enum DiscoJavaDistribution implements JavaDistribution<DiscoJavaRemoteVer
             return !fileName.endsWith("-lite.tar.gz") && !fileName.endsWith("-lite.zip");
         }
     },
-    ZULU("Zulu", "zulu", "Azul",
+    ZULU("Azul Zulu", "zulu", "Azul",
             EnumSet.of(JDK, JRE, JDKFX, JREFX),
             pair(WINDOWS, EnumSet.of(X86_64, X86, ARM64)),
             pair(LINUX, EnumSet.of(X86_64, X86, ARM64, ARM32, RISCV64, PPC64LE)),
             pair(OSX, EnumSet.of(X86_64, ARM64))),
-    GRAALVM("GraalVM", "graalvm", "Oracle",
+    GRAALVM("Oracle GraalVM", "graalvm", "Oracle",
             EnumSet.of(JDK),
             pair(WINDOWS, EnumSet.of(X86_64)),
             pair(LINUX, EnumSet.of(X86_64, ARM64)),
@@ -71,6 +71,12 @@ public enum DiscoJavaDistribution implements JavaDistribution<DiscoJavaRemoteVer
             EnumSet.of(JDK, JRE),
             pair(WINDOWS, EnumSet.of(X86_64)),
             pair(LINUX, EnumSet.of(X86_64, ARM64, PPC64LE, S390X)),
+            pair(OSX, EnumSet.of(X86_64, ARM64))
+    ),
+    CORRETTO("Amazon Corretto", "corretto", "Amazon",
+            EnumSet.of(JDK),
+            pair(WINDOWS, EnumSet.of(X86_64)),
+            pair(LINUX, EnumSet.of(X86_64, ARM64)),
             pair(OSX, EnumSet.of(X86_64, ARM64))
     );
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/disco/DiscoJavaRemoteVersion.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/disco/DiscoJavaRemoteVersion.java
@@ -191,7 +191,7 @@ public final class DiscoJavaRemoteVersion implements JavaRemoteVersion {
         return packageType;
     }
 
-    public boolean isJavafxBundled() {
+    public boolean isJavaFXBundled() {
         return javafxBundled;
     }
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/java/JavaInfo.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/java/JavaInfo.java
@@ -126,6 +126,7 @@ public final class JavaInfo {
                 return "Azul";
             case "IBM Corporation":
             case "International Business Machines Corporation":
+            case "Eclipse OpenJ9":
                 return "IBM";
             case "Eclipse Adoptium":
                 return "Adoptium";


### PR DESCRIPTION
* 修复下载的 Java 有时不完全符合用户选中的选项的问题
* 优化 JDK 名称显示
* 添加 Amazon Corretto 下载项
* 对于提供 JRE 的 Java 发行版优先下载 JRE