### PR TITLE
Adjust i18n related to edit instance terms (Chinese only)

### DIFF
--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -166,7 +166,7 @@ archive.version=版本
 
 assets.download=下載資源
 assets.download_all=驗證資源檔案完整性
-assets.index.malformed=資源檔案的索引檔案損壞，你可以在相應實例的「實例管理」頁面中，點擊頁面左下角的「設定 → 更新遊戲資源檔案」以修復該問題。
+assets.index.malformed=資源檔案的索引檔案損壞，你可以在相應實例的「編輯實例」頁面中，點擊頁面左下角的「設定 → 更新遊戲資源檔案」以修復該問題。
 
 button.cancel=取消
 button.change_source=切換下載源
@@ -415,7 +415,7 @@ game.crash.reason.mod_resolution0=目前遊戲由於一些模組出現問題，�
 game.crash.reason.need_jdk11=目前遊戲由於 Java 虛擬機版本不合適，無法繼續執行。\n你需要下載安裝 Java 11，並在「(全域/實例特定) 遊戲設定 → 遊戲 Java」中將 Java 設定為 11 開頭的版本。
 game.crash.reason.java_version_is_too_high=目前遊戲由於使用的 Java 版本過高而崩潰了，無法繼續執行。\n請在「(全域/實例特定) 遊戲設定 → 遊戲 Java」中改用較低版本的 Java，然後再啟動遊戲。\n如果沒有，可以從 <a href="https://www.java.com/download/">java.com (Java 8)</a> 或 <a href="https://bell-sw.com/pages/downloads/#downloads">BellSoft Liberica Full JRE (Java 17)</a> 等平台下載、安裝一個 (安裝完後需重啟啟動器)。
 game.crash.reason.mod_name=目前遊戲由於模組檔案名稱問題，無法繼續執行。\n模組檔案名稱應只使用半型的大小寫字母 (Aa~Zz)、數位 (0~9)、橫線 (-)、底線 (_)和點 (.)。\n請到模組目錄中將所有不合規的模組檔案名稱修正為上述合規字元。
-game.crash.reason.incomplete_forge_installation=目前遊戲由於 Forge 安裝不完整，無法繼續執行。\n請在「實例管理 - 自動安裝」中移除 Forge 並重新安裝。
+game.crash.reason.incomplete_forge_installation=目前遊戲由於 Forge 安裝不完整，無法繼續執行。\n請在「編輯實例 - 自動安裝」中移除 Forge 並重新安裝。
 game.crash.reason.file_already_exists=目前遊戲由於檔案「%1$s」已經存在，無法繼續執行。\n如果你認為這個檔案可以刪除，你可以在備份這個檔案後嘗試刪除它，並重新啟動遊戲。
 game.crash.reason.file_changed=目前遊戲由於檔案校驗失敗，無法繼續執行。\n如果你手動修改了 Minecraft.jar 檔案，你需要回退修改，或者重新下載遊戲。
 game.crash.reason.gl_operation_failure=目前遊戲由於你使用的某些模組/光影包/資源包出現問題，無法繼續執行。\n請先嘗試禁用你所使用的模組/光影包/資源包再試。
@@ -441,13 +441,13 @@ game.crash.reason.mod_resolution_missing=目前遊戲由於缺少相依模組，
 game.crash.reason.mod_resolution_missing_minecraft=目前遊戲由於模組和 Minecraft 遊戲版本不匹配，無法繼續執行。\n「%1$s」需要 Minecraft %2$s 才能執行。\n如果你要繼續使用你已經安裝的模組，你可以選取安裝對應的 Minecraft 版本；如果你要繼續使用目前的 Minecraft 版本，你需要安裝對應版本的模組。
 game.crash.reason.mod_resolution_mod_version=%1$s (版本號 %2$s)
 game.crash.reason.mod_resolution_mod_version.any=%1$s (任意版本)
