### PR TITLE
修复 Copyright © 显示为“漏”的bug

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/AboutPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/AboutPage.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 import static org.jackhuang.hmcl.util.logging.Logger.LOG;
@@ -116,7 +117,7 @@ public final class AboutPage extends StackPane {
             return componentList;
         }
 
-        try (Reader reader = new InputStreamReader(input)) {
+        try (Reader reader = new InputStreamReader(input, StandardCharsets.UTF_8)) {
             JsonArray array = JsonUtils.GSON.fromJson(reader, JsonArray.class);
 
             for (JsonElement element : array) {


### PR DESCRIPTION
Fixes #3436

Specify UTF-8 charset when reading `deps.json` file in `AboutPage.java`.
