### PR TITLE
修复部分控件响应任意鼠标按键点击事件的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
@@ -957,6 +957,15 @@ public final class FXUtils {
         });
     }
 
+    public static void onClicked(Node node, Runnable action) {
+        node.addEventHandler(MouseEvent.MOUSE_CLICKED, e -> {
+            if (e.getButton() == MouseButton.PRIMARY && e.getClickCount() == 1) {
+                action.run();
+                e.consume();
+            }
+        });
+    }
+
     public static void copyText(String text) {
         ClipboardContent content = new ClipboardContent();
         content.putString(text);
@@ -987,7 +996,7 @@ public final class FXUtils {
                     if ("a".equals(element.getTagName())) {
                         String href = element.getAttribute("href");
                         Text text = new Text(element.getTextContent());
-                        text.setOnMouseClicked(e -> {
+                        onClicked(text, () -> {
                             String link = href;
                             try {
                                 link = new URI(href).toASCIIString();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/HTMLRenderer.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/HTMLRenderer.java
@@ -123,7 +123,7 @@ public final class HTMLRenderer {
         if (hyperlink != null) {
             URI target = resolveLink(hyperlink);
             if (target != null) {
-                text.setOnMouseClicked(event -> onClickHyperlink.accept(target));
+                FXUtils.onClicked(text, () -> onClickHyperlink.accept(target));
                 text.setCursor(Cursor.HAND);
             }
             text.getStyleClass().add("html-hyperlink");
@@ -192,7 +192,7 @@ public final class HTMLRenderer {
                 if (hyperlink != null) {
                     URI target = resolveLink(hyperlink);
                     if (target != null) {
-                        imageView.setOnMouseClicked(event -> onClickHyperlink.accept(target));
+                        FXUtils.onClicked(imageView, () -> onClickHyperlink.accept(target));
                         imageView.setCursor(Cursor.HAND);
                     }
                 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
@@ -23,7 +23,6 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.css.PseudoClass;
-import javafx.event.EventHandler;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Cursor;
@@ -33,7 +32,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.Skin;
 import javafx.scene.control.SkinBase;
 import javafx.scene.image.ImageView;
-import javafx.scene.input.MouseEvent;
+import javafx.scene.input.MouseButton;
 import javafx.scene.layout.*;
 import org.jackhuang.hmcl.download.LibraryAnalyzer;
 import org.jackhuang.hmcl.setting.Theme;
@@ -60,8 +59,8 @@ public class InstallerItem extends Control {
     private final ObjectProperty<InstalledState> versionProperty = new SimpleObjectProperty<>(this, "version", null);
     private final ObjectProperty<State> resolvedStateProperty = new SimpleObjectProperty<>(this, "resolvedState", InstallableState.INSTANCE);
 
-    private final ObjectProperty<EventHandler<? super MouseEvent>> installActionProperty = new SimpleObjectProperty<>(this, "installAction");
-    private final ObjectProperty<EventHandler<? super MouseEvent>> removeActionProperty = new SimpleObjectProperty<>(this, "removeAction");
+    private final ObjectProperty<Runnable> onInstall = new SimpleObjectProperty<>(this, "installAction");
+    private final ObjectProperty<Runnable> onRemove = new SimpleObjectProperty<>(this, "removeAction");
 
     public interface State {
     }
@@ -170,12 +169,28 @@ public class InstallerItem extends Control {
         return resolvedStateProperty;
     }
 
-    public ObjectProperty<EventHandler<? super MouseEvent>> installActionProperty() {
-        return installActionProperty;
+    public ObjectProperty<Runnable> onInstallProperty() {
+        return onInstall;
     }
 
-    public ObjectProperty<EventHandler<? super MouseEvent>> removeActionProperty() {
-        return removeActionProperty;
+    public Runnable getOnInstall() {
+        return onInstall.get();
+    }
+
+    public void setOnInstall(Runnable onInstall) {
+        this.onInstall.set(onInstall);
+    }
+
+    public ObjectProperty<Runnable> onRemoveProperty() {
+        return onRemove;
+    }
+
+    public Runnable getOnRemove() {
+        return onRemove.get();
+    }
+
+    public void setOnRemove(Runnable onRemove) {
+        this.onRemove.set(onRemove);
     }
 
     @Override
@@ -371,7 +386,11 @@ public class InstallerItem extends Control {
                 removeButton.visibleProperty().bind(Bindings.createBooleanBinding(() -> control.resolvedStateProperty.get() instanceof InstalledState, control.resolvedStateProperty));
             }
             removeButton.managedProperty().bind(removeButton.visibleProperty());
-            removeButton.onMouseClickedProperty().bind(control.removeActionProperty);
+            removeButton.setOnAction(e -> {
+                Runnable onRemove = control.getOnRemove();
+                if (onRemove != null)
+                    onRemove.run();
+            });
             buttonsContainer.getChildren().add(removeButton);
 
             JFXButton installButton = new JFXButton();
@@ -383,7 +402,7 @@ public class InstallerItem extends Control {
             ));
             installButton.getStyleClass().add("toggle-icon4");
             installButton.visibleProperty().bind(Bindings.createBooleanBinding(() -> {
-                if (control.installActionProperty.get() == null) {
+                if (control.onInstall.get() == null) {
                     return false;
                 }
 
@@ -396,18 +415,28 @@ public class InstallerItem extends Control {
                 }
 
                 return false;
-            }, control.resolvedStateProperty, control.installActionProperty));
+            }, control.resolvedStateProperty, control.onInstall));
             installButton.managedProperty().bind(installButton.visibleProperty());
-            installButton.onMouseClickedProperty().bind(control.installActionProperty);
+            installButton.setOnAction(e -> {
+                Runnable onInstall = control.getOnInstall();
+                if (onInstall != null)
+                    onInstall.run();
+            });
             buttonsContainer.getChildren().add(installButton);
 
             FXUtils.onChangeAndOperate(installButton.visibleProperty(), clickable -> {
                 if (clickable) {
-                    container.onMouseClickedProperty().bind(control.installActionProperty);
+                    container.setOnMouseClicked(event -> {
+                        Runnable onInstall = control.getOnInstall();
+                        if (onInstall != null && event.getButton() == MouseButton.PRIMARY && event.getClickCount() == 1) {
+                            onInstall.run();
+                            event.consume();
+                        }
+                    });
                     pane.setCursor(Cursor.HAND);
                 } else {
                     container.onMouseClickedProperty().unbind();
-                    container.onMouseClickedProperty().set(null);
+                    container.setOnMouseClicked(null);
                     pane.setCursor(Cursor.DEFAULT);
                 }
             });

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
@@ -402,7 +402,7 @@ public class InstallerItem extends Control {
             ));
             installButton.getStyleClass().add("toggle-icon4");
             installButton.visibleProperty().bind(Bindings.createBooleanBinding(() -> {
-                if (control.onInstall.get() == null) {
+                if (control.getOnInstall() == null) {
                     return false;
                 }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
@@ -435,7 +435,6 @@ public class InstallerItem extends Control {
                     });
                     pane.setCursor(Cursor.HAND);
                 } else {
-                    container.onMouseClickedProperty().unbind();
                     container.setOnMouseClicked(null);
                     pane.setCursor(Cursor.DEFAULT);
                 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
@@ -59,8 +59,8 @@ public class InstallerItem extends Control {
     private final ObjectProperty<InstalledState> versionProperty = new SimpleObjectProperty<>(this, "version", null);
     private final ObjectProperty<State> resolvedStateProperty = new SimpleObjectProperty<>(this, "resolvedState", InstallableState.INSTANCE);
 
-    private final ObjectProperty<Runnable> onInstall = new SimpleObjectProperty<>(this, "installAction");
-    private final ObjectProperty<Runnable> onRemove = new SimpleObjectProperty<>(this, "removeAction");
+    private final ObjectProperty<Runnable> onInstall = new SimpleObjectProperty<>(this, "onInstall");
+    private final ObjectProperty<Runnable> onRemove = new SimpleObjectProperty<>(this, "onRemove");
 
     public interface State {
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/LogWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/LogWindow.java
@@ -34,6 +34,7 @@ import javafx.scene.Scene;
 import javafx.scene.control.Label;
 import javafx.scene.control.*;
 import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseButton;
 import javafx.scene.layout.*;
 import javafx.stage.Stage;
 import org.jackhuang.hmcl.game.GameDumpGenerator;
@@ -322,6 +323,9 @@ public final class LogWindow extends Stage {
                         setGraphic(null);
 
                         setOnMouseClicked(event -> {
+                            if (event.getButton() != MouseButton.PRIMARY)
+                                return;
+
                             if (!event.isControlDown()) {
                                 for (ListCell<Log> logListCell : selected) {
                                     if (logListCell != this) {
@@ -340,6 +344,8 @@ public final class LogWindow extends Stage {
                             if (getItem() != null) {
                                 getItem().setSelected(true);
                             }
+
+                            event.consume();
                         });
                     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/CreateAccountPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/CreateAccountPane.java
@@ -297,7 +297,7 @@ public class CreateAccountPane extends JFXDialogLayout implements DialogAware {
                         hintPane.setSegment(i18n("account.methods.microsoft.hint"));
                     }
                 });
-                hintPane.setOnMouseClicked(e -> {
+                FXUtils.onClicked(hintPane, () -> {
                     if (deviceCode.get() != null) {
                         FXUtils.copyText(deviceCode.get().getUserCode());
                     }
@@ -658,7 +658,7 @@ public class CreateAccountPane extends JFXDialogLayout implements DialogAware {
                     TexturesLoader.bindAvatar(portraitCanvas, service, profile.getId());
 
                     IconedItem accountItem = new IconedItem(portraitCanvas, profile.getName());
-                    accountItem.setOnMouseClicked(e -> {
+                    FXUtils.onClicked(accountItem, () -> {
                         selectedProfile = profile;
                         latch.countDown();
                     });

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OAuthAccountLoginDialog.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OAuthAccountLoginDialog.java
@@ -58,7 +58,7 @@ public class OAuthAccountLoginDialog extends DialogPane {
                 );
             }
         });
-        hintPane.setOnMouseClicked(e -> {
+        FXUtils.onClicked(hintPane, () -> {
             if (deviceCode.get() != null) {
                 FXUtils.copyText(deviceCode.get().getUserCode());
             }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/AdvancedListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/AdvancedListItem.java
@@ -25,7 +25,6 @@ import javafx.scene.control.Control;
 import javafx.scene.control.Skin;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
 import org.jackhuang.hmcl.ui.FXUtils;
 import org.jackhuang.hmcl.util.Pair;
@@ -42,7 +41,7 @@ public class AdvancedListItem extends Control {
 
     public AdvancedListItem() {
         getStyleClass().add("advanced-list-item");
-        addEventHandler(MouseEvent.MOUSE_CLICKED, e -> fireEvent(new ActionEvent()));
+        FXUtils.onClicked(this, () -> fireEvent(new ActionEvent()));
     }
 
     public Node getLeftGraphic() {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/ComponentListCell.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/ComponentListCell.java
@@ -25,9 +25,6 @@ import javafx.animation.Timeline;
 import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
-import javafx.event.ActionEvent;
-import javafx.event.Event;
-import javafx.event.EventHandler;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
@@ -139,7 +136,7 @@ final class ComponentListCell extends StackPane {
             container.getChildren().setAll(content);
             groupNode.getChildren().add(container);
 
-            EventHandler<Event> onExpand = e -> {
+            Runnable onExpand = () -> {
                 if (expandAnimation != null && expandAnimation.getStatus() == Animation.Status.RUNNING) {
                     expandAnimation.stop();
                 }
@@ -182,8 +179,8 @@ final class ComponentListCell extends StackPane {
                 });
             };
 
-            headerRippler.setOnMouseClicked(onExpand);
-            expandButton.setOnAction((EventHandler<ActionEvent>) (Object) onExpand);
+            FXUtils.onClicked(headerRippler, onExpand);
+            expandButton.setOnAction(e -> onExpand.run());
 
             expandedProperty().addListener((a, b, newValue) -> expandIcon.setRotate(newValue ? 180 : 0));
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/FontComboBox.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/FontComboBox.java
@@ -21,6 +21,7 @@ import static javafx.collections.FXCollections.emptyObservableList;
 import static javafx.collections.FXCollections.observableList;
 import static javafx.collections.FXCollections.singletonObservableList;
 
+import org.jackhuang.hmcl.ui.FXUtils;
 import org.jackhuang.hmcl.util.javafx.BindingMapping;
 
 import com.jfoenix.controls.JFXComboBox;
@@ -51,7 +52,7 @@ public class FontComboBox extends JFXComboBox<String> {
         itemsProperty().bind(BindingMapping.of(valueProperty())
                         .map(value -> value == null ? emptyObservableList() : singletonObservableList(value)));
 
-        setOnMouseClicked(e -> {
+        FXUtils.onClicked(this, () -> {
             if (loaded)
                 return;
             itemsProperty().unbind();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/IconedMenuItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/IconedMenuItem.java
@@ -30,9 +30,9 @@ public class IconedMenuItem extends IconedItem {
         getStyleClass().setAll("iconed-menu-item");
 
         if (popup == null) {
-            setOnMouseClicked(e -> action.run());
+            FXUtils.onClicked(this, action);
         } else {
-            setOnMouseClicked(e -> {
+            FXUtils.onClicked(this, () -> {
                 action.run();
                 popup.hide();
             });

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/ImagePickerItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/ImagePickerItem.java
@@ -23,12 +23,12 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
@@ -44,8 +44,8 @@ public final class ImagePickerItem extends BorderPane {
     private final ImageView imageView;
 
     private final StringProperty title = new SimpleStringProperty(this, "title");
-    private final ObjectProperty<EventHandler<? super MouseEvent>> onSelectButtonClicked = new SimpleObjectProperty<>(this, "onSelectButtonClicked");
-    private final ObjectProperty<EventHandler<? super MouseEvent>> onDeleteButtonClicked = new SimpleObjectProperty<>(this, "onDeleteButtonClicked");
+    private final ObjectProperty<EventHandler<ActionEvent>> onSelectButtonClicked = new SimpleObjectProperty<>(this, "onSelectButtonClicked");
+    private final ObjectProperty<EventHandler<ActionEvent>> onDeleteButtonClicked = new SimpleObjectProperty<>(this, "onDeleteButtonClicked");
     private final ObjectProperty<Image> image = new SimpleObjectProperty<>(this, "image");
 
     public ImagePickerItem() {
@@ -55,12 +55,12 @@ public final class ImagePickerItem extends BorderPane {
 
         JFXButton selectButton = new JFXButton();
         selectButton.setGraphic(SVG.PENCIL.createIcon(Theme.blackFill(), 20, 20));
-        selectButton.onMouseClickedProperty().bind(onSelectButtonClicked);
+        selectButton.onActionProperty().bind(onSelectButtonClicked);
         selectButton.getStyleClass().add("toggle-icon4");
 
         JFXButton deleteButton = new JFXButton();
         deleteButton.setGraphic(SVG.CLOSE.createIcon(Theme.blackFill(), 20, 20));
-        deleteButton.onMouseClickedProperty().bind(onDeleteButtonClicked);
+        deleteButton.onActionProperty().bind(onDeleteButtonClicked);
         deleteButton.getStyleClass().add("toggle-icon4");
 
         FXUtils.installFastTooltip(selectButton, i18n("button.edit"));
@@ -93,27 +93,27 @@ public final class ImagePickerItem extends BorderPane {
         this.title.set(title);
     }
 
-    public EventHandler<? super MouseEvent> getOnSelectButtonClicked() {
+    public EventHandler<ActionEvent> getOnSelectButtonClicked() {
         return onSelectButtonClicked.get();
     }
 
-    public ObjectProperty<EventHandler<? super MouseEvent>> onSelectButtonClickedProperty() {
+    public ObjectProperty<EventHandler<ActionEvent>> onSelectButtonClickedProperty() {
         return onSelectButtonClicked;
     }
 
-    public void setOnSelectButtonClicked(EventHandler<? super MouseEvent> onSelectButtonClicked) {
+    public void setOnSelectButtonClicked(EventHandler<ActionEvent> onSelectButtonClicked) {
         this.onSelectButtonClicked.set(onSelectButtonClicked);
     }
 
-    public EventHandler<? super MouseEvent> getOnDeleteButtonClicked() {
+    public EventHandler<ActionEvent> getOnDeleteButtonClicked() {
         return onDeleteButtonClicked.get();
     }
 
-    public ObjectProperty<EventHandler<? super MouseEvent>> onDeleteButtonClickedProperty() {
+    public ObjectProperty<EventHandler<ActionEvent>> onDeleteButtonClickedProperty() {
         return onDeleteButtonClicked;
     }
 
-    public void setOnDeleteButtonClicked(EventHandler<? super MouseEvent> onDeleteButtonClicked) {
+    public void setOnDeleteButtonClicked(EventHandler<ActionEvent> onDeleteButtonClicked) {
         this.onDeleteButtonClicked.set(onDeleteButtonClicked);
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/OptionToggleButton.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/OptionToggleButton.java
@@ -61,9 +61,7 @@ public class OptionToggleButton extends StackPane {
         toggleButton.setSize(8);
         FXUtils.setLimitHeight(toggleButton, 30);
 
-        container.setOnMouseClicked(e -> {
-            toggleButton.setSelected(!toggleButton.isSelected());
-        });
+        FXUtils.onClicked(container, () -> toggleButton.setSelected(!toggleButton.isSelected()));
 
         FXUtils.onChangeAndOperate(subtitleProperty(), subtitle -> {
             if (StringUtils.isNotBlank(subtitle)) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/SpinnerPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/SpinnerPane.java
@@ -28,8 +28,6 @@ import javafx.scene.Node;
 import javafx.scene.control.Control;
 import javafx.scene.control.Label;
 import javafx.scene.control.SkinBase;
-import javafx.scene.input.MouseButton;
-import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
 import org.jackhuang.hmcl.ui.FXUtils;
 import org.jackhuang.hmcl.ui.animation.ContainerAnimations;
@@ -110,11 +108,11 @@ public class SpinnerPane extends Control {
     };
 
     @Override
-    protected Skin createDefaultSkin() {
+    protected SkinBase<SpinnerPane> createDefaultSkin() {
         return new Skin(this);
     }
 
-    private static class Skin extends SkinBase<SpinnerPane> {
+    private static final class Skin extends SkinBase<SpinnerPane> {
         private final JFXSpinner spinner = new JFXSpinner();
         private final StackPane contentPane = new StackPane();
         private final StackPane topPane = new StackPane();
@@ -131,12 +129,10 @@ public class SpinnerPane extends Control {
             topPane.getStyleClass().add("notice-pane");
             failedPane.getStyleClass().add("notice-pane");
             failedPane.getChildren().setAll(failedReasonLabel);
-            failedPane.addEventHandler(MouseEvent.MOUSE_CLICKED, event -> {
+            FXUtils.onClicked(failedPane, () -> {
                 EventHandler<Event> action = control.getOnFailedAction();
-                if (event.getButton() == MouseButton.PRIMARY && event.getClickCount() == 1 && action != null) {
+                if (action != null)
                     action.handle(new Event(FAILED_ACTION));
-                    event.consume();
-                }
             });
 
             FXUtils.onChangeAndOperate(getSkinnable().content, newValue -> {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/SpinnerPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/SpinnerPane.java
@@ -122,7 +122,7 @@ public class SpinnerPane extends Control {
         @SuppressWarnings("FieldCanBeLocal") // prevent from gc.
         private final InvalidationListener observer;
 
-        protected Skin(SpinnerPane control) {
+        Skin(SpinnerPane control) {
             super(control);
 
             topPane.getChildren().setAll(spinner);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/SpinnerPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/SpinnerPane.java
@@ -28,11 +28,12 @@ import javafx.scene.Node;
 import javafx.scene.control.Control;
 import javafx.scene.control.Label;
 import javafx.scene.control.SkinBase;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
 import org.jackhuang.hmcl.ui.FXUtils;
 import org.jackhuang.hmcl.ui.animation.ContainerAnimations;
 import org.jackhuang.hmcl.ui.animation.TransitionPane;
-import org.jackhuang.hmcl.util.javafx.BindingMapping;
 
 @DefaultProperty("content")
 public class SpinnerPane extends Control {
@@ -101,12 +102,13 @@ public class SpinnerPane extends Control {
         return onFailedActionProperty().get();
     }
 
-    private ObjectProperty<EventHandler<Event>> onFailedAction = new SimpleObjectProperty<EventHandler<Event>>(this, "onFailedAction") {
+    private final ObjectProperty<EventHandler<Event>> onFailedAction = new SimpleObjectProperty<EventHandler<Event>>(this, "onFailedAction") {
         @Override
         protected void invalidated() {
             setEventHandler(FAILED_ACTION, get());
         }
     };
+
     @Override
     protected Skin createDefaultSkin() {
         return new Skin(this);
@@ -129,13 +131,13 @@ public class SpinnerPane extends Control {
             topPane.getStyleClass().add("notice-pane");
             failedPane.getStyleClass().add("notice-pane");
             failedPane.getChildren().setAll(failedReasonLabel);
-            failedPane.onMouseClickedProperty().bind(
-                    BindingMapping.of(control.onFailedAction)
-                            .map(actionHandler -> (e -> {
-                                if (actionHandler != null) {
-                                    actionHandler.handle(new Event(FAILED_ACTION));
-                                }
-                            })));
+            failedPane.addEventHandler(MouseEvent.MOUSE_CLICKED, event -> {
+                EventHandler<Event> action = control.getOnFailedAction();
+                if (event.getButton() == MouseButton.PRIMARY && event.getClickCount() == 1 && action != null) {
+                    action.handle(new Event(FAILED_ACTION));
+                    event.consume();
+                }
+            });
 
             FXUtils.onChangeAndOperate(getSkinnable().content, newValue -> {
                 if (newValue == null) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TabHeader.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TabHeader.java
@@ -30,7 +30,6 @@ import javafx.geometry.Insets;
 import javafx.geometry.Side;
 import javafx.scene.Node;
 import javafx.scene.control.*;
-import javafx.scene.input.MouseButton;
 import javafx.scene.layout.*;
 import javafx.scene.paint.Color;
 import javafx.scene.transform.Rotate;
@@ -594,11 +593,9 @@ public class TabHeader extends Control implements TabControl, PageAware {
 
                 FXUtils.onChangeAndOperate(tab.selectedProperty(), selected -> inner.pseudoClassStateChanged(SELECTED_PSEUDOCLASS_STATE, selected));
 
-                this.setOnMouseClicked(event -> {
-                    if (event.getButton() == MouseButton.PRIMARY) {
-                        this.setOpacity(1);
-                        getSkinnable().getSelectionModel().select(tab);
-                    }
+                FXUtils.onClicked(this, () -> {
+                    this.setOpacity(1);
+                    getSkinnable().getSelectionModel().select(tab);
                 });
             }
         }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AdditionalInstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AdditionalInstallersPage.java
@@ -59,7 +59,7 @@ class AdditionalInstallersPage extends InstallersPage {
         for (InstallerItem library : group.getLibraries()) {
             String libraryId = library.getLibraryId();
             if (libraryId.equals("game")) continue;
-            library.removeActionProperty().set(e -> {
+            library.setOnRemove(() -> {
                 controller.getSettings().put(libraryId, new UpdateInstallerWizardProvider.RemoveVersionAction(libraryId));
                 reload();
             });

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java
@@ -69,7 +69,7 @@ public class InstallersPage extends Control implements WizardPage {
         for (InstallerItem library : group.getLibraries()) {
             String libraryId = library.getLibraryId();
             if (libraryId.equals(LibraryAnalyzer.LibraryType.MINECRAFT.getPatchId())) continue;
-            library.installActionProperty().set(e -> {
+            library.setOnInstall(() -> {
                 if (LibraryAnalyzer.LibraryType.FABRIC_API.getPatchId().equals(libraryId)) {
                     Controllers.dialog(i18n("install.installer.fabric-api.warning"), i18n("message.warning"), MessageDialogPane.MessageType.WARNING);
                 }
@@ -77,7 +77,7 @@ public class InstallersPage extends Control implements WizardPage {
                 if (!(library.resolvedStateProperty().get() instanceof InstallerItem.IncompatibleState))
                     controller.onNext(new VersionsPage(controller, i18n("install.installer.choose", i18n("install.installer." + libraryId)), gameVersion, downloadProvider, libraryId, () -> controller.onPrev(false)));
             });
-            library.removeActionProperty().set(e -> {
+            library.setOnRemove(() -> {
                 controller.getSettings().remove(libraryId);
                 reload();
             });

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
@@ -95,7 +95,7 @@ public final class VersionsPage extends BorderPane implements WizardPage, Refres
         HintPane hintPane = new HintPane();
         hintPane.setText(i18n("sponsor.bmclapi"));
         hintPane.getStyleClass().add("sponsor-pane");
-        hintPane.setOnMouseClicked(e -> onSponsor());
+        FXUtils.onClicked(hintPane, this::onSponsor);
         BorderPane.setMargin(hintPane, new Insets(10, 10, 0, 10));
         this.setTop(hintPane);
 
@@ -146,7 +146,7 @@ public final class VersionsPage extends BorderPane implements WizardPage, Refres
             failedPane.getStyleClass().add("notice-pane");
             {
                 Label label = new Label(i18n("download.failed.refresh"));
-                label.setOnMouseClicked(e -> onRefresh());
+                FXUtils.onClicked(label, this::onRefresh);
 
                 failedPane.getChildren().setAll(label);
             }
@@ -155,7 +155,7 @@ public final class VersionsPage extends BorderPane implements WizardPage, Refres
             emptyPane.getStyleClass().add("notice-pane");
             {
                 Label label = new Label(i18n("download.failed.empty"));
-                label.setOnMouseClicked(e -> onBack());
+                FXUtils.onClicked(label, this::onBack);
 
                 emptyPane.getChildren().setAll(label);
             }
@@ -180,7 +180,7 @@ public final class VersionsPage extends BorderPane implements WizardPage, Refres
         Holder<RemoteVersionListCell> lastCell = new Holder<>();
         list.setCellFactory(listView -> new RemoteVersionListCell(lastCell));
 
-        list.setOnMouseClicked(e -> {
+        FXUtils.onClicked(list, () -> {
             if (list.getSelectionModel().getSelectedIndex() < 0)
                 return;
             navigation.getSettings().put(libraryId, list.getSelectionModel().getSelectedItem());

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ModpackInfoPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ModpackInfoPage.java
@@ -21,12 +21,10 @@ import com.jfoenix.controls.*;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.*;
 import javafx.collections.ObservableList;
-import javafx.event.EventHandler;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.*;
-import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.*;
 import javafx.stage.FileChooser;
 import org.jackhuang.hmcl.auth.Account;
@@ -78,7 +76,6 @@ public final class ModpackInfoPage extends Control implements WizardPage {
     private final SimpleStringProperty authlibInjectorServer = new SimpleStringProperty();
     private final SimpleStringProperty launchArguments = new SimpleStringProperty("");
     private final SimpleStringProperty javaArguments = new SimpleStringProperty("");
-    private final ObjectProperty<EventHandler<? super MouseEvent>> next = new SimpleObjectProperty<>();
     private final SimpleStringProperty mcbbsThreadId = new SimpleStringProperty("");
 
     public ModpackInfoPage(WizardController controller, HMCLGameRepository gameRepository, String version) {
@@ -97,8 +94,6 @@ public final class ModpackInfoPage extends Control implements WizardPage {
         javaArguments.set(versionSetting.getJavaArgs());
 
         canIncludeLauncher = JarUtils.thisJarPath() != null;
-
-        next.set(e -> onNext());
     }
 
     private void onNext() {
@@ -376,7 +371,7 @@ public final class ModpackInfoPage extends Control implements WizardPage {
                     borderPane.setBottom(hbox);
 
                     JFXButton nextButton = FXUtils.newRaisedButton(i18n("wizard.next"));
-                    nextButton.onMouseClickedProperty().bind(skinnable.next);
+                    nextButton.setOnAction(e -> skinnable.onNext());
                     nextButton.setPrefWidth(100);
                     nextButton.setPrefHeight(40);
                     nextButton.disableProperty().bind(

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/MainPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/MainPage.java
@@ -117,7 +117,7 @@ public final class MainPage extends StackPane implements DecoratorPage {
         FXUtils.setLimitWidth(updatePane, 230);
         FXUtils.setLimitHeight(updatePane, 55);
         StackPane.setAlignment(updatePane, Pos.TOP_RIGHT);
-        updatePane.setOnMouseClicked(e -> onUpgrade());
+        FXUtils.onClicked(updatePane, this::onUpgrade);
         FXUtils.onChange(showUpdateProperty(), this::showUpdate);
 
         {
@@ -224,10 +224,10 @@ public final class MainPage extends StackPane implements DecoratorPage {
         menu.setMaxHeight(365);
         menu.setMaxWidth(545);
         menu.setAlwaysShowingVBar(true);
-        menu.setOnMouseClicked(e -> popup.hide());
+        FXUtils.onClicked(menu, popup::hide);
         versionNodes = MappedObservableList.create(versions, version -> {
             Node node = PopupMenu.wrapPopupMenuItem(new GameItem(profile, version.getId()));
-            node.setOnMouseClicked(e -> profile.setSelectedVersion(version.getId()));
+            FXUtils.onClicked(node, () -> profile.setSelectedVersion(version.getId()));
             return node;
         });
         Bindings.bindContent(menu.getContent(), versionNodes);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/SettingsView.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/SettingsView.java
@@ -73,7 +73,7 @@ public abstract class SettingsView extends StackPane {
                     {
                         StackPane sponsorPane = new StackPane();
                         sponsorPane.setCursor(Cursor.HAND);
-                        sponsorPane.setOnMouseClicked(e -> onSponsor());
+                        FXUtils.onClicked(sponsorPane, this::onSponsor);
                         sponsorPane.setPadding(new Insets(8, 0, 8, 0));
 
                         GridPane gridPane = new GridPane();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/profile/ProfileListItemSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/profile/ProfileListItemSkin.java
@@ -22,7 +22,6 @@ import javafx.css.PseudoClass;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.SkinBase;
-import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import org.jackhuang.hmcl.setting.Theme;
@@ -47,9 +46,7 @@ public class ProfileListItemSkin extends SkinBase<ProfileListItem> {
             skinnable.pseudoClassStateChanged(SELECTED, active);
         });
 
-        getSkinnable().addEventHandler(MouseEvent.MOUSE_CLICKED, e -> {
-            getSkinnable().setSelected(true);
-        });
+        FXUtils.onClicked(getSkinnable(), () -> getSkinnable().setSelected(true));
 
         Node left = VersionPage.wrap(SVG.FOLDER_OUTLINE);
         root.setLeft(left);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadListPage.java
@@ -488,7 +488,7 @@ public class DownloadListPage extends Control implements DecoratorPage, VersionP
                 JFXListView<RemoteMod> listView = new JFXListView<>();
                 spinnerPane.setContent(listView);
                 Bindings.bindContent(listView.getItems(), getSkinnable().items);
-                listView.setOnMouseClicked(e -> {
+                FXUtils.onClicked(listView, () -> {
                     if (listView.getSelectionModel().getSelectedIndex() < 0)
                         return;
                     RemoteMod selectedItem = listView.getSelectionModel().getSelectedItem();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
@@ -346,7 +346,7 @@ public class DownloadPage extends Control implements DecoratorPage {
             pane.getChildren().setAll(FXUtils.limitingSize(imageView, 40, 40), content);
 
             RipplerContainer container = new RipplerContainer(pane);
-            container.setOnMouseClicked(e -> Controllers.navigate(new DownloadPage(page, addon, version, callback)));
+            FXUtils.onClicked(container, () -> Controllers.navigate(new DownloadPage(page, addon, version, callback)));
             getChildren().setAll(container);
 
             if (addon != RemoteMod.BROKEN) {
@@ -428,7 +428,7 @@ public class DownloadPage extends Control implements DecoratorPage {
             }
 
             RipplerContainer container = new RipplerContainer(pane);
-            container.setOnMouseClicked(e -> Controllers.dialog(new ModVersion(dataItem, selfPage)));
+            FXUtils.onClicked(container, () -> Controllers.dialog(new ModVersion(dataItem, selfPage)));
             getChildren().setAll(container);
 
             // Workaround for https://github.com/HMCL-dev/HMCL/issues/2129
@@ -443,7 +443,7 @@ public class DownloadPage extends Control implements DecoratorPage {
             VBox box = new VBox(8);
             box.setPadding(new Insets(8));
             ModItem modItem = new ModItem(version, selfPage);
-            modItem.setOnMouseClicked(e -> fireEvent(new DialogCloseEvent()));
+            FXUtils.onClicked(modItem, () -> fireEvent(new DialogCloseEvent()));
             box.getChildren().setAll(modItem);
             SpinnerPane spinnerPane = new SpinnerPane();
             ScrollPane scrollPane = new ScrollPane();
@@ -505,7 +505,7 @@ public class DownloadPage extends Control implements DecoratorPage {
                         dependencies.put(dependency.getType(), list);
                     }
                     DependencyModItem dependencyModItem = new DependencyModItem(selfPage.page, dependency.load(), selfPage.version, selfPage.callback);
-                    dependencyModItem.setOnMouseClicked(e -> fireEvent(new DialogCloseEvent()));
+                    FXUtils.onClicked(dependencyModItem, () -> fireEvent(new DialogCloseEvent()));
                     dependencies.get(dependency.getType()).add(dependencyModItem);
                 }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/InstallerListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/InstallerListPage.java
@@ -97,11 +97,11 @@ public class InstallerListPage extends ListPageBase<InstallerItem> implements Ve
                     item.versionProperty().set(null);
                 }
 
-                item.installActionProperty().set(e -> {
+                item.setOnInstall(() -> {
                     Controllers.getDecorator().startWizard(new UpdateInstallerWizardProvider(profile, gameVersion, version, libraryId, libraryVersion));
                 });
 
-                item.removeActionProperty().set(e -> profile.getDependency().removeLibraryAsync(version, libraryId)
+                item.setOnRemove(() -> profile.getDependency().removeLibraryAsync(version, libraryId)
                         .thenComposeAsync(profile.getRepository()::saveAsync)
                         .withComposeAsync(profile.getRepository().refreshVersionsAsync())
                         .withRunAsync(Schedulers.javafx(), () -> loadVersion(this.profile, this.versionId))
@@ -121,7 +121,7 @@ public class InstallerListPage extends ListPageBase<InstallerItem> implements Ve
 
                 InstallerItem installerItem = new InstallerItem(libraryId, InstallerItem.Style.LIST_ITEM);
                 installerItem.versionProperty().set(new InstallerItem.InstalledState(libraryVersion, false, false));
-                installerItem.removeActionProperty().set(e -> profile.getDependency().removeLibraryAsync(version, libraryId)
+                installerItem.setOnRemove(() -> profile.getDependency().removeLibraryAsync(version, libraryId)
                         .thenComposeAsync(profile.getRepository()::saveAsync)
                         .withComposeAsync(profile.getRepository().refreshVersionsAsync())
                         .withRunAsync(Schedulers.javafx(), () -> loadVersion(this.profile, this.versionId))

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionIconDialog.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionIconDialog.java
@@ -95,9 +95,7 @@ public class VersionIconDialog extends DialogPane {
         RipplerContainer container = new RipplerContainer(shape);
         FXUtils.setLimitWidth(container, 36);
         FXUtils.setLimitHeight(container, 36);
-        container.setOnMouseClicked(e -> {
-            exploreIcon();
-        });
+        FXUtils.onClicked(container, this::exploreIcon);
         return container;
     }
 
@@ -107,7 +105,7 @@ public class VersionIconDialog extends DialogPane {
         RipplerContainer container = new RipplerContainer(imageView);
         FXUtils.setLimitWidth(container, 36);
         FXUtils.setLimitHeight(container, 36);
-        container.setOnMouseClicked(e -> {
+        FXUtils.onClicked(container, () -> {
             if (vs != null) {
                 vs.setVersionIcon(type);
                 onAccept();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/WorldListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/WorldListItem.java
@@ -51,7 +51,7 @@ public class WorldListItem extends Control {
 
         subtitle.set(i18n("world.description", world.getFileName(), formatDateTime(Instant.ofEpochMilli(world.getLastPlayed())), world.getGameVersion() == null ? i18n("message.unknown") : world.getGameVersion()));
 
-        setOnMouseClicked(event -> showInfo());
+        FXUtils.onClicked(this, this::showInfo);
     }
 
     @Override


### PR DESCRIPTION
目前 HMCL 中大量控件响应任何鼠标点击事件（包括中键、返回键等），不符合常规应用的行为，而且和一部分按钮的行为不一致。本 PR 清理了这些代码，让它们只响应鼠标左键单击。