-game.crash.reason.forge_repeat_installation=目前遊戲由於 Forge 重複安裝，無法繼續執行。<a href="https://github.com/HMCL-dev/HMCL/issues/1880">此為已知問題</a>\n建議將日誌上傳並回報至 GitHub，以便我們找到更多線索並修復此問題。\n目前你可以在「實例管理 → 自動安裝」中移除 Forge 並重新安裝。
-game.crash.reason.optifine_repeat_installation=目前遊戲由於重複安裝 OptiFine，無法繼續執行。\n請刪除模組目錄下的 OptiFine 或前往「實例管理 → 自動安裝」移除安裝的 OptiFine。
-game.crash.reason.optifine_is_not_compatible_with_forge=目前遊戲由於 OptiFine 與目前版本的 Forge 不相容，導致了遊戲崩潰。\n請前往 <a href="https://optifine.net/downloads">OptiFine 官網</a>查看 OptiFine 所相容的 Forge 版本，並嚴格按照對應版本重新安裝遊戲，或在「實例管理 → 自動安裝」中更換版本。\n經測試，Forge 版本過高或過低都可能導致崩潰。
+game.crash.reason.forge_repeat_installation=目前遊戲由於 Forge 重複安裝，無法繼續執行。<a href="https://github.com/HMCL-dev/HMCL/issues/1880">此為已知問題</a>\n建議將日誌上傳並回報至 GitHub，以便我們找到更多線索並修復此問題。\n目前你可以在「編輯實例 → 自動安裝」中移除 Forge 並重新安裝。
+game.crash.reason.optifine_repeat_installation=目前遊戲由於重複安裝 OptiFine，無法繼續執行。\n請刪除模組目錄下的 OptiFine 或在「編輯實例 → 自動安裝」中移除安裝的 OptiFine。
+game.crash.reason.optifine_is_not_compatible_with_forge=目前遊戲由於 OptiFine 與目前版本的 Forge 不相容，導致了遊戲崩潰。\n請前往 <a href="https://optifine.net/downloads">OptiFine 官網</a>查看 OptiFine 所相容的 Forge 版本，並嚴格按照對應版本重新安裝遊戲，或在「編輯實例 → 自動安裝」中更換版本。\n經測試，Forge 版本過高或過低都可能導致崩潰。
 game.crash.reason.night_config_fixes=目前遊戲由於 Night Config 庫的一些問題，無法繼續執行。\n你可以嘗試安裝 <a href="https://www.curseforge.com/minecraft/mc-mods/night-config-fixes">Night Config Fixes</a> 模組，這或許能幫助你解決這個問題。\n了解更多，可訪問該模組的 <a href="https://github.com/Fuzss/nightconfigfixes">GitHub 倉庫</a>。
 game.crash.reason.mod_files_are_decompressed=目前遊戲由於模組檔案被解壓了，無法繼續執行。\n請直接把整個模組檔案放進模組目錄中即可。\n若解壓就會導致遊戲出錯，請刪除模組目錄中已被解壓的模組，然後再啟動遊戲。
 game.crash.reason.too_many_mods_lead_to_exceeding_the_id_limit=目前遊戲由於你所安裝的模組過多，超出了遊戲的 ID 限制，無法繼續執行。\n請嘗試安裝<a href="https://www.curseforge.com/minecraft/mc-mods/jeid">JEID</a>等修正模組，或刪除部分大型模組。
-game.crash.reason.optifine_causes_the_world_to_fail_to_load=目前遊戲可能由於 OptiFine 而無法繼續執行。\n該問題只在特定 OptiFine 版本中出現，你可以嘗試在「實例管理 → 自動安裝」中更換 OptiFine 的版本。
+game.crash.reason.optifine_causes_the_world_to_fail_to_load=目前遊戲可能由於 OptiFine 而無法繼續執行。\n該問題只在特定 OptiFine 版本中出現，你可以嘗試在「編輯實例 → 自動安裝」中更換 OptiFine 的版本。
 game.crash.reason.modlauncher_8=目前遊戲由於你所使用的 Forge 版本與目前使用的 Java 衝突崩潰，請嘗試更新 Forge。
 game.crash.reason.shaders_mod=目前遊戲由於同時安裝了 OptiFine 和 Shaders 模組，無法繼續執行。 \n由於 OptiFine 已整合 Shaders 模組的功能，只需刪除 Shaders 模組即可。
 game.crash.reason.rtss_forest_sodium=目前遊戲由於 RivaTuner Statistics Server (RTSS) 與 Sodium 不相容，導致遊戲崩潰。\n點擊 <a href="https://github.com/CaffeineMC/sodium-fabric/wiki/Known-Issues#rtss-incompatible">此處</a> 查看詳情。
@@ -1132,8 +1132,8 @@ version.manage.duplicate=複製遊戲實例
 version.manage.duplicate.duplicate_save=複製存檔
 version.manage.duplicate.prompt=請輸入新遊戲實例名稱
 version.manage.duplicate.confirm=新的遊戲將複製該實例目錄 (".minecraft/versions/<實例名>") 下的檔案，並帶有獨立的執行目錄和設定。
-version.manage.manage=實例管理
-version.manage.manage.title=實例管理 - %1s
+version.manage.manage=編輯實例
+version.manage.manage.title=編輯實例 - %1s
 version.manage.redownload_assets_index=更新遊戲資源檔案
 version.manage.remove=刪除該版本
 version.manage.remove.confirm=真的要刪除實例「%s」嗎? 你將無法找回被刪除的檔案！！！

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -175,7 +175,7 @@ archive.version=版本
 
 assets.download=下载资源
 assets.download_all=检查资源文件完整性
