### PR TITLE
禁止标题栏按钮获取焦点

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorSkin.java
@@ -187,16 +187,19 @@ public class DecoratorSkin extends SkinBase<Decorator> {
             buttonsContainer.setMaxHeight(40);
             {
                 JFXButton btnHelp = new JFXButton();
+                btnHelp.setFocusTraversable(false);
                 btnHelp.setGraphic(SVG.HELP_CIRCLE_OUTLINE.createIcon(Theme.foregroundFillBinding(), -1, -1));
                 btnHelp.getStyleClass().add("jfx-decorator-button");
                 btnHelp.setOnAction(e -> FXUtils.openLink("https://docs.hmcl.net/help.html"));
 
                 JFXButton btnMin = new JFXButton();
+                btnMin.setFocusTraversable(false);
                 btnMin.setGraphic(SVG.MINUS.createIcon(Theme.foregroundFillBinding(), -1, -1));
                 btnMin.getStyleClass().add("jfx-decorator-button");
                 btnMin.setOnAction(e -> skinnable.minimize());
 
                 JFXButton btnClose = new JFXButton();
+                btnClose.setFocusTraversable(false);
                 btnClose.setGraphic(SVG.CLOSE.createIcon(Theme.foregroundFillBinding(), -1, -1));
                 btnClose.getStyleClass().add("jfx-decorator-button");
                 btnClose.setOnAction(e -> skinnable.close());


### PR DESCRIPTION
最小化窗口并恢复后，最小化按钮会保持获取焦点的高亮状态。本 PR 通过禁止该按钮获取焦点避免这种情况。

![image](https://github.com/user-attachments/assets/816df5b4-b9af-42f1-bf6e-b3b9e8ff159d)
