### PR TITLE
fix(i18n): fix a missing i18n for LittleSkin term

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
@@ -111,7 +111,7 @@ public class OfflineAccountSkinPane extends StackPane {
                 new MultiFileItem.Option<>(i18n("account.skin.type.steve"), Skin.Type.STEVE),
                 new MultiFileItem.Option<>(i18n("account.skin.type.alex"), Skin.Type.ALEX),
                 new MultiFileItem.Option<>(i18n("account.skin.type.local_file"), Skin.Type.LOCAL_FILE),
-                new MultiFileItem.Option<>("LittleSkin", Skin.Type.LITTLE_SKIN),
+                new MultiFileItem.Option<>(i18n("account.skin.type.little_skin"), Skin.Type.LITTLE_SKIN),
                 new MultiFileItem.Option<>(i18n("account.skin.type.csl_api"), Skin.Type.CUSTOM_SKIN_LOADER_API)
         ));
 


### PR DESCRIPTION
The word "LittleSkin" appears twice in OfflineAccountSkinPane, but one of them is hardcoded. Add i18n support for the hardcoded one.