### PR TITLE
修复 NeoForge 版本识别错误的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/LibraryAnalyzer.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/LibraryAnalyzer.java
@@ -216,11 +216,6 @@ public final class LibraryAnalyzer implements Iterable<LibraryAnalyzer.LibraryMa
 
             @Override
             protected String patchVersion(Version gameVersion, String libraryVersion) {
-                Matcher matcher = NEO_FORGE_VERSION_MATCHER.matcher(libraryVersion);
-                if (matcher.find()) {
-                    return matcher.group("forge");
-                }
-
                 String res = scanVersion(gameVersion);
                 if (res != null) {
                     return res;
@@ -231,6 +226,11 @@ public final class LibraryAnalyzer implements Iterable<LibraryAnalyzer.LibraryMa
                     if (res != null) {
                         return res;
                     }
+                }
+
+                Matcher matcher = NEO_FORGE_VERSION_MATCHER.matcher(libraryVersion);
+                if (matcher.find()) {
+                    return matcher.group("forge");
                 }
 
                 return super.patchVersion(gameVersion, libraryVersion);
@@ -248,12 +248,15 @@ public final class LibraryAnalyzer implements Iterable<LibraryAnalyzer.LibraryMa
 
                 for (int i = 0; i < gameArguments.size() - 1; i++) {
                     Argument argument = gameArguments.get(i);
-                    if (argument instanceof StringArgument && "--fml.neoForgeVersion".equals(((StringArgument) argument).getArgument())) {
-                        Argument next = gameArguments.get(i + 1);
-                        if (next instanceof StringArgument) {
-                            return ((StringArgument) next).getArgument();
+                    if (argument instanceof StringArgument) {
+                        String argumentValue = ((StringArgument) argument).getArgument();
+                        if ("--fml.neoForgeVersion".equals(argumentValue) || "--fml.forgeVersion".equals(argumentValue)) {
+                            Argument next = gameArguments.get(i + 1);
+                            if (next instanceof StringArgument) {
+                                return ((StringArgument) next).getArgument();
+                            }
+                            return null; // Normally, there should not be two --fml.neoForgeVersion argument.
                         }
-                        return null; // Normally, there should not be two --fml.neoForgeVersion argument.
                     }
                 }
                 return null;


### PR DESCRIPTION
问题报告：https://www.bilibili.com/video/BV1BzAfewECR

当使用其他启动器安装 Minecraft 1.20.1+NeoForge 47.1.106 的时候，HMCL 会错误的将 NeoForge 版本识别为 47.2.2。

造成该问题的原因是 NeoForge 1.20.1-47.1.106  的 FML 版本是 47.2.2，HMCL 在没有找到 patch 的情况下就会错误地将 FML 版本当成 NeoForge 版本。

NeoForge 的版本号规则过于复杂，我不确定会不会对识别其他版本造成影响，所以该补丁需要更多测试。