-assets.index.malformed=资源文件的索引文件损坏，你可以在相应版本的“版本管理”页面中，点击左下角“管理 → 更新游戏资源文件”以修复该问题。\n你可以点击右上角帮助按钮进行求助。
+assets.index.malformed=资源文件的索引文件损坏，你可以在相应版本的“编辑版本”页面中，点击左下角“管理 → 更新游戏资源文件”以修复该问题。\n你可以点击右上角帮助按钮进行求助。
 
 button.cancel=取消
 button.change_source=切换下载源
@@ -444,8 +444,8 @@ game.crash.reason.mod_resolution_missing=当前游戏由于缺少前置模组，
 game.crash.reason.mod_resolution_missing_minecraft=当前游戏由于模组和 Minecraft 游戏版本不匹配，无法继续运行。\n“%1$s”需要 Minecraft %2$s 才能运行。\n如果你要继续使用你已经安装的模组，你可以选择安装对应的 Minecraft 版本；如果你要继续使用当前 Minecraft 版本，你需要安装对应版本的模组。
 game.crash.reason.mod_resolution_mod_version=%1$s (版本号 %2$s)
 game.crash.reason.mod_resolution_mod_version.any=%1$s (任意版本)
-game.crash.reason.forge_repeat_installation=当前游戏由于 Forge 重复安装，无法继续运行。<a href="https://github.com/HMCL-dev/HMCL/issues/1880">此为已知问题</a>\n建议将日志上传并反馈至 GitHub，以便我们找到更多线索并修复此问题。\n目前你可以在“版本管理 → 自动安装”中卸载 Forge 并重新安装。
-game.crash.reason.optifine_repeat_installation=当前游戏由于 OptiFine 重复安装，无法继续运行。\n请删除模组文件夹下的 OptiFine 或前往“版本管理 → 自动安装”卸载安装的 OptiFine。
+game.crash.reason.forge_repeat_installation=当前游戏由于 Forge 重复安装，无法继续运行。<a href="https://github.com/HMCL-dev/HMCL/issues/1880">此为已知问题</a>\n建议将日志上传并反馈至 GitHub，以便我们找到更多线索并修复此问题。\n目前你可以在“编辑版本 → 自动安装”中卸载 Forge 并重新安装。
+game.crash.reason.optifine_repeat_installation=当前游戏由于 OptiFine 重复安装，无法继续运行。\n请删除模组文件夹下的 OptiFine 或在“编辑版本 → 自动安装”中卸载安装的 OptiFine。
 game.crash.reason.forgemod_resolution=当前游戏由于模组依赖问题，无法继续运行。Forge/NeoForge 提供了如下信息：\n%1$s 
 game.crash.reason.forge_found_duplicate_mods=当前游戏由于模组重复安装，无法继续运行。Forge/NeoForge 提供了如下信息：\n%1$s 
 game.crash.reason.modmixin_failure=当前游戏由于某些模组注入失败，无法继续运行。\n这一般代表着该模组存在问题，或与当前环境不兼容。\n你可以查看日志寻找出错模组。
@@ -454,13 +454,13 @@ game.crash.reason.forge_error=Forge/NeoForge 可能已经提供了错误信息�
 game.crash.reason.mod_resolution0=当前游戏由于一些模组出现问题，无法继续运行。\n你可以查看日志寻找出错模组。
 game.crash.reason.java_version_is_too_high=当前游戏由于 Java 虚拟机版本过高，无法继续运行。\n请在“(全局/版本特定) 游戏设置 → 游戏 Java”中改用较低版本的 Java，然后再启动游戏。\n如果没有，可以从 <a href="https://www.java.com/download/">java.com (Java 8)</a> 或 <a href="https://bell-sw.com/pages/downloads/#downloads">BellSoft Liberica Full JRE (Java 17)</a> 等平台下载、安装一个 (安装完后需重启启动器)。
 game.crash.reason.mod_name=当前游戏由于模组文件名称问题，无法继续运行。\n模组文件名称应只使用半角的大小写字母 (Aa~Zz)、数字 (0~9)、横线 (-)、下划线 (_)和点 (.)。\n请到模组文件夹中将所有不合规的模组文件名修改为上述合规字符。
