### PR TITLE
[I18n zh_cn] "测试版" vs "开发版"? "快照版" vs "预览版"?

### DIFF
--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -332,7 +332,7 @@ download=下载
 download.hint=安装游戏和整合包或下载模组、资源包和地图
 download.code.404=远程服务器不包含需要下载的文件: %s\n你可以点击右上角帮助按钮进行求助。
 download.content=游戏内容
-download.curseforge.unavailable=HMCL 预览版暂不支持访问 CurseForge，请使用稳定版或开发版进行下载。
+download.curseforge.unavailable=HMCL 快照版暂不支持访问 CurseForge，请使用稳定版或测试版进行下载。
 download.existing=文件已存在，无法保存。你可以将文件保存至其他地方。
 download.external_link=打开下载网站
 download.failed=下载失败: %1$s，\n错误码：%2$d\n你可以点击右上角帮助按钮进行求助。
@@ -1098,16 +1098,16 @@ unofficial.hint=你正在使用非官方构建的 HMCL，我们无法保证其�
 update=启动器更新
 update.accept=更新
 update.changelog=更新日志
-update.channel.dev=开发版
-update.channel.dev.hint=你正在使用 HMCL 开发版。开发版包含一些未在稳定版中包含的测试性功能，仅用于体验新功能。开发版功能未受充分验证，使用起来可能不稳定！<a href="https://hmcl.huangyuhui.net/download">下载稳定版</a>\n\
+update.channel.dev=测试版
+update.channel.dev.hint=你正在使用 HMCL 测试版。测试版包含一些未在稳定版中包含的测试性功能，仅用于体验新功能。测试版功能未受充分验证，使用起来可能不稳定！<a href="https://hmcl.huangyuhui.net/download">下载稳定版</a>\n\
   \n\
   如果你使用时遇到了问题，可以通过设置中<a href="hmcl://settings/feedback">反馈页面</a>提供的渠道进行反馈。欢迎关注 B 站账号 <a href="https://space.bilibili.com/1445341">@huanghongxun</a> 以关注 HMCL 的开发进展。
-update.channel.dev.title=开发版提示
-update.channel.nightly=预览版
-update.channel.nightly.hint=你正在使用 HMCL 预览版。预览版更新较为频繁，包含一些未在稳定版和开发版中包含的测试性功能，仅用于体验新功能。预览版功能未受充分验证，使用起来可能不稳定！<a href="https://hmcl.huangyuhui.net/download">下载稳定版</a>\n\
+update.channel.dev.title=测试版提示
+update.channel.nightly=快照版
+update.channel.nightly.hint=你正在使用 HMCL 快照版。快照版更新较为频繁，包含一些未在稳定版和测试版中包含的测试性功能，仅用于体验新功能。快照版功能未受充分验证，使用起来可能不稳定！<a href="https://hmcl.huangyuhui.net/download">下载稳定版</a>\n\
   \n\
   如果你使用时遇到了问题，可以通过设置中<a href="hmcl://settings/feedback">反馈页面</a>提供的渠道进行反馈。欢迎关注 B 站账号 <a href="https://space.bilibili.com/1445341">@huanghongxun</a> 以关注 HMCL 的开发进展。
-update.channel.nightly.title=预览版提示
+update.channel.nightly.title=快照版提示
 update.channel.stable=稳定版
 update.checking=正在检查更新
 update.failed=更新失败
@@ -1115,7 +1115,7 @@ update.found=发现更新
 update.newest_version=最新版本为：%s
 update.bubble.title=发现更新：%s
 update.bubble.subtitle=点击此处进行升级
-update.note=开发版与预览版包含更多的功能以及错误修复，但也可能会包含其他的问题。
+update.note=与快照版包含更多的功能以及错误修复，但也可能会包含其他的问题。
 update.latest=当前版本为最新版本
 update.no_browser=无法打开浏览器，网址已经复制到剪贴板，你可以手动粘贴网址打开页面。
 update.tooltip=更新


### PR DESCRIPTION
问题来自 HMCL 用户群 1 群，在 Burning TNT 的支持下，建议改为使用官方名称，“测试版”代替“开发版”，“快照版”代替“预览版”。
如果讨论后认为此改动不合适可以随时关闭本 PR。