### PR TITLE
chore(locale): revise english

### DIFF
--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -682,7 +682,6 @@ install.installer.depend=Requires %s
 install.installer.fabric=Fabric
 install.installer.fabric-api=Fabric API
 install.installer.fabric-api.warning=Warning: Fabric API is a mod and will be installed into the mod directory of the game instance. Please do not change the working directory of the game, or the Fabric API won't function. If you do want to change the directory, you should reinstall it.
-#'
 install.installer.forge=Forge
 install.installer.neoforge=NeoForge
 install.installer.game=Minecraft

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -682,6 +682,7 @@ install.installer.depend=Requires %s
 install.installer.fabric=Fabric
 install.installer.fabric-api=Fabric API
 install.installer.fabric-api.warning=Warning: Fabric API is a mod and will be installed into the mod directory of the game instance. Please do not change the working directory of the game, or the Fabric API won't function. If you do want to change the directory, you should reinstall it.
+#'
 install.installer.forge=Forge
 install.installer.neoforge=NeoForge
 install.installer.game=Minecraft
@@ -1247,7 +1248,7 @@ settings.launcher.font=Font
 settings.launcher.general=General
 settings.launcher.language=Language (Applies After Restart)
 settings.launcher.launcher_log.export=Export Launcher Logs
-settings.launcher.launcher_log.reveal=Reveal Logs in Explorer
+settings.launcher.launcher_log.reveal=Reveal Logs in File Manager
 settings.launcher.launcher_log.export.failed=Failed to export logs.
 settings.launcher.launcher_log.export.success=Logs have been exported to "%s".
 settings.launcher.log=Logging
@@ -1302,12 +1303,12 @@ update.changelog=Changelog
 update.channel.dev=Beta
 update.channel.dev.hint=You are currently using a Beta channel build of the launcher. While it may include some extra features, it is also sometimes less stable than the Release channel builds.\n\
    \n\
-   If you encounter any bugs or problems, please navigate to <a href="hmcl://settings/feedback">Settings → Feedback</a> page to submit your feedback.
+   If you encounter any bugs or problems, please submit feedback via the channels provided on the <a href="hmcl://settings/feedback">Feedback</a> page.
 update.channel.dev.title=Beta Channel Notice
 update.channel.nightly=Nightly
 update.channel.nightly.hint=You are currently using a Nightly channel build of the launcher. While it may include some extra features, it is also always less stable than the other channel builds.\n\
    \n\
-   If you encounter any bugs or problems, please navigate to <a href="hmcl://settings/feedback">Settings → Feedback</a> page to submit your feedback.
+   If you encounter any bugs or problems, please submit feedback via the channels provided on the <a href="hmcl://settings/feedback">Feedback</a> page.
 update.channel.nightly.title=Nightly Channel Notice
 update.channel.stable=Release
 update.checking=Checking for Updates


### PR DESCRIPTION
`settings.launcher.launcher_log.reveal`  
Considering that HMCL is a cross-platform launcher and not all systems use the term `Explorer`, this should be changed to a more generic term.

`update.channel.dev.hint` and `update.channel.nightly.hint`  
Revise text style.

Misc  
Resolve rendering issues on some text editors.