### PR TITLE
fix(locale): fix zh-tw locale for game crash window buttons

### DIFF
--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -628,7 +628,7 @@ logwindow.terminate_game=結束遊戲處理程式
 logwindow.title=日誌
 logwindow.help=你可以前往 HMCL 社群，向他人尋求幫助
 logwindow.autoscroll=自動滾動
-logwindow.export_game_crash_logs=匯出遊戲崩潰訊息
+logwindow.export_game_crash_logs=匯出遊戲崩潰資訊
 logwindow.export_dump=匯出遊戲執行堆疊
 logwindow.export_dump.no_dependency=你的 Java 不包含用於建立遊戲執行堆疊的相依元件。請前往 Discord 或 HMCL QQ 群尋求幫助。
 


### PR DESCRIPTION
Noticed it by chance, checked en-US and zh-CN and they are fine.

This was a mistake in my previous PR, fixing it now.