### PR TITLE
清理对 setOnMouseClicked 的误用

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/CrashWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/CrashWindow.java
@@ -53,7 +53,7 @@ public class CrashWindow extends Stage {
 
         Button btnContact = new Button();
         btnContact.setText(i18n("launcher.contact"));
-        btnContact.setOnMouseClicked(event -> FXUtils.openLink(Metadata.CONTACT_URL));
+        btnContact.setOnAction(event -> FXUtils.openLink(Metadata.CONTACT_URL));
         HBox box = new HBox();
         box.setStyle("-fx-padding: 8px;");
         box.getChildren().add(btnContact);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/GameCrashWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/GameCrashWindow.java
@@ -417,10 +417,10 @@ public class GameCrashWindow extends Stage {
             HBox toolBar = new HBox();
             {
                 JFXButton exportGameCrashInfoButton = FXUtils.newRaisedButton(i18n("logwindow.export_game_crash_logs"));
-                exportGameCrashInfoButton.setOnMouseClicked(e -> exportGameCrashInfo());
+                exportGameCrashInfoButton.setOnAction(e -> exportGameCrashInfo());
 
                 JFXButton logButton = FXUtils.newRaisedButton(i18n("logwindow.title"));
-                logButton.setOnMouseClicked(e -> showLogWindow());
+                logButton.setOnAction(e -> showLogWindow());
 
                 JFXButton helpButton = FXUtils.newRaisedButton(i18n("help"));
                 helpButton.setOnAction(e -> FXUtils.openLink("https://docs.hmcl.net/help.html"));

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/ListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/ListPageSkin.java
@@ -70,7 +70,7 @@ public class ListPageSkin extends SkinBase<ListPage<?>> {
                 btnAdd.getStyleClass().add("jfx-button-raised-round");
                 btnAdd.setButtonType(JFXButton.ButtonType.RAISED);
                 btnAdd.setGraphic(SVG.PLUS.createIcon(Theme.whiteFill(), -1, -1));
-                btnAdd.setOnMouseClicked(e -> skinnable.add());
+                btnAdd.setOnAction(e -> skinnable.add());
 
                 JFXButton btnRefresh = new JFXButton();
                 FXUtils.setLimitWidth(btnRefresh, 40);
@@ -78,7 +78,7 @@ public class ListPageSkin extends SkinBase<ListPage<?>> {
                 btnRefresh.getStyleClass().add("jfx-button-raised-round");
                 btnRefresh.setButtonType(JFXButton.ButtonType.RAISED);
                 btnRefresh.setGraphic(SVG.REFRESH.createIcon(Theme.whiteFill(), -1, -1));
-                btnRefresh.setOnMouseClicked(e -> skinnable.refresh());
+                btnRefresh.setOnAction(e -> skinnable.refresh());
 
                 vBox.getChildren().setAll(btnAdd);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/ToolbarListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/ToolbarListPageSkin.java
@@ -91,7 +91,7 @@ public abstract class ToolbarListPageSkin<T extends ListPageBase<? extends Node>
         ret.textFillProperty().bind(Theme.foregroundFillBinding());
         ret.setGraphic(wrap(svg.createIcon(Theme.foregroundFillBinding(), -1, -1)));
         ret.setText(text);
-        ret.setOnMouseClicked(e -> onClick.run());
+        ret.setOnAction(e -> onClick.run());
         return ret;
     }
 
@@ -100,7 +100,7 @@ public abstract class ToolbarListPageSkin<T extends ListPageBase<? extends Node>
         ret.getStyleClass().add("jfx-tool-bar-button");
         ret.setGraphic(wrap(svg.createIcon(Theme.blackFill(), -1, -1)));
         ret.setText(text);
-        ret.setOnMouseClicked(e -> onClick.run());
+        ret.setOnAction(e -> onClick.run());
         return ret;
     }
 
@@ -110,7 +110,7 @@ public abstract class ToolbarListPageSkin<T extends ListPageBase<? extends Node>
         ret.textFillProperty().bind(Theme.foregroundFillBinding());
         ret.setGraphic(wrap(svg.createIcon(Theme.foregroundFillBinding(), -1, -1)));
         FXUtils.installFastTooltip(ret, tooltip);
-        ret.setOnMouseClicked(e -> onClick.run());
+        ret.setOnAction(e -> onClick.run());
         return ret;
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
@@ -94,7 +94,7 @@ public class AccountListItemSkin extends SkinBase<AccountListItem> {
         JFXButton btnMove = new JFXButton();
         SpinnerPane spinnerMove = new SpinnerPane();
         spinnerMove.getStyleClass().add("small-spinner-pane");
-        btnMove.setOnMouseClicked(e -> {
+        btnMove.setOnAction(e -> {
             Account account = skinnable.getAccount();
             Accounts.getAccounts().remove(account);
             if (account.isPortable()) {
@@ -129,7 +129,7 @@ public class AccountListItemSkin extends SkinBase<AccountListItem> {
         JFXButton btnRefresh = new JFXButton();
         SpinnerPane spinnerRefresh = new SpinnerPane();
         spinnerRefresh.getStyleClass().setAll("small-spinner-pane");
-        btnRefresh.setOnMouseClicked(e -> {
+        btnRefresh.setOnAction(e -> {
             spinnerRefresh.showSpinner();
             skinnable.refreshAsync()
                     .whenComplete(Schedulers.javafx(), ex -> {
@@ -149,7 +149,7 @@ public class AccountListItemSkin extends SkinBase<AccountListItem> {
 
         JFXButton btnUpload = new JFXButton();
         SpinnerPane spinnerUpload = new SpinnerPane();
-        btnUpload.setOnMouseClicked(e -> {
+        btnUpload.setOnAction(e -> {
             Task<?> uploadTask = skinnable.uploadSkin();
             if (uploadTask != null) {
                 spinnerUpload.showSpinner();
@@ -170,14 +170,14 @@ public class AccountListItemSkin extends SkinBase<AccountListItem> {
         JFXButton btnCopyUUID = new JFXButton();
         SpinnerPane spinnerCopyUUID = new SpinnerPane();
         spinnerCopyUUID.getStyleClass().add("small-spinner-pane");
-        btnCopyUUID.setOnMouseClicked(e -> FXUtils.copyText(skinnable.getAccount().getUUID().toString()));
+        btnCopyUUID.setOnAction(e -> FXUtils.copyText(skinnable.getAccount().getUUID().toString()));
         btnCopyUUID.setGraphic(SVG.COPY.createIcon(Theme.blackFill(), -1, -1));
         runInFX(() -> FXUtils.installFastTooltip(btnCopyUUID, i18n("account.copy_uuid")));
         spinnerCopyUUID.setContent(btnCopyUUID);
         right.getChildren().add(spinnerCopyUUID);
 
         JFXButton btnRemove = new JFXButton();
-        btnRemove.setOnMouseClicked(e -> Controllers.confirm(i18n("button.remove.confirm"), i18n("button.remove"), skinnable::remove, null));
+        btnRemove.setOnAction(e -> Controllers.confirm(i18n("button.remove.confirm"), i18n("button.remove"), skinnable::remove, null));
         btnRemove.getStyleClass().add("toggle-icon4");
         BorderPane.setAlignment(btnRemove, Pos.CENTER);
         btnRemove.setGraphic(SVG.DELETE.createIcon(Theme.blackFill(), -1, -1));

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/FileItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/FileItem.java
@@ -60,7 +60,7 @@ public class FileItem extends BorderPane {
         JFXButton right = new JFXButton();
         right.setGraphic(SVG.PENCIL.createIcon(Theme.blackFill(), 15, 15));
         right.getStyleClass().add("toggle-icon4");
-        right.setOnMouseClicked(e -> onExplore());
+        right.setOnAction(e -> onExplore());
         FXUtils.installFastTooltip(right, i18n("button.edit"));
         setRight(right);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java
@@ -222,7 +222,7 @@ public class InstallersPage extends Control implements WizardPage {
                 installButton.disableProperty().bind(control.installable.not());
                 installButton.setPrefWidth(100);
                 installButton.setPrefHeight(40);
-                installButton.setOnMouseClicked(e -> control.onInstall());
+                installButton.setOnAction(e -> control.onInstall());
                 BorderPane.setAlignment(installButton, Pos.CENTER_RIGHT);
                 root.setBottom(installButton);
             }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ModpackInfoPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ModpackInfoPage.java
@@ -178,9 +178,7 @@ public final class ModpackInfoPage extends Control implements WizardPage {
 
                 if (skinnable.controller.getSettings().get(MODPACK_TYPE) == MODPACK_TYPE_SERVER) {
                     Hyperlink hyperlink = new Hyperlink(i18n("modpack.wizard.step.initialization.server"));
-                    hyperlink.setOnMouseClicked(e -> {
-                        FXUtils.openLink("https://docs.hmcl.net/modpack/serverpack.html");
-                    });
+                    hyperlink.setOnAction(e -> FXUtils.openLink("https://docs.hmcl.net/modpack/serverpack.html"));
                     borderPane.setTop(hyperlink);
                 } else {
                     HintPane pane = new HintPane(MessageDialogPane.MessageType.INFO);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/MainPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/MainPage.java
@@ -144,7 +144,7 @@ public final class MainPage extends StackPane implements DecoratorPage {
             StackPane.setAlignment(closeUpdateButton, Pos.TOP_RIGHT);
             closeUpdateButton.getStyleClass().add("toggle-icon-tiny");
             StackPane.setMargin(closeUpdateButton, new Insets(5));
-            closeUpdateButton.setOnMouseClicked(e -> closeUpdateBubble());
+            closeUpdateButton.setOnAction(e -> closeUpdateBubble());
 
             updatePane.getChildren().setAll(hBox, closeUpdateButton);
         }
@@ -206,7 +206,7 @@ public final class MainPage extends StackPane implements DecoratorPage {
             menuButton.setPrefWidth(230);
             //menuButton.setButtonType(JFXButton.ButtonType.RAISED);
             menuButton.setStyle("-fx-font-size: 15px;");
-            menuButton.setOnMouseClicked(e -> onMenu());
+            menuButton.setOnAction(e -> onMenu());
             menuButton.setClip(new Rectangle(211, -100, 100, 200));
             StackPane graphic = new StackPane();
             Node svg = SVG.TRIANGLE.createIcon(Theme.foregroundFillBinding(), 10, 10);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/SettingsView.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/SettingsView.java
@@ -121,7 +121,7 @@ public abstract class SettingsView extends StackPane {
 
                     {
                         btnUpdate = new JFXButton();
-                        btnUpdate.setOnMouseClicked(e -> onUpdate());
+                        btnUpdate.setOnAction(e -> onUpdate());
                         btnUpdate.getStyleClass().add("toggle-icon4");
                         btnUpdate.setGraphic(SVG.UPDATE.createIcon(Theme.blackFill(), 20, 20));
 
@@ -161,7 +161,7 @@ public abstract class SettingsView extends StackPane {
 
                     {
                         JFXButton cleanButton = new JFXButton(i18n("launcher.cache_directory.clean"));
-                        cleanButton.setOnMouseClicked(e -> clearCacheDirectory());
+                        cleanButton.setOnAction(e -> clearCacheDirectory());
                         cleanButton.getStyleClass().add("jfx-button-border");
 
                         fileCommonLocationSublist.setHeaderRight(cleanButton);
@@ -193,11 +193,11 @@ public abstract class SettingsView extends StackPane {
                     debugPane.setLeft(left);
 
                     JFXButton openLogFolderButton = new JFXButton(i18n("settings.launcher.launcher_log.reveal"));
-                    openLogFolderButton.setOnMouseClicked(e -> openLogFolder());
+                    openLogFolderButton.setOnAction(e -> openLogFolder());
                     openLogFolderButton.getStyleClass().add("jfx-button-border");
 
                     JFXButton logButton = new JFXButton(i18n("settings.launcher.launcher_log.export"));
-                    logButton.setOnMouseClicked(e -> onExportLogs());
+                    logButton.setOnAction(e -> onExportLogs());
                     logButton.getStyleClass().add("jfx-button-border");
 
                     HBox buttonBox = new HBox();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/profile/ProfileListItemSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/profile/ProfileListItemSkin.java
@@ -64,7 +64,7 @@ public class ProfileListItemSkin extends SkinBase<ProfileListItem> {
         right.setAlignment(Pos.CENTER_RIGHT);
 
         JFXButton btnRemove = new JFXButton();
-        btnRemove.setOnMouseClicked(e -> skinnable.remove());
+        btnRemove.setOnAction(e -> skinnable.remove());
         btnRemove.getStyleClass().add("toggle-icon4");
         BorderPane.setAlignment(btnRemove, Pos.CENTER);
         btnRemove.setGraphic(SVG.CLOSE.createIcon(Theme.blackFill(), 14, 14));

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/GameListItemSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/GameListItemSkin.java
@@ -79,7 +79,7 @@ public class GameListItemSkin extends SkinBase<GameListItem> {
         right.setAlignment(Pos.CENTER_RIGHT);
         if (skinnable.canUpdate()) {
             JFXButton btnUpgrade = new JFXButton();
-            btnUpgrade.setOnMouseClicked(e -> skinnable.update());
+            btnUpgrade.setOnAction(e -> skinnable.update());
             btnUpgrade.getStyleClass().add("toggle-icon4");
             btnUpgrade.setGraphic(FXUtils.limitingSize(SVG.UPDATE.createIcon(Theme.blackFill(), 24, 24), 24, 24));
             runInFX(() -> FXUtils.installFastTooltip(btnUpgrade, i18n("version.update")));
@@ -88,7 +88,7 @@ public class GameListItemSkin extends SkinBase<GameListItem> {
 
         {
             JFXButton btnLaunch = new JFXButton();
-            btnLaunch.setOnMouseClicked(e -> skinnable.launch());
+            btnLaunch.setOnAction(e -> skinnable.launch());
             btnLaunch.getStyleClass().add("toggle-icon4");
             BorderPane.setAlignment(btnLaunch, Pos.CENTER);
             btnLaunch.setGraphic(FXUtils.limitingSize(SVG.ROCKET_LAUNCH_OUTLINE.createIcon(Theme.blackFill(), 24, 24), 24, 24));
@@ -98,7 +98,7 @@ public class GameListItemSkin extends SkinBase<GameListItem> {
 
         {
             JFXButton btnManage = new JFXButton();
-            btnManage.setOnMouseClicked(e -> {
+            btnManage.setOnAction(e -> {
                 currentSkinnable = skinnable;
                 popup.get().show(root, JFXPopup.PopupVPosition.TOP, JFXPopup.PopupHPosition.RIGHT, 0, root.getHeight());
             });

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
@@ -539,7 +539,7 @@ class ModListPageSkin extends SkinBase<ModListPage> {
             }
             checkBox.selectedProperty().bindBidirectional(booleanProperty = dataItem.active);
             restoreButton.setVisible(!dataItem.getModInfo().getMod().getOldFiles().isEmpty());
-            restoreButton.setOnMouseClicked(e -> {
+            restoreButton.setOnAction(e -> {
                 menu.get().getContent().setAll(dataItem.getModInfo().getMod().getOldFiles().stream()
                         .map(localModFile -> new IconedMenuItem(null, localModFile.getVersion(),
                                 () -> getSkinnable().rollback(dataItem.getModInfo(), localModFile),
@@ -549,12 +549,8 @@ class ModListPageSkin extends SkinBase<ModListPage> {
 
                 popup.get().show(restoreButton, JFXPopup.PopupVPosition.TOP, JFXPopup.PopupHPosition.RIGHT, 0, restoreButton.getHeight());
             });
-            revealButton.setOnMouseClicked(e -> {
-                FXUtils.showFileInExplorer(dataItem.getModInfo().getFile());
-            });
-            infoButton.setOnMouseClicked(e -> {
-                Controllers.dialog(new ModInfoDialog(dataItem));
-            });
+            revealButton.setOnAction(e -> FXUtils.showFileInExplorer(dataItem.getModInfo().getFile()));
+            infoButton.setOnAction(e -> Controllers.dialog(new ModInfoDialog(dataItem)));
         }
     }
 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/WorldExportPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/WorldExportPageSkin.java
@@ -83,7 +83,7 @@ public class WorldExportPageSkin extends SkinBase<WorldExportPage> {
         JFXButton btnExport = FXUtils.newRaisedButton(i18n("button.export"));
         btnExport.disableProperty().bind(Bindings.createBooleanBinding(() -> txtWorldName.getText().isEmpty() || Files.exists(Paths.get(fileItem.getPath())),
                 txtWorldName.textProperty().isEmpty(), fileItem.pathProperty()));
-        btnExport.setOnMouseClicked(e -> skinnable.export());
+        btnExport.setOnAction(e -> skinnable.export());
         HBox bottom = new HBox();
         bottom.setAlignment(Pos.CENTER_RIGHT);
         bottom.getChildren().setAll(btnExport);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/WorldListItemSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/WorldListItemSkin.java
@@ -76,9 +76,7 @@ public class WorldListItemSkin extends SkinBase<WorldListItem> {
         right.setAlignment(Pos.CENTER_RIGHT);
 
         JFXButton btnManage = new JFXButton();
-        btnManage.setOnMouseClicked(e -> {
-            popup.show(root, JFXPopup.PopupVPosition.TOP, JFXPopup.PopupHPosition.RIGHT, 0, root.getHeight());
-        });
+        btnManage.setOnAction(e -> popup.show(root, JFXPopup.PopupVPosition.TOP, JFXPopup.PopupHPosition.RIGHT, 0, root.getHeight()));
         btnManage.getStyleClass().add("toggle-icon4");
         BorderPane.setAlignment(btnManage, Pos.CENTER);
         btnManage.setGraphic(SVG.DOTS_VERTICAL.createIcon(Theme.blackFill(), -1, -1));


### PR DESCRIPTION
目前代码中存在大量对 `setOnMouseClicked ` 的误用，这导致一些按钮不响应键盘，或者响应非鼠标左键的点击。本 PR 清理了其中一部分代码。