### PR TITLE
修复 OAuth 登录时轮询过于频繁的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/OAuth.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/OAuth.java
@@ -109,7 +109,7 @@ public class OAuth {
         options.callback.openBrowser(deviceTokenResponse.verificationURI);
 
         long startTime = System.nanoTime();
-        long interval = TimeUnit.SECONDS.convert(deviceTokenResponse.interval, TimeUnit.MICROSECONDS);
+        long interval = TimeUnit.MILLISECONDS.convert(deviceTokenResponse.interval, TimeUnit.SECONDS);
 
         while (true) {
             Thread.sleep(Math.max(interval, 1));

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/OAuth.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/OAuth.java
@@ -109,7 +109,7 @@ public class OAuth {
         options.callback.openBrowser(deviceTokenResponse.verificationURI);
 
         long startTime = System.nanoTime();
-        int interval = deviceTokenResponse.interval;
+        long interval = TimeUnit.SECONDS.convert(deviceTokenResponse.interval, TimeUnit.MICROSECONDS);
 
         while (true) {
             Thread.sleep(Math.max(interval, 1));
@@ -138,7 +138,7 @@ public class OAuth {
             }
 
             if ("slow_down".equals(tokenResponse.error)) {
-                interval += 5;
+                interval += 5000;
                 continue;
             }
 


### PR DESCRIPTION
`interval` 的单位应当是秒，之前的实现错误的把它当做毫秒处理，导致轮询过于频繁。