### PR TITLE
调整 Java 下载对话框中包类型和版本的显示顺序

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaDownloadDialog.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaDownloadDialog.java
@@ -210,8 +210,8 @@ public final class JavaDownloadDialog extends StackPane {
             body.setHgap(16);
 
             body.addRow(0, new Label(i18n("java.download.distribution")), distributionBox);
-            body.addRow(1, new Label(i18n("java.download.version")), remoteVersionBox);
-            body.addRow(2, new Label(i18n("java.download.packageType")), packageTypeBox);
+            body.addRow(1, new Label(i18n("java.download.packageType")), packageTypeBox);
+            body.addRow(2, new Label(i18n("java.download.version")), remoteVersionBox);
 
             distributionBox.setItems(FXCollections.observableList(new ArrayList<>(distributions)));
 


### PR DESCRIPTION
Fix #3508