-game.crash.reason.incomplete_forge_installation=当前游戏由于 Forge/NeoForge 安装不完整，无法继续运行。\n请在“版本管理 → 自动安装”中卸载 Forge 并重新安装。
-game.crash.reason.optifine_is_not_compatible_with_forge=当前游戏由于 OptiFine 与当前版本的 Forge 不兼容，导致游戏崩溃。\n点击 <a href="https://zkitefly.github.io/optifine-forge-support-list">此处</a> 查看 OptiFine 所兼容的 Forge 版本，并严格按照对应版本重新安装游戏或在“版本管理 → 自动安装”中更换版本。\n经测试，Forge 版本过高或过低都可能导致崩溃。
+game.crash.reason.incomplete_forge_installation=当前游戏由于 Forge/NeoForge 安装不完整，无法继续运行。\n请在“编辑版本 → 自动安装”中卸载 Forge 并重新安装。
+game.crash.reason.optifine_is_not_compatible_with_forge=当前游戏由于 OptiFine 与当前版本的 Forge 不兼容，导致游戏崩溃。\n点击 <a href="https://zkitefly.github.io/optifine-forge-support-list">此处</a> 查看 OptiFine 所兼容的 Forge 版本，并严格按照对应版本重新安装游戏或在“编辑版本 → 自动安装”中更换版本。\n经测试，Forge 版本过高或过低都可能导致崩溃。
 game.crash.reason.mod_files_are_decompressed=当前游戏由于模组文件被解压了，无法继续运行。\n请直接把整个模组文件放进模组文件夹中即可。\n解压模组会导致游戏出错，请删除模组文件夹中已被解压的模组，然后再启动游戏。
 game.crash.reason.shaders_mod=当前游戏由于同时安装了 OptiFine 和 Shaders 模组，无法继续运行。\n由于 OptiFine 已集成 Shaders 模组的功能，所以只需删除 Shaders 模组即可。
 game.crash.reason.rtss_forest_sodium=当前游戏由于 RivaTuner Statistics Server (RTSS) 与 Sodium 不兼容，导致游戏崩溃。\n点击 <a href="https://github.com/CaffeineMC/sodium-fabric/wiki/Known-Issues#rtss-incompatible">此处</a> 查看详情。
 game.crash.reason.too_many_mods_lead_to_exceeding_the_id_limit=当前游戏由于你所安装的模组过多，超出了游戏的 ID 限制，无法继续运行。\n请尝试安装 <a href="https://www.curseforge.com/minecraft/mc-mods/jeid">JEID</a> 等修复模组，或删除部分大型模组。
-game.crash.reason.optifine_causes_the_world_to_fail_to_load=当前游戏可能由于 OptiFine 而无法继续运行。\n该问题只在特定 OptiFine 版本中出现，你可以尝试在“版本管理 → 自动安装”中更换 OptiFine 的版本。
+game.crash.reason.optifine_causes_the_world_to_fail_to_load=当前游戏可能由于 OptiFine 而无法继续运行。\n该问题只在特定 OptiFine 版本中出现，你可以尝试在“编辑版本 → 自动安装”中更换 OptiFine 的版本。
 game.crash.reason.modlauncher_8=当前游戏由于你所使用的 Forge 版本与当前使用的 Java 冲突而崩溃，请尝试更新 Forge 到 36.2.26 或更高版本或换用版本低于 1.8.0.320 的 Java。<a href="https://bell-sw.com/pages/downloads/?version=java-8&package=jre-full">Liberica JDK 8u312+7</a>
 game.crash.reason.no_class_def_found_error=当前游戏由于代码不完整，无法继续运行。\n你的游戏可能缺失了某个模组，或者某些模组文件不完整，或者模组与游戏的版本不匹配。\n你可能需要重新安装游戏和模组，或寻求他人帮助。\n缺失：\n%1$s 
 game.crash.reason.no_such_method_error=当前游戏由于代码不完整，无法继续运行。\n你的游戏可能缺失了某个模组，或者某些模组文件不完整，或者模组与游戏的版本不匹配。\n你可能需要重新安装游戏和模组，或寻求他人帮助。
@@ -1143,8 +1143,8 @@ version.manage.duplicate=复制游戏版本
 version.manage.duplicate.duplicate_save=复制存档
 version.manage.duplicate.prompt=请输入新游戏名称
 version.manage.duplicate.confirm=新的游戏版本将复制该版本文件夹 (".minecraft/versions/<版本名>") 下的文件，并带有独立的运行文件夹和设置。
-version.manage.manage=版本管理
-version.manage.manage.title=版本管理 - %1s
+version.manage.manage=编辑版本 
+version.manage.manage.title=编辑版本 - %1s
 version.manage.redownload_assets_index=更新游戏资源文件
 version.manage.remove=删除该版本
 version.manage.remove.confirm=真的要删除版本“%s”吗？你将无法找回被删除的文件！！！


### PR DESCRIPTION
The translation I used previously was one I decided on in a hurry, and now it feels a bit weird —users could easily mistake it for *manage all instances*.

This PR changes the term to *编辑版本*/*編輯實例* to avoid potential misunderstandings and to be consistent with English.

In addition, some relevant texts were revised.