### PR TITLE
修复对话框按钮自行移动的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Theme.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Theme.java
@@ -25,7 +25,6 @@ import javafx.beans.binding.ObjectBinding;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import org.jackhuang.hmcl.ui.FXUtils;
-import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.io.FileUtils;
 
 import java.io.File;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Theme.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Theme.java
@@ -154,7 +154,11 @@ public class Theme {
                     .append("-fx-base-text-fill:").append(getColorDisplayName(getForegroundColor())).append(";")
                     .append("-theme-thumb:").append(rgba(paint, 0.7)).append(";");
 
-            themeBuilder.append("-fx-font-family:\"").append(Lang.requireNonNullElse(fontFamily, "-fx-base-font-family")).append("\";");
+            // https://github.com/HMCL-dev/HMCL/pull/3423
+            if (fontFamily == null)
+                fontFamily = "-fx-base-font-family";
+
+            themeBuilder.append("-fx-font-family:\"").append(fontFamily).append("\";");
             if (fontStyle != null && !fontStyle.isEmpty())
                 themeBuilder.append("-fx-font-style:\"").append(fontStyle).append("\";");
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Theme.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Theme.java
@@ -153,11 +153,12 @@ public class Theme {
                     .append("-fx-base-text-fill:").append(getColorDisplayName(getForegroundColor())).append(";")
                     .append("-theme-thumb:").append(rgba(paint, 0.7)).append(";");
 
-            // https://github.com/HMCL-dev/HMCL/pull/3423
             if (fontFamily == null)
-                fontFamily = "-fx-base-font-family";
+                // https://github.com/HMCL-dev/HMCL/pull/3423
+                themeBuilder.append("-fx-font-family: -fx-base-font-family;");
+            else
+                themeBuilder.append("-fx-font-family:\"").append(fontFamily).append("\";");
 
-            themeBuilder.append("-fx-font-family:\"").append(fontFamily).append("\";");
             if (fontStyle != null && !fontStyle.isEmpty())
                 themeBuilder.append("-fx-font-style:\"").append(fontStyle).append("\";");
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Theme.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Theme.java
@@ -25,6 +25,7 @@ import javafx.beans.binding.ObjectBinding;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import org.jackhuang.hmcl.ui.FXUtils;
+import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.io.FileUtils;
 
 import java.io.File;
@@ -153,11 +154,9 @@ public class Theme {
                     .append("-fx-base-text-fill:").append(getColorDisplayName(getForegroundColor())).append(";")
                     .append("-theme-thumb:").append(rgba(paint, 0.7)).append(";");
 
-            if (fontFamily != null) {
-                themeBuilder.append("-fx-font-family:\"").append(fontFamily).append("\";");
-                if (fontStyle != null && !fontStyle.isEmpty())
-                    themeBuilder.append("-fx-font-style:\"").append(fontStyle).append("\";");
-            }
+            themeBuilder.append("-fx-font-family:\"").append(Lang.requireNonNullElse(fontFamily, "-fx-base-font-family")).append("\";");
+            if (fontStyle != null && !fontStyle.isEmpty())
+                themeBuilder.append("-fx-font-style:\"").append(fontStyle).append("\";");
 
             themeBuilder.append('}');
 

--- a/HMCL/src/main/resources/assets/css/blue.css
+++ b/HMCL/src/main/resources/assets/css/blue.css
@@ -23,6 +23,8 @@
     -fx-base-rippler-color: derive(rgba(92, 107, 192, 0.3), 100%);
     -fx-base-disabled-text-fill: rgba(256, 256, 256, 0.7);
     -fx-base-text-fill: white;
+
+    /* https://github.com/HMCL-dev/HMCL/pull/3423 */
     -fx-font-family: -fx-base-font-family;
 
     -theme-thumb: rgba(92, 107, 192, 0.7);

--- a/HMCL/src/main/resources/assets/css/blue.css
+++ b/HMCL/src/main/resources/assets/css/blue.css
@@ -23,6 +23,7 @@
     -fx-base-rippler-color: derive(rgba(92, 107, 192, 0.3), 100%);
     -fx-base-disabled-text-fill: rgba(256, 256, 256, 0.7);
     -fx-base-text-fill: white;
+    -fx-font-family: -fx-base-font-family;
 
     -theme-thumb: rgba(92, 107, 192, 0.7);
 }


### PR DESCRIPTION
确定该问题由 #3324 造成。不太明白具体为什么，但指定一个无效的字体就能避免这种情况。