### PR TITLE
For language selection, remove all region descriptions

### DIFF
--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -729,7 +729,7 @@ java.reveal=Reveal the Java directory
 java.uninstall=Uninstall Java
 java.uninstall.confirm=Are you sure you want to uninstall this Java? This action cannot be undone!
 
-lang=English (United States)
+lang=English
 lang.default=Use System Locales
 launch.advice=%s Do you still want to continue to launch?
 launch.advice.multi=The following problems were detected:\n\n%s\n\nThese problems may cause unable to launch the game or affect the game experience.\nDo you still want to continue to launch?

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -557,7 +557,7 @@ java.reveal=浏览 Java 文件夹
 java.uninstall=卸载此 Java
 java.uninstall.confirm=你确定要卸载此 Java 吗？此操作无法撤销！
 
-lang=简体中文 (中国大陆)
+lang=简体中文
 lang.default=跟随系统语言
 
 launch.advice==%s 是否继续启动？


### PR DESCRIPTION
Currently, HMCL does not provide variants for languages ​​(e.g. US, UK, etc.). 

For Chinese, there are already descriptions of Simplified (简体) and Traditional (繁體) to distinguish them, so keep them.