### PR TITLE
Fix #2048: 当微软账户 Token 过期时应当刷新账户

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/microsoft/MicrosoftAccount.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/microsoft/MicrosoftAccount.java
@@ -84,7 +84,7 @@ public final class MicrosoftAccount extends OAuthAccount {
 
     @Override
     public AuthInfo logIn() throws AuthenticationException {
-        if (!authenticated) {
+        if (!authenticated || System.currentTimeMillis() > session.getNotAfter()) {
             if (service.validate(session.getNotAfter(), session.getTokenType(), session.getAccessToken())) {
                 authenticated = true;
             } else {


### PR DESCRIPTION
需要测试是否会引发其他问题。