### PR TITLE
Adjust language selection order

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/Locales.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/Locales.java
@@ -40,16 +40,6 @@ public final class Locales {
     public static final SupportedLocale EN = new SupportedLocale(Locale.ROOT);
 
     /**
-     * Traditional Chinese
-     */
-    public static final SupportedLocale ZH = new SupportedLocale(Locale.TRADITIONAL_CHINESE);
-
-    /**
-     * Simplified Chinese
-     */
-    public static final SupportedLocale ZH_CN = new SupportedLocale(Locale.SIMPLIFIED_CHINESE);
-
-    /**
      * Spanish
      */
     public static final SupportedLocale ES = new SupportedLocale(Locale.forLanguageTag("es"));
@@ -64,23 +54,33 @@ public final class Locales {
      */
     public static final SupportedLocale JA = new SupportedLocale(Locale.JAPANESE);
 
-    public static final List<SupportedLocale> LOCALES = Lang.immutableListOf(DEFAULT, EN, ZH_CN, ZH, ES, RU, JA);
+    /**
+     * Traditional Chinese
+     */
+    public static final SupportedLocale ZH = new SupportedLocale(Locale.TRADITIONAL_CHINESE);
+
+    /**
+     * Simplified Chinese
+     */
+    public static final SupportedLocale ZH_CN = new SupportedLocale(Locale.SIMPLIFIED_CHINESE);
+
+    public static final List<SupportedLocale> LOCALES = Lang.immutableListOf(DEFAULT, EN, ES, JA, RU, ZH_CN, ZH);
 
     public static SupportedLocale getLocaleByName(String name) {
         if (name == null) return DEFAULT;
         switch (name.toLowerCase(Locale.ROOT)) {
             case "en":
                 return EN;
+            case "es":
+                return ES;
+            case "ja":
+                return JA;
+            case "ru":
+                return RU;
             case "zh":
                 return ZH;
             case "zh_cn":
                 return ZH_CN;
-            case "es":
-                return ES;
-            case "ru":
-                return RU;
-            case "ja":
-                return JA;
             default:
                 return DEFAULT;
         }
@@ -88,11 +88,11 @@ public final class Locales {
 
     public static String getNameByLocale(SupportedLocale locale) {
         if (locale == EN) return "en";
-        else if (locale == ZH) return "zh";
-        else if (locale == ZH_CN) return "zh_CN";
         else if (locale == ES) return "es";
         else if (locale == RU) return "ru";
         else if (locale == JA) return "ja";
+        else if (locale == ZH) return "zh";
+        else if (locale == ZH_CN) return "zh_CN";
         else if (locale == DEFAULT) return "def";
         else throw new IllegalArgumentException("Unknown locale: " + locale);
     }


### PR DESCRIPTION
Sort alphabetically by language code.

| IETF Language Tag | HMCL Internal Usage Code | Language Name (Native) | Language Name (English) |
| :---------------: | :----------------------: | :--------------------: | :---------------------: |
|       en-US       |            EN            |        English         |         English         |
|       es-ES       |            ES            |        Español         |         Spanish         |
|       ja-JP       |            JA            |         日本語         |        Japanese         |
|       ru-RU       |            RU            |        Русский         |         Russian         |
|       zh-CN       |          ZH_CN           |        简体中文        |   Simplified Chinese    |
|       zh-TW       |            ZH            |        繁體中文        |   Traditional Chinese   |

![hmcl-language-selection](https://github.com/user-attachments/assets/3dd8b8c8-7fa1-47cd-8155-29b36cfe6bbf)