### PR TITLE
Check word 其它 → 其他 when checking translation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,6 +94,13 @@ tasks.create("checkTranslations") {
             }
         }
 
+        zh_CN.forEach {
+            if (it.value.toString().contains("其它")) {
+                project.logger.warn("The misspelled '其它' in '${it.key}' should be replaced by '其他'")
+                success = false
+            }
+        }
+
         if (!success) {
             throw GradleException("Part of the translation is missing")
         }


### PR DESCRIPTION
There is some controversy over the use of this word. In order to ensure consistency in formal texts, we should unify them to more tried-and-true and commonly used usages.

By checking at build time, it lets the translator or proofreader correct the word on his/her own without any special attention from the reviewer.