### PR TITLE
fix(locale): adjust time formats for various languages

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/I18n.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/I18n.java
@@ -77,7 +77,7 @@ public final class I18n {
     public static String formatDateTime(Instant instant) {
         DateTimeFormatter formatter = dateTimeFormatter;
         if (formatter == null) {
-            formatter = dateTimeFormatter = DateTimeFormatter.ofPattern(getResourceBundle().getString("world.time")).withZone(ZoneId.systemDefault());
+            formatter = dateTimeFormatter = DateTimeFormatter.ofPattern(getResourceBundle().getString("datetime.format")).withZone(ZoneId.systemDefault());
         }
 
         return formatter.format(instant);

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -319,6 +319,8 @@ curse.sort.name=Name
 curse.sort.popularity=Popularity
 curse.sort.total_downloads=Total Downloads
 
+datetime.format=MMM d, yyyy, h\:mm\:ss a
+
 download=Download
 download.hint=Install games and modpacks or download mods, resource packs, and worlds.
 download.code.404=File "%s" not found on the remote server.
@@ -1088,7 +1090,6 @@ world.name=World Name
 world.name.enter=Enter the world name
 world.reveal=Reveal in Explorer
 world.show_all=Show All
-world.time=h\:mm\:ss a, EEE, MMM d yyyy
 
 profile=Game Directories
 profile.already_exists=This name already exists. Please use a different name.

--- a/HMCL/src/main/resources/assets/lang/I18N_es.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_es.properties
@@ -319,6 +319,8 @@ curse.sort.name=Nombre
 curse.sort.popularity=Popularidad
 curse.sort.total_downloads=Descargas totales
 
+datetime.format=d MMM yyyy, H\:mm\:ss
+
 download=Descargar
 download.hint=Instalar juegos y modpacks o descargar mods, paquetes de recursos y mundos.
 download.code.404=Archivo no encontrado en el servidor remoto: %s
@@ -1035,7 +1037,6 @@ world.name=Nombre del mundo
 world.name.enter=Introducir el nombre del mundo
 world.reveal=Abrir en el Explorador
 world.show_all=Mostrar todo
-world.time=EEE, MMM d, yyyy HH\:mm\:ss
 
 profile=Directorios del juego
 profile.already_exists=Este nombre ya existe, por favor, utilice un nombre diferente.

--- a/HMCL/src/main/resources/assets/lang/I18N_ja.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_ja.properties
@@ -283,6 +283,8 @@ curse.sort.name=名前
 curse.sort.popularity=人気
 curse.sort.total_downloads=合計ダウンロード数
 
+datetime.format=yyyy/MM/dd H:mm:ss
+
 download=ダウンロード
 download.hint=ゲームや modpack をインストールするか、mod、リソース パック、マップをダウンロードします
 download.code.404=リモートサーバーにファイルが見つかりません：%s
@@ -717,7 +719,6 @@ world.name=マップ名
 world.name.enter=マップ名を入力してください
 world.reveal=フォルダを表示
 world.show_all=すべて表示
-world.time=EEE、MMM d、yyyy HH：mm：ss
 
 profile=ゲームディレクトリ
 profile.already_exists=この名前はすでに存在します。別の名前を使用してください。

--- a/HMCL/src/main/resources/assets/lang/I18N_ru.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_ru.properties
@@ -295,6 +295,8 @@ curse.sort.name=Название
 curse.sort.popularity=Популярность
 curse.sort.total_downloads=Скачиваний
 
+datetime.format=d MMM yyyy г., HH\:mm\:ss
+
 download=Скачать
 download.hint=Установите игры и пакеты модов или загрузите моды, пакеты ресурсов и карты
 download.code.404=Файл не найден на удалённом сервере: %s
@@ -776,7 +778,6 @@ world.name=Название мира
 world.name.enter=Введите название мира
 world.reveal=Показать в проводнике
 world.show_all=Показать все
-world.time=EEE, MMM d, yyyy HH\:mm\:ss
 
 profile=Папки с играми
 profile.already_exists=Имя уже существует, используйте другое имя.

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -319,6 +319,8 @@ curse.sort.name=名稱
 curse.sort.popularity=熱度
 curse.sort.total_downloads=下載量
 
+datetime.format=yyyy 年 MM 月 dd 日 HH:mm:ss
+
 download=下載
 download.hint=安裝遊戲和模組包或下載模組、資源包和地圖
 download.code.404=遠端伺服器沒有需要下載的檔案：%s
@@ -892,7 +894,6 @@ world.name=世界名稱
 world.name.enter=輸入世界名稱
 world.reveal=開啟目錄
 world.show_all=全部顯示
-world.time=yyyy 年 MM 月 dd 日 HH:mm:ss
 
 profile=遊戲目錄
 profile.already_exists=該名稱已存在

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -328,6 +328,8 @@ curse.sort.name=名称
 curse.sort.popularity=热度
 curse.sort.total_downloads=下载量
 
+datetime.format=yyyy 年 MM 月 dd 日 HH:mm:ss
+
 download=下载
 download.hint=安装游戏和整合包或下载模组、资源包和地图
 download.code.404=远程服务器不包含需要下载的文件: %s\n你可以点击右上角帮助按钮进行求助。
@@ -903,7 +905,6 @@ world.name=世界名称
 world.name.enter=输入世界名称
 world.reveal=打开文件夹
 world.show_all=显示全部
-world.time=yyyy 年 MM 月 dd 日 HH:mm:ss
 
 profile=游戏文件夹
 profile.already_exists=该名称已存在


### PR DESCRIPTION
- Change to a standard and commonly used format.
- Rename i18n key as it is used in more than one place.

---

<s>目前中文时间格式不加空格更加流行且耐看，所以我去掉了空格。</s>
其他语言我根据 https://github.com/HMCL-dev/HMCL/pull/3608 的效果做了调整。

由于不止在一个地方使用，我重命名了 i18n 键。