### PR TITLE
fix(ui): limit width of FileSelector in offline skin pane

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
@@ -101,6 +101,9 @@ public class OfflineAccountSkinPane extends StackPane {
         VBox optionPane = new VBox(skinItem, skinOptionPane);
         pane.setRight(optionPane);
 
+        skinSelector.maxWidthProperty().bind(skinOptionPane.maxWidthProperty().multiply(0.7));
+        capeSelector.maxWidthProperty().bind(skinOptionPane.maxWidthProperty().multiply(0.7));
+
         layout.setBody(pane);
 
         cslApiField.setPromptText(i18n("account.skin.type.csl_api.location.hint"));


### PR DESCRIPTION
make the text around the selector not be covered.

resolves https://github.com/HMCL-dev/HMCL/issues/3296

## Image

<details>
<summary>Diff Preview</summary>

BEFORE ___________ AFTER

*Russian*
![hmcl-skin-pane-1](https://github.com/user-attachments/assets/70be2343-aa4a-4dd8-953f-57c19c0b7ae5)

*Spanish*
![hmcl-skin-pane-2](https://github.com/user-attachments/assets/32d6d850-b4a7-4ef5-a3b1-d5e6dd5792bb)

</details>

---

研究了好一会。如果解决方式欠妥还请指教。

cc @burningtnt, @Glavo, @yushijinhun, and @zkitefly 