### PR TITLE
fix(locale): unify terminology usage of 'JVM' and 'Java'

### DIFF
--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -491,7 +491,7 @@ game.crash.reason.java_version_is_too_high=The game crashed because the Java ver
    Please use the previous major Java version in "Global/Instance-specific Settings → Java" and then launch the game.\n\
    \n\
    If not, you can download it from <a href="https://www.java.com/download/">java.com (Java 8)</a> or <a href="https://bell-sw.com/pages/downloads/#downloads">BellSoft Liberica Full JRE (Java 17)</a> and other distributions to download and install one (restart the launcher after installation).
-game.crash.reason.need_jdk11=The game crashed because of an inappropriate Java VM version.\n\
+game.crash.reason.need_jdk11=The game crashed because of an inappropriate Java version.\n\
    \n\
    You need to download and install Java 11, and set it in "Global/Instance-specific Settings → Java".
 game.crash.reason.mod_name=The game crashed because of mod filename problems.\n\
@@ -561,7 +561,7 @@ game.crash.reason.optifine_causes_the_world_to_fail_to_load=The game may not con
 game.crash.reason.jdk_9=The game crashed because the Java version is too new for this instance.\n\
    \n\
    You need to download and install Java 8 and choose it in "Global/Instance-specific Settings → Java".
-game.crash.reason.jvm_32bit=The game crashed because the current memory allocation exceeded the 32-bit Java VM limit.\n\
+game.crash.reason.jvm_32bit=The game crashed because the current memory allocation exceeded the 32-bit JVM limit.\n\
    \n\
    If your OS is 64-bit, please install and use a 64-bit Java version. Otherwise, you may need to reinstall a 64-bit OS or get a moderner computer.\n\
    \n\
@@ -642,7 +642,7 @@ game.crash.reason.opengl_not_supported=The game crashed because your graphics dr
    Or, you can update your graphic driver to the latest version and then try again.\n\
    \n\
    If your computer has a dedicated graphics card, please make sure the game is indeed using it for rendering. If the problem persists, please consider getting a new graphics card or a new computer.
-game.crash.reason.openj9=The game is unable to run on an OpenJ9 VM. Please switch to a Java that uses the Hotspot VM in "Global/Instance-specific Settings → Java" and relaunch the game. If you do not have one, you can download one.
+game.crash.reason.openj9=The game is unable to run on an OpenJ9 JVM. Please switch to a Java that uses the Hotspot JVM in "Global/Instance-specific Settings → Java" and relaunch the game. If you do not have one, you can download one.
 game.crash.reason.out_of_memory=The game crashed because the computer ran out of memory.\n\
    \n\
    Maybe there is not enough memory available or too many mods installed. You can try resolving it by increasing the allocated memory in "Global/Instance-specific Settings → Memory".\n\
@@ -656,7 +656,7 @@ game.crash.reason.stacktrace=The crash reason is unknown. You can view its detai
    There are some keywords that might contain some mod names. You can search them online to figure out the problem yourself.\n\
    \n\
    %s
-game.crash.reason.too_old_java=The game crashed because you are using an outdated Java VM version.\n\
+game.crash.reason.too_old_java=The game crashed because you are using an outdated Java version.\n\
    \n\
    You need to switch to a newer Java version (%1$s) in "Global/Instance-specific Settings → Java" and then relaunch the game. You can download Java from <a href="https://learn.microsoft.com/java/openjdk/download">here</a>.
 game.crash.reason.unknown=We are not able to figure out why the game crashed. Please refer to the game logs.
@@ -765,10 +765,10 @@ lang.default=Use System Locales
 
 launch.advice=%s Do you still want to continue to launch?
 launch.advice.multi=The following problems were detected:\n\n%s\n\nThese problems may prevent you from launching the game or affect gaming experience.\nDo you still want to continue to launch?
-launch.advice.java.auto=The current Java VM version is not compatible with the instance.\n\nClick "Yes" to automatically choose the most compatible Java VM version. Or, you can navigate to "Global/Instance-specific Settings → Java" to choose one yourself.
+launch.advice.java.auto=The current Java version is not compatible with the instance.\n\nClick "Yes" to automatically choose the most compatible Java version. Or, you can navigate to "Global/Instance-specific Settings → Java" to choose one yourself.
 launch.advice.java.modded_java_7=Minecraft 1.7.2 and previous versions require Java 7 or earlier.
-launch.advice.corrected=We have resolved the Java VM problem. If you still want to use your choice of Java version, you can disable "Do not check Java VM compatibility" in "Global/Instance-specific Settings → Advanced Settings".
-launch.advice.uncorrected=If you still want to use your choice of Java version, you can disable "Do not check Java VM compatibility" in "Global/Instance-specific Settings → Advanced Settings".
+launch.advice.corrected=We have resolved the Java problem. If you still want to use your choice of Java version, you can disable "Do not check JVM compatibility" in "Global/Instance-specific Settings → Advanced Settings".
+launch.advice.uncorrected=If you still want to use your choice of Java version, you can disable "Do not check JVM compatibility" in "Global/Instance-specific Settings → Advanced Settings".
 launch.advice.different_platform=The 64-bit Java version is recommended for your device, but you have installed a 32-bit one.
 launch.advice.forge2760_liteloader=Forge version 2760 is not compatible with LiteLoader. Please consider upgrading Forge to version 2773 or later.
 launch.advice.forge28_2_2_optifine=Forge version 28.2.2 or later is not compatible with OptiFine. Please consider downgrading Forge to version 28.2.1 or earlier.
@@ -786,7 +786,7 @@ launch.advice.vanilla_linux_java_8=Minecraft 1.12.2 or earlier only supports Jav
 launch.advice.vanilla_x86.translation=Minecraft is not fully supported on your platform, so you may experience missing features or even be unable to launch the game.\nYou can download Java for the <b>x86-64</b> architecture <a href="https://learn.microsoft.com/java/openjdk/download">here</a> for a full gaming experience.
 launch.advice.unknown=The game cannot be launched due to the following reasons:
 launch.failed=Failed to launch
-launch.failed.cannot_create_jvm=We are unable to create a Java VM. It may be caused by incorrect Java VM arguments. You can try resolving it by removing all arguments you added in "Global/Instance-specific Settings → Advanced Settings → Java VM Options".
+launch.failed.cannot_create_jvm=We are unable to create a JVM. It may be caused by incorrect JVM arguments. You can try resolving it by removing all arguments you added in "Global/Instance-specific Settings → Advanced Settings → JVM Options".
 launch.failed.creating_process=We are unable to create a new process. Please check your Java path.\n
 launch.failed.command_too_long=The command length exceeds the maximum length of a batch script. Please try exporting it as a PowerShell script.
 launch.failed.decompressing_natives=Failed to extract native libraries.\n
@@ -1235,18 +1235,18 @@ settings.advanced.custom_commands.hint=The following environment variables are p
    \  · $INST_FABRIC: set if Fabric is installed.\n\
    \  · $INST_QUILT: set if Quilt is installed.
 settings.advanced.dont_check_game_completeness=Do not check game integrity
-settings.advanced.dont_check_jvm_validity=Do not check Java VM compatibility
+settings.advanced.dont_check_jvm_validity=Do not check JVM compatibility
 settings.advanced.dont_patch_natives=Do not attempt to automatically replace native libraries
 settings.advanced.environment_variables=Environment Variables
 settings.advanced.game_dir.default=Default (".minecraft/")
 settings.advanced.game_dir.independent=Isolated (".minecraft/versions/<instance name>/", except for assets and libraries)
 settings.advanced.java_permanent_generation_space=PermGen Space
 settings.advanced.java_permanent_generation_space.prompt=in MiB
-settings.advanced.jvm=Java VM Options
-settings.advanced.jvm_args=Java VM Arguments
-settings.advanced.jvm_args.prompt=\  · If the arguments entered in "Java VM arguments" are the same as the default arguments, it will not be added.\n\
-   \  · Enter any GC arguments in "Java VM arguments", and the G1 argument of the default arguments will be disabled.\n\
-   \  · Enable "Do not add default Java VM arguments" to launch the game without adding default arguments.
+settings.advanced.jvm=JVM Options
+settings.advanced.jvm_args=JVM Arguments
+settings.advanced.jvm_args.prompt=\  · If the arguments entered in "JVM Arguments" are the same as the default arguments, it will not be added.\n\
+   \  · Enter any GC arguments in "JVM Arguments", and the G1 argument of the default arguments will be disabled.\n\
+   \  · Enable "Do not add default JVM arguments" to launch the game without adding default arguments.
 settings.advanced.launcher_visibility.close=Close the launcher after the game launches
 settings.advanced.launcher_visibility.hide=Hide the launcher after the game launches
 settings.advanced.launcher_visibility.hide_and_reopen=Hide the launcher and show it when the game closes
@@ -1262,7 +1262,7 @@ settings.advanced.natives_directory.hint=This option is intended only for users 
    \n\
    Before proceeding, please make sure all libraries (e.g. lwjgl.dll, libopenal.so) are provided in your desired directory.\n\
    Note: It is recommended to use a fully English-letters path for the specified local library file. Otherwise it may lead to game launch failure.
-settings.advanced.no_jvm_args=Do not add default Java VM arguments
+settings.advanced.no_jvm_args=Do not add default JVM arguments
 settings.advanced.precall_command=Pre-launch Command
 settings.advanced.precall_command.prompt=Commands to execute before the game launches
 settings.advanced.process_priority=Process Priority

--- a/HMCL/src/main/resources/assets/lang/I18N_es.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_es.properties
@@ -514,7 +514,7 @@ game.crash.reason.jdk_9=El juego se ha colgado porque la versión de Java es dem
 game.crash.reason.need_jdk11=El juego se ha colgado debido a una versión inadecuada de Java.\n\
   \n\
   Debes descargar e instalar Java 11 y configurarlo en «Config. Global/Específica de instancia → Java».
-game.crash.reason.jvm_32bit=El juego se ha colgado porque la asignación de memoria actual excedía el límite de 32 bits JVM.\n\
+game.crash.reason.jvm_32bit=El juego se ha colgado porque la asignación de memoria actual excedía el límite de 32 bits de la JVM.\n\
   \n\
   Si su sistema operativo es de 64 bits, instale y utilice una versión de Java de 64 bits. De lo contrario, es posible que tenga que volver a instalar un sistema operativo de 64 bits o adquirir un ordenador más moderno.\n\
   \n\
@@ -647,7 +647,7 @@ game.crash.reason.stacktrace=El motivo del cuelgue es desconocido. Puedes ver lo
   Hay algunas palabras clave que pueden contener algunos nombres de mods. Puedes buscarlas en Internet para averiguar el problema tú mismo.\n\
   \n\
   %s
-game.crash.reason.too_old_java=El juego se ha colgado porque estás utilizando una versión de Java VM obsoleta.\n\
+game.crash.reason.too_old_java=El juego se ha colgado porque estás utilizando una versión de Java obsoleta.\n\
   \n\
   Tienes que cambiar a una versión de Java más reciente (%1$s) en «Config. Global/Específica de instancia → Java» y, a continuación, volver a ejecutar el juego. Puede descargar Java desde <a href="https://learn.microsoft.com/java/openjdk/download">aquí</a>.
 game.crash.reason.unknown=No somos capaces de averiguar por qué se ha colgado el juego. Por favor, refiérase a los registros del juego.
@@ -775,10 +775,10 @@ lang.default=Usar idioma del sistema
 
 launch.advice=%s ¿Todavía quieres continuar?
 launch.advice.multi=Se han detectado los siguientes problemas:\n\n%s\n\nEstos problemas pueden impedir que inicies el juego o afectar a la experiencia de juego.\n\n¿Todavía quieres continuar?
-launch.advice.java.auto=La versión actual de la máquina virtual de Java no cumple los requisitos del juego.\n\nHaga clic en «Sí» para elegir automáticamente la versión de Java VM más compatible. O bien, puede navegar hasta «Config. Global/Específica de instancia → Java» para elegir uno usted mismo.
+launch.advice.java.auto=La versión actual de Java no es compatible con la instancia.\n\nHaga clic en «Sí» para elegir automáticamente la versión de Java más compatible. O bien, puede navegar hasta «Config. Global/Específica de instancia → Java» para elegir uno usted mismo.
 launch.advice.java.modded_java_7=Minecraft 1.7.2 y versiones anteriores requieren Java 7 o anterior.
-launch.advice.corrected=Hemos solucionado el problema de la máquina virtual de Java. Si todavía quieres utilizar la versión de Java que elijas, puedes desactivar la opción «No comprobar la compatibilidad de la JVM» en «Config. Global/Específica de instancia → Configuración avanzada».
-launch.advice.uncorrected=Si todavía quieres utilizar la versión de Java que elijas, puedes desactivar la opción «No comprobar la compatibilidad de la JVM» en «Config. Global/Específica de instancia → Configuración avanzada».
+launch.advice.corrected=Hemos resuelto el problema de Java. Si aún desea utilizar la versión de Java que elija, puede desactivar «No comprobar la compatibilidad con JVM» en «Config. Global/Específica de instancia → Configuración avanzada».
+launch.advice.uncorrected=Si aún desea utilizar la versión de Java que elija, puede desactivar «No comprobar la compatibilidad con JVM» en «Config. Global/Específica de instancia → Configuración avanzada».
 launch.advice.different_platform=Se recomienda la versión de 64 bits de Java para tu dispositivo, pero has instalado una de 32 bits.
 launch.advice.forge2760_liteloader=La versión 2760 o posterior de Forge no es compatible con LiteLoader, por favor considere actualizar Forge a la versión 2773 o posterior.
 launch.advice.forge28_2_2_optifine=La versión 28.2.2 o posterior de Forge no es compatible con OptiFine. Considere la posibilidad de actualizar Forge a la versión 28.2.1 o anterior.
@@ -796,7 +796,7 @@ launch.advice.vanilla_linux_java_8=Minecraft 1.12.2 o inferior sólo admite Java
 launch.advice.vanilla_x86.translation=Minecraft no proporciona actualmente soporte oficial para arquitecturas distintas de x86 y x86-64.\n\nPor favor, instale Java para x86-64 para jugar a Minecraft a través del entorno de traducción Rosetta, o descargue sus bibliotecas nativas correspondientes y especifique su ruta.
 launch.advice.unknown=El juego no puede iniciarse por las siguientes razones:
 launch.failed=No se puede ejecutar
-launch.failed.cannot_create_jvm=No podemos crear una máquina virtual Java. Puede deberse a un problema con los argumentos de ejecución proporcionados, puede intentar solucionarlo eliminando todos los argumentos que haya añadido en la configuración de la instancia.
+launch.failed.cannot_create_jvm=No podemos crear una JVM. Puede deberse a un problema con los argumentos de ejecución proporcionados, puede intentar solucionarlo eliminando todos los argumentos que haya añadido en la configuración de la instancia.
 launch.failed.creating_process=No podemos crear un nuevo proceso, por favor compruebe la ruta de Java.\n
 launch.failed.command_too_long=La longitud del comando excede la longitud máxima de un script bat. Por favor, intente exportarlo como un script de PowerShell.
 launch.failed.decompressing_natives=No se han podido descomprimir las bibliotecas nativas.\n
@@ -1225,18 +1225,18 @@ settings.advanced.custom_commands.hint=Se proporcionan las siguientes variables 
   \  · $INST_FABRIC: disponible si Fabric está instalado.\n\
   \  · $INST_QUILT: disponible si Quilt está instalado.
 settings.advanced.dont_check_game_completeness=No chequear integridad del juego
-settings.advanced.dont_check_jvm_validity=No comprobar la compatibilidad de la JVM
+settings.advanced.dont_check_jvm_validity=No comprobar la compatibilidad con JVM
 settings.advanced.dont_patch_natives=No intente sustituir automáticamente las bibliotecas nativas
 settings.advanced.environment_variables=Variables de entorno
 settings.advanced.game_dir.default=Por defecto («.minecraft/»)
 settings.advanced.game_dir.independent=Aislar («.minecraft/versions/<nombre de la instancia>/», excepto para los activos y las bibliotecas)
 settings.advanced.java_permanent_generation_space=Espacio PermGen
 settings.advanced.java_permanent_generation_space.prompt=en MiB
-settings.advanced.jvm=Opciones de la máquina virtual de Java
-settings.advanced.jvm_args=Argumentos de la máquina virtual de Java
-settings.advanced.jvm_args.prompt=\  · Si los argumentos introducidos en «Argumentos de la máquina virtual de Java» son los mismos que los argumentos por defecto, no se añadirán.\n\
-  \  · Introduzca cualquier argumento GC en «Argumentos de la máquina virtual de Java», y se desactivará el argumento G1 de los argumentos por defecto.\n\
-  \  · Activa «No añadir argumentos por defecto de JVM» para ejecutar el juego sin añadir argumentos por defecto.
+settings.advanced.jvm=Opciones de JVM
+settings.advanced.jvm_args=Argumentos JVM
+settings.advanced.jvm_args.prompt=\  · Si los argumentos introducidos en «Argumentos JVM» son los mismos que los argumentos por defecto, no se añadirán.\n\
+  \  · Introduzca cualquier argumento GC en «Argumentos JVM», y se desactivará el argumento G1 de los argumentos por defecto.\n\
+  \  · Activa «No añadir argumentos JVM por defecto» para ejecutar el juego sin añadir argumentos por defecto.
 settings.advanced.launcher_visibility.close=Cerrar el launcher después de ejecutar el juego.
 settings.advanced.launcher_visibility.hide=Ocultar el launcher después de ejecutar el juego.
 settings.advanced.launcher_visibility.hide_and_reopen=Ocultar el launcher y volver a abrirlo cuando se cierra el juego.
@@ -1251,7 +1251,7 @@ settings.advanced.natives_directory.default=Por defecto
 settings.advanced.natives_directory.hint=Esta opción está pensada sólo para usuarios de Apple M1 u otras plataformas no soportadas oficialmente. Por favor, no modifique esta opción a menos que sepa lo que está haciendo.\n\
   \n\
   Antes de proceder, por favor, asegúrese de que todas las bibliotecas (por ejemplo, lwjgl.dll, libopenal.so) se proporcionan en su directorio deseado.
-settings.advanced.no_jvm_args=No añadir argumentos por defecto de JVM
+settings.advanced.no_jvm_args=No añadir argumentos JVM por defecto
 settings.advanced.precall_command=Comando pre-lanzamiento:
 settings.advanced.precall_command.prompt=El comando se ejecuta antes de que los juegos se lance
 settings.advanced.process_priority=Prioridad del proceso

--- a/HMCL/src/main/resources/assets/lang/I18N_ru.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_ru.properties
@@ -1224,18 +1224,18 @@ settings.advanced.custom_commands.hint=Пользовательские кома
   \  · $INST_FABRIC: устанавливается, если установлен Fabric.\n\
   \  · $INST_QUILT: устанавливается, если установлен Quilt.
 settings.advanced.dont_check_game_completeness=Не проверять целостность игры
-settings.advanced.dont_check_jvm_validity=Не проверять совместимость Java VM
+settings.advanced.dont_check_jvm_validity=Не проверять совместимость JVM
 settings.advanced.dont_patch_natives=Не пытайтесь автоматически заменить нативные библиотеки
 settings.advanced.environment_variables=Переменные среды
 settings.advanced.game_dir.default=По умолчанию («.minecraft/»)
 settings.advanced.game_dir.independent=Раздельно («.minecraft/versions/<имя сборки>/», кроме assets и библиотек)
 settings.advanced.java_permanent_generation_space=Пространство PermGen
 settings.advanced.java_permanent_generation_space.prompt=в МиБ
-settings.advanced.jvm=Настройки Java VM
-settings.advanced.jvm_args=Аргументы Java VM
-settings.advanced.jvm_args.prompt=\  · Если параметр, введённый в «Аргументы Java VM», совпадает с параметром по умолчанию, он не будет добавлен.\n\
-  \  · Введите любые параметры GC в «Аргументы Java VM», параметр G1 по умолчанию будет отключен.\n\
-  \  · Нажмите «Не добавлять аргументы Java VM по умолчанию» ниже, чтобы запустить игру без добавления аргументов по умолчанию.
+settings.advanced.jvm=Настройки JVM
+settings.advanced.jvm_args=Аргументы JVM
+settings.advanced.jvm_args.prompt=\  · Если параметр, введённый в «Аргументы JVM», совпадает с параметром по умолчанию, он не будет добавлен.\n\
+  \  · Введите любые параметры GC в «Аргументы JVM», параметр G1 по умолчанию будет отключен.\n\
+  \  · Нажмите «Не добавлять аргументы JVM по умолчанию» ниже, чтобы запустить игру без добавления аргументов по умолчанию.
 settings.advanced.launcher_visibility.close=Закрывать после запуска игры
 settings.advanced.launcher_visibility.hide=Скрыть после запуска игры
 settings.advanced.launcher_visibility.hide_and_reopen=Скрыть после запуска и показать после закрытия игры
@@ -1251,7 +1251,7 @@ settings.advanced.natives_directory.hint=Параметр предназначе
   \n\
   Прежде чем продолжить, убедитесь что все библиотеки (например, lwjgl.dll, libopenal.so) находятся в нужной папке.\n\
   Примечание: Рекомендуется использовать полностью английские пути для указанных файлов локальных библиотек, иначе игра может не запуститься.
-settings.advanced.no_jvm_args=Не добавлять аргументы Java VM по умолчанию
+settings.advanced.no_jvm_args=Не добавлять аргументы JVM по умолчанию
 settings.advanced.precall_command=Команда перед запуском
 settings.advanced.precall_command.prompt=Команды, которые необходимо выполнить перед запуском игры
 settings.advanced.process_priority=Приоритет процесса

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -360,7 +360,7 @@ exception.access_denied=無法存取檔案「%s」。因為 HMCL 沒有對該檔
   請你檢查目前作業系統帳戶是否能訪存取檔案，比如非管理員使用者可能不能訪問其他帳戶的個人目錄內的檔案。\n\
   對於 Windows 使用者，你還可以嘗試透過資源監視器查看是否有程式占用了該檔案。如果是，你可以關閉占用此檔案的程式，或者重啟電腦再試。
 exception.artifact_malformed=下載的檔案正確，但無法透過校驗。
-exception.ssl_handshake=無法建立 SSL 連線。因為目前 Java 虛擬機缺少相關的 SSL 證書。你可以嘗試使用其他的 Java 虛擬機或關閉網路代理開啟 HMCL 再試。
+exception.ssl_handshake=無法建立 SSL 連線。目前 Java 缺少相關的 SSL 證書。你可以嘗試使用其他 Java 或關閉網路代理開啟 HMCL 再試。
 
 extension.bat=Windows 批次檔
 extension.mod=模組檔案
@@ -430,7 +430,7 @@ game.crash.reason.modmixin_failure=目前遊戲由於某些模組注入失敗，
 game.crash.reason.mod_repeat_installation=目前遊戲由於重複安裝了多個相同的模組，無法繼續執行。\n每個模組只能出現一次，請刪除重複的模組，然後再啟動遊戲。
 game.crash.reason.forge_error=Forge/NeoForge 可能已經提供了錯誤資訊。\n你可以查看日誌，並根據錯誤報告中的日誌資訊進行對應處。\n如果沒有看到報錯資訊，可以查看錯誤報告了解錯誤具體是如何發生的。\n%1$s
 game.crash.reason.mod_resolution0=目前遊戲由於一些模組出現問題，無法繼續執行。\n你可以查看日誌尋找出錯模組。
-game.crash.reason.need_jdk11=目前遊戲由於 Java 虛擬機版本不合適，無法繼續執行。\n你需要下載安裝 Java 11，並在「(全域/實例特定) 遊戲設定 → 遊戲 Java」中將 Java 設定為 11.x 的版本。
+game.crash.reason.need_jdk11=目前遊戲由於 Java 版本不合適，無法繼續執行。\n你需要下載安裝 Java 11，並在「(全域/實例特定) 遊戲設定 → 遊戲 Java」中將 Java 設定為 11.x 的版本。
 game.crash.reason.java_version_is_too_high=目前遊戲由於使用的 Java 版本過高而崩潰了，無法繼續執行。\n請在「(全域/實例特定) 遊戲設定 → 遊戲 Java」中改用較低版本的 Java，然後再啟動遊戲。\n如果沒有，可以從 <a href="https://www.java.com/download/">java.com (Java 8)</a> 或 <a href="https://bell-sw.com/pages/downloads/#downloads">BellSoft Liberica Full JRE (Java 17)</a> 等平台下載、安裝一個 (安裝完後需重啟啟動器)。
 game.crash.reason.mod_name=目前遊戲由於模組檔案名稱問題，無法繼續執行。\n模組檔案名稱應只使用半型的大小寫字母 (Aa~Zz)、數位 (0~9)、橫線 (-)、底線 (_)和點 (.)。\n請到模組目錄中將所有不合規的模組檔案名稱修正為上述合規字元。
 game.crash.reason.incomplete_forge_installation=目前遊戲由於 Forge 安裝不完整，無法繼續執行。\n請在「實例管理 - 自動安裝」中移除 Forge 並重新安裝。
@@ -444,7 +444,7 @@ game.crash.reason.macos_failed_to_find_service_port_for_display=目前遊戲由�
 game.crash.reason.illegal_access_error=目前遊戲由於某些模組的問題，無法繼續執行。\n如果你認識「%1$s」，你可以更新或刪除對應模組再試。
 game.crash.reason.install_mixinbootstrap=目前遊戲由於缺失 MixinBootstrap，無法繼續執行。\n你可以嘗試安裝 <a href="https://www.curseforge.com/minecraft/mc-mods/mixinbootstrap">MixinBootstrap</a> 解決該問題。若安裝後崩潰，可以嘗試在該模組的檔案名前新增半形驚嘆號 (!) 解決。
 game.crash.reason.jdk_9=目前遊戲由於 Java 版本過高，無法繼續執行。\n你需要下載安裝 Java 8，並在「(全域/實例特定) 遊戲設定 → 遊戲 Java」中將 Java 設定為 1.8.x 的版本。
-game.crash.reason.jvm_32bit=目前遊戲由於記憶體分配過大，超過了 32 位 Java 記憶體限制，無法繼續執行。\n如果你的電腦是 64 位系統，請下載安裝並更換 64 位 Java。\n如果你的電腦是 32 位系統，你或許可以重新安裝 64 位系統，或換一台新電腦。\n或者，你可以關閉「(全域/實例特定) 遊戲設定 → 遊戲記憶體」中的「自動分配」，並且把記憶體分配值調節為 1024 MiB 或以下。
+game.crash.reason.jvm_32bit=目前遊戲由於記憶體分配過大，超過了 32 位 Java 虛擬機記憶體限制，無法繼續執行。\n如果你的電腦是 64 位系統，請下載安裝並更換 64 位 Java。\n如果你的電腦是 32 位系統，你或許可以重新安裝 64 位系統，或換一台新電腦。\n或者，你可以關閉「(全域/實例特定) 遊戲設定 → 遊戲記憶體」中的「自動分配」，並且把記憶體分配值調節為 1024 MiB 或以下。
 game.crash.reason.loading_crashed_forge=目前遊戲由於模組「%1$s (%2$s)」錯誤，無法繼續執行。\n你可以嘗試刪除或更新該模組以解決問題。
 game.crash.reason.loading_crashed_fabric=目前遊戲由於模組「%1$s」錯誤，無法繼續執行。\n你可以嘗試刪除或更新該模組以解決問題。
 game.crash.reason.mac_jdk_8u261=目前遊戲由於你所使用的 Forge 或 OptiFine 與 Java 衝突而崩潰。\n請嘗試更新 Forge 和 OptiFine，或使用 Java 8u251 及更早版本啟動。
@@ -472,11 +472,11 @@ game.crash.reason.rtss_forest_sodium=目前遊戲由於 RivaTuner Statistics Ser
 game.crash.reason.no_class_def_found_error=目前遊戲由於程式碼不完整，無法繼續執行。\n你的遊戲可能缺失了某個模組，或者某些模組檔案不完整，或者模組與遊戲的版本不匹配。\n你可能需要重新安裝遊戲和模組，或請求他人幫助。\n缺失：%1$s
 game.crash.reason.no_such_method_error=目前遊戲由於程式碼不完整，無法繼續執行。\n你的遊戲可能缺失了某個模組，或者某些模組檔案不完整，或者模組與遊戲的版本不匹配。\n你可能需要重新安裝遊戲和模組，或請求他人幫助。
 game.crash.reason.opengl_not_supported=目前遊戲由於你的顯示卡驅動存在問題，無法繼續執行。\n原因是 OpenGL 不受支援，你現在是否在遠端桌面或者串流模式下？如果是，請直接使用原電腦啟動遊戲。\n或者嘗試升級你的顯示卡驅動到最新版本後再嘗試啟動遊戲。如果你的電腦同時存在獨立顯示卡與整合式顯示卡，你需要檢查遊戲是否使用整合式顯示卡啟動。如果是，請嘗試使用獨立顯示卡開啟 HMCL 與遊戲。如果仍有問題，你可能需要考慮換一個新顯示卡或新電腦。
-game.crash.reason.openj9=目前遊戲無法執行在 OpenJ9 虛擬機上。請你在「(全域/實例特定) 遊戲設定 → 遊戲 Java」中更換 Hotspot Java 虛擬機，並重新啟動遊戲。如果沒有下載安裝，你可以在網路上自行下載。
+game.crash.reason.openj9=目前遊戲無法執行在 OpenJ9 虛擬機上。請你在「(全域/實例特定) 遊戲設定 → 遊戲 Java」中更換為使用 Hotspot 虛擬機的 Java，並重新啟動遊戲。如果沒有下載安裝，你可以在網路上自行下載。
 game.crash.reason.out_of_memory=目前遊戲由於記憶體不足，無法繼續執行。\n這可能是記憶體分配過小，或者模組數量過多導致的。\n你可以在「(全域/實例特定) 遊戲設定 → 遊戲記憶體」中調整遊戲記憶體分配值以允許遊戲在更大的記憶體下執行。\n如果仍然出現該錯誤，你可能需要換一台更好的電腦。
 game.crash.reason.resolution_too_high=目前遊戲由於資源包/紋理包解析度過高，無法繼續執行。\n你可以更換一個解析度更低的資源包/紋理包，或者更換一個視訊記憶體更大的顯示卡。
 game.crash.reason.stacktrace=原因未知。請點擊日誌按鈕查看詳細訊息。\n下面是一些關鍵字，其中可能包含模組名稱，你可以透過搜尋的方式尋找有關訊息。\n%s
-game.crash.reason.too_old_java=目前遊戲由於 Java 虛擬機版本過低，無法繼續執行。\n你需要在「(全域/實例特定) 遊戲設定 → 遊戲 Java」中更換 %1$s 或更高版本的 Java 虛擬機，並重新啟動遊戲。如果沒有下載安裝，你可以點擊 <a href="https://learn.microsoft.com/java/openjdk/download">此處</a> 下載 Microsoft JDK。
+game.crash.reason.too_old_java=目前遊戲由於 Java 版本過低，無法繼續執行。\n你需要在「(全域/實例特定) 遊戲設定 → 遊戲 Java」中更換 %1$s 或更高版本的 Java，並重新啟動遊戲。如果沒有下載安裝，你可以點擊 <a href="https://learn.microsoft.com/java/openjdk/download">此處</a> 下載 Microsoft JDK。
 game.crash.reason.unknown=原因未知。請點擊日誌按鈕查看詳細訊息。
 game.crash.reason.unsatisfied_link_error=目前遊戲由於缺少本機庫，無法繼續執行。\n這些本機庫缺失：%1$s。\n如果你在「(全域/實例特定) 遊戲設定 → 進階設定」中修改了本機庫路徑選項，請你修改回預設模式。\n如果你正在使用預設模式，請檢查遊戲目錄路徑是否只包含英文字母、數字和底線。\n如果是，那麼請檢查是否為模組或 HMCL 導致了本機庫缺失的問題。如果你確定是 HMCL 引起的，建議你向我們回報。\n<b>對於 Windows 使用者，你還可以嘗試在「控制台 → 時鐘和區域 → 地區 → 系統管理 → 變更系統區域設定」中，關閉「Beta：使用 Unicode UTF-8 提供全球語言支援」選項；</b>\n<b>或將遊戲目錄路徑中的所有非英文字母的名稱 (例如中文、空格等) 修改為英文字母。</b>\n如果你確實需要自訂本機庫路徑，你需要保證其中包含缺失的本機庫！
 game.crash.title=遊戲意外退出
@@ -577,10 +577,10 @@ lang.default=使用系統語言
 
 launch.advice=%s 是否繼續啟動？
 launch.advice.multi=檢測到以下問題：\n\n%s\n\n這些問題可能導致遊戲無法正常啟動或影響遊戲體驗，是否繼續啟動？
-launch.advice.java.auto=目前選取的 Java 虛擬機版本不滿足遊戲要求，是否自動選取合適的 Java 虛擬機版本？\n或者你可以到「(全域/實例特定) 遊戲設定 → 遊戲 Java」中選取一個合適的 Java 虛擬機版本。
+launch.advice.java.auto=目前選取的 Java 版本不滿足遊戲要求，是否自動選取合適的 Java 版本？\n或者你可以到「(全域/實例特定) 遊戲設定 → 遊戲 Java」中選取一個合適的 Java 版本。
 launch.advice.java.modded_java_7=Minecraft 1.7.2 及更低版本需要 Java 7 及更低版本。
-launch.advice.corrected=我們已經修正了問題。如果你確實希望使用你自訂的 Java 虛擬機，你可以在「(全域/實例特定) 遊戲設定 → 進階設定」中往下滑，開啟「不檢查 JVM 與遊戲的相容性」。
-launch.advice.uncorrected=如果你確實希望使用你自訂的 Java 虛擬機，你可以在「(全域/實例特定) 遊戲設定 → 進階設定」中往下滑，開啟「不檢查 JVM 與遊戲的相容性」。
+launch.advice.corrected=我們已經修正了 Java 版本問題。如果你確實希望使用你自訂的 Java，你可以在「(全域/實例特定) 遊戲設定 → 進階設定」中往下滑，開啟「不檢查 Java 虛擬機與遊戲的相容性」。
+launch.advice.uncorrected=如果你確實希望使用你自訂的 Java，你可以在「(全域/實例特定) 遊戲設定 → 進階設定」中往下滑，開啟「不檢查 Java 虛擬機與遊戲的相容性」。
 launch.advice.different_platform=你正在使用 32 位元 Java 啟動遊戲。建議更換至 64 位元 Java。
 launch.advice.forge2760_liteloader=Forge 14.23.5.2760 與 LiteLoader 不相容。請更新 Forge 至 14.23.5.2773 或更高版本。
 launch.advice.forge28_2_2_optifine=Forge 28.2.2 及更高版本與 OptiFine 不相容，請降級 Forge 至 28.2.1 或更低版本。
@@ -598,7 +598,7 @@ launch.advice.vanilla_linux_java_8=對於 Linux x86-64 平台，Minecraft 1.12.2
 launch.advice.vanilla_x86.translation=Minecraft 尚未為你的平臺提供完善支援，所以可能影響遊戲體驗或無法啟動遊戲。\n你可以在 <a href="https://learn.microsoft.com/java/openjdk/download">這裡</a> 下載 <b>x86-64</b> 架構的 Java 以獲得更完整的體驗。\n是否繼續啟動？
 launch.advice.unknown=由於以下原因，無法繼續啟動遊戲：
 launch.failed=啟動失敗
-launch.failed.cannot_create_jvm=無法建立 Java 虛擬機，可能是 Java 參數有問題。可以在「(全域/實例特定) 遊戲設定 → 進階設定 → Java 虛擬機設定」中移除所有 Java 虛擬機參數後，嘗試再次啟動遊戲。
+launch.failed.cannot_create_jvm=無法建立 Java 虛擬機。可能是虛擬機參數有問題。可以在「(全域/實例特定) 遊戲設定 → 進階設定 → Java 虛擬機設定」中移除所有虛擬機參數後，嘗試再次啟動遊戲。
 launch.failed.creating_process=啟動失敗，在建立新處理程式時發生錯誤。可能是 Java 路徑錯誤。
 launch.failed.command_too_long=指令長度超過限制，無法建立批次檔指令碼，請匯出為 PowerShell 指令碼。
 launch.failed.decompressing_natives=無法解壓縮遊戲本機庫。
@@ -609,7 +609,7 @@ launch.failed.execution_policy.failed_to_set=設定執行策略失敗
 launch.failed.execution_policy.hint=目前執行策略封鎖你執行 PowerShell 指令碼。\n點擊「確定」允許目前使用者執行本機 PowerShell 指令碼，或點擊「取消」保持現狀。
 launch.failed.exited_abnormally=遊戲非正常退出。請查看日誌檔案，或聯絡他人尋求幫助。
 launch.failed.java_version_too_low=你所指定的 Java 版本過低。請重新設定 Java 版本。
-launch.failed.no_accepted_java=找不到適合目前遊戲使用的 Java。是否使用預設 Java 啟動遊戲？點擊「是」使用預設 Java 繼續啟動遊戲，\n或者請到「(全域/實例特定) 遊戲設定 → 遊戲 Java」中選取一個合適的 Java 虛擬機版本。
+launch.failed.no_accepted_java=找不到適合目前遊戲使用的 Java。是否使用預設 Java 啟動遊戲？點擊「是」使用預設 Java 繼續啟動遊戲，\n或者請到「(全域/實例特定) 遊戲設定 → 遊戲 Java」中選取一個合適的 Java 版本。
 launch.failed.sigkill=遊戲被使用者或系統強制終止。
 launch.state.dependencies=處理遊戲相依元件
 launch.state.done=啟動完成
@@ -1044,7 +1044,7 @@ settings.advanced.jvm=Java 虛擬機設定
 settings.advanced.jvm_args=Java 虛擬機參數
 settings.advanced.jvm_args.prompt=\  · 若在「Java 虛擬機參數」中輸入的參數與預設參數相同，則不會新增；\n\
   \  · 若在「Java 虛擬機參數」輸入任何 GC 參數，預設參數的 G1 參數會被禁用；\n\
-  \  · 啟用下方「不新增預設的 JVM 參數」可在啟動遊戲時不新增預設參數。
+  \  · 啟用下方「不新增預設的 Java 虛擬機參數」可在啟動遊戲時不新增預設參數。
 settings.advanced.launcher_visibility.close=遊戲啟動後結束啟動器
 settings.advanced.launcher_visibility.hide=遊戲啟動後隱藏啟動器
 settings.advanced.launcher_visibility.hide_and_reopen=隱藏啟動器並在遊戲結束後重新開啟

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -369,7 +369,7 @@ exception.access_denied=无法访问文件“%s”。HMCL 没有对该文件的�
   对于 Windows 用户，你还可以尝试通过资源监视器查看是否有程序占用了该文件。如果是，请关闭占用该文件的程序，或者重启电脑再试。\n\
   如遇到问题，你可以点击右上角帮助按钮进行求助。
 exception.artifact_malformed=下载的文件无法通过校验。\n你可以点击右上角帮助按钮进行求助。
-exception.ssl_handshake=无法建立 SSL 连接。当前 Java 虚拟机缺少相关的 SSL 证书。你可以尝试使用其他 Java 虚拟机启动 HMCL 再试。\n你可以点击右上角帮助按钮进行求助。
+exception.ssl_handshake=无法建立 SSL 连接。当前 Java 缺少相关的 SSL 证书。你可以尝试使用其他 Java 启动 HMCL 再试。\n你可以点击右上角帮助按钮进行求助。
 
 extension.bat=Windows 脚本
 extension.mod=模组文件
@@ -446,9 +446,9 @@ game.crash.reason.graphics_driver=当前游戏由于显卡驱动问题而崩溃�
 game.crash.reason.macos_failed_to_find_service_port_for_display=当前游戏由于 Apple Silicon 平台下初始化 OpenGL 窗口失败，无法继续运行。\n对于该问题，HMCL 暂无直接性的解决方案。请你尝试任意打开一个浏览器并全屏，然后再回到 HMCL 启动游戏。在弹出游戏窗口前<b>迅速切回浏览器页面</b>，等待游戏窗口出现后再切回游戏窗口。
 game.crash.reason.illegal_access_error=当前游戏由于某些模组的问题，无法继续运行。\n如果你认识“%1$s”，你可以更新或删除对应模组再试。
 game.crash.reason.install_mixinbootstrap=当前游戏由于缺失 MixinBootstrap，无法继续运行。\n你可以尝试安装 <a href="https://www.curseforge.com/minecraft/mc-mods/mixinbootstrap">MixinBootstrap</a> 解决该问题。若安装后崩溃，可以尝试在该模组的文件名开头添加半角感叹号 (!) 解决。
-game.crash.reason.need_jdk11=当前游戏由于 Java 虚拟机版本不合适，无法继续运行。\n你需要下载安装 <a href="https://bell-sw.com/pages/downloads/#downloads">Java 11</a>，并在“(全局/版本特定) 游戏设置 → 游戏 Java”中将 Java 设置为 11.x 的版本。
+game.crash.reason.need_jdk11=当前游戏由于 Java 版本不合适，无法继续运行。\n你需要下载安装 <a href="https://bell-sw.com/pages/downloads/#downloads">Java 11</a>，并在“(全局/版本特定) 游戏设置 → 游戏 Java”中将 Java 设置为 11.x 的版本。
 game.crash.reason.jdk_9=当前游戏由于 Java 版本过高，无法继续运行。\n你需要下载安装 <a href="https://bell-sw.com/pages/downloads/#downloads">Java 8</a>，并在“(全局/版本特定) 游戏设置 → 游戏 Java”中将 Java 设置为 1.8.x 的版本。
-game.crash.reason.jvm_32bit=当前游戏由于内存分配过大，超过了 32 位 Java 内存限制，无法继续运行。\n如果你的电脑是 64 位系统，请下载安装并更换 64 位 Java。<a href="https://bell-sw.com/pages/downloads/#downloads">下载 Java</a>\n如果你的电脑是 32 位系统，你或许可以重新安装 64 位系统，或换一台新电脑。\n或者，你可以在“(全局/版本特定) 游戏设置 → 游戏内存”中关闭“自动分配内存”，并把内存分配值调整为 1024 MiB 或以下。
+game.crash.reason.jvm_32bit=当前游戏由于内存分配过大，超过了 32 位 Java 虚拟机内存限制，无法继续运行。\n如果你的电脑是 64 位系统，请下载安装并更换 64 位 Java。<a href="https://bell-sw.com/pages/downloads/#downloads">下载 Java</a>\n如果你的电脑是 32 位系统，你或许可以重新安装 64 位系统，或换一台新电脑。\n或者，你可以在“(全局/版本特定) 游戏设置 → 游戏内存”中关闭“自动分配内存”，并把内存分配值调整为 1024 MiB 或以下。
 game.crash.reason.loading_crashed_forge=当前游戏由于模组“%1$s (%2$s)”错误，无法继续运行。\n你可以尝试删除或更新该模组以解决问题。
 game.crash.reason.loading_crashed_fabric=当前游戏由于模组“%1$s”错误，无法继续运行。\n你可以尝试删除或更新该模组以解决问题。
 game.crash.reason.memory_exceeded=当前游戏由于内存分配过大，无法继续运行。\n该问题是由于系统页面文件太小导致的。\n你需要在“(全局/版本特定) 游戏设置”中关闭“自动分配内存”，并将内存分配值调低至游戏能正常启动为止。\n你还可以尝试将虚拟内存设置调整为“自动管理所有驱动器分页文件大小”，<a href="https://docs.hmcl.net/assets/img/hmcl/自动管理所有驱动器分页文件大小.webp">详情</a>。
@@ -469,7 +469,7 @@ game.crash.reason.modmixin_failure=当前游戏由于某些模组注入失败，
 game.crash.reason.night_config_fixes=当前游戏由于 Night Config 库的一些问题，无法继续运行。\n你可以尝试安装 <a href="https://www.curseforge.com/minecraft/mc-mods/night-config-fixes">Night Config Fixes</a> 模组，这或许能帮助你解决这个问题。\n更多详情，可访问该模组的 <a href="https://github.com/Fuzss/nightconfigfixes">GitHub 仓库</a>。
 game.crash.reason.forge_error=Forge/NeoForge 可能已经提供了错误信息。\n你可以查看日志，并根据错误报告中的日志信息进行对应处理。\n如果没有看到报错信息，可以查看错误报告了解错误具体是如何发生的。\n%1$s
 game.crash.reason.mod_resolution0=当前游戏由于一些模组出现问题，无法继续运行。\n你可以查看日志寻找出错模组。
-game.crash.reason.java_version_is_too_high=当前游戏由于 Java 虚拟机版本过高，无法继续运行。\n请在“(全局/版本特定) 游戏设置 → 游戏 Java”中改用较低版本的 Java，然后再启动游戏。\n如果没有，可以从 <a href="https://www.java.com/download/">java.com (Java 8)</a> 或 <a href="https://bell-sw.com/pages/downloads/#downloads">BellSoft Liberica Full JRE (Java 17)</a> 等平台下载、安装一个 (安装完后需重启启动器)。
+game.crash.reason.java_version_is_too_high=当前游戏由于 Java 版本过高，无法继续运行。\n请在“(全局/版本特定) 游戏设置 → 游戏 Java”中改用较低版本的 Java，然后再启动游戏。\n如果没有，可以从 <a href="https://www.java.com/download/">java.com (Java 8)</a> 或 <a href="https://bell-sw.com/pages/downloads/#downloads">BellSoft Liberica Full JRE (Java 17)</a> 等平台下载、安装一个 (安装完后需重启启动器)。
 game.crash.reason.mod_name=当前游戏由于模组文件名称问题，无法继续运行。\n模组文件名称应只使用半角的大小写字母 (Aa~Zz)、数字 (0~9)、横线 (-)、下划线 (_)和点 (.)。\n请到模组文件夹中将所有不合规的模组文件名修改为上述合规字符。
 game.crash.reason.incomplete_forge_installation=当前游戏由于 Forge/NeoForge 安装不完整，无法继续运行。\n请在“版本管理 → 自动安装”中卸载 Forge 并重新安装。
 game.crash.reason.optifine_is_not_compatible_with_forge=当前游戏由于 OptiFine 与当前版本的 Forge 不兼容，导致游戏崩溃。\n点击 <a href="https://zkitefly.github.io/optifine-forge-support-list">此处</a> 查看 OptiFine 所兼容的 Forge 版本，并严格按照对应版本重新安装游戏或在“版本管理 → 自动安装”中更换版本。\n经测试，Forge 版本过高或过低都可能导致崩溃。
@@ -482,11 +482,11 @@ game.crash.reason.modlauncher_8=当前游戏由于你所使用的 Forge 版本�
 game.crash.reason.no_class_def_found_error=当前游戏由于代码不完整，无法继续运行。\n你的游戏可能缺失了某个模组，或者某些模组文件不完整，或者模组与游戏的版本不匹配。\n你可能需要重新安装游戏和模组，或寻求他人帮助。\n缺失：\n%1$s 
 game.crash.reason.no_such_method_error=当前游戏由于代码不完整，无法继续运行。\n你的游戏可能缺失了某个模组，或者某些模组文件不完整，或者模组与游戏的版本不匹配。\n你可能需要重新安装游戏和模组，或寻求他人帮助。
 game.crash.reason.opengl_not_supported=当前游戏由于你的显卡驱动存在问题，无法继续运行。\n原因是 OpenGL 不受支持，你现在是否在远程桌面或者串流模式下？如果是，请直接使用原电脑启动游戏。\n或者尝试升级你的显卡驱动到最新版本后再尝试启动游戏。如果你的电脑同时存在独立显卡和集成显卡，你需要检查游戏是否使用集成显卡启动。如果是，请尝试使用独立显卡启动 HMCL 与游戏。如果仍有问题，你可能需要考虑换一个新显卡或新电脑。
-game.crash.reason.openj9=当前游戏无法在 OpenJ9 虚拟机上运行。请你在“(全局/版本特定) 游戏设置 → 游戏 Java”中更换 Hotspot Java 虚拟机，并重新启动游戏。如果没有下载安装，你可以在网上自行下载。
+game.crash.reason.openj9=当前游戏无法在 OpenJ9 虚拟机上运行。请你在“(全局/版本特定) 游戏设置 → 游戏 Java”中更换为使用 Hotspot 虚拟机的 Java，并重新启动游戏。如果没有下载安装，你可以在网上自行下载。
 game.crash.reason.out_of_memory=当前游戏由于内存不足，无法继续运行。\n这可能是内存分配过小，或者模组数量过多导致的。\n你可以在“(全局/版本特定) 游戏设置 → 游戏内存”中调整内存分配值以允许游戏在更大内存下运行。\n如果仍然出现该错误，你可能需要换一台更好的电脑。
 game.crash.reason.resolution_too_high=当前游戏由于资源包/纹理包分辨率过高，无法继续运行。\n你可以更换一个分辨率更低的资源包/纹理包，或者更换一个显存更大的显卡。
 game.crash.reason.stacktrace=原因未知。请点击日志按钮查看详细信息。\n下面是一些关键词，其中可能包含模组名称，你可以通过搜索的方式查找有关信息。\n%s
-game.crash.reason.too_old_java=当前游戏由于 Java 虚拟机版本过低，无法继续运行。\n你需要在“(全局/版本特定) 游戏设置 → 游戏 Java”中更换 Java %1$s 或更新版本的 Java 虚拟机，并重新启动游戏。如果没有下载安装，你可以点击 <a href="https://learn.microsoft.com/java/openjdk/download">此处</a> 下载 Microsoft JDK。
+game.crash.reason.too_old_java=当前游戏由于 Java 版本过低，无法继续运行。\n你需要在“(全局/版本特定) 游戏设置 → 游戏 Java”中更换 Java %1$s 或更新版本的 Java，并重新启动游戏。如果没有下载安装，你可以点击 <a href="https://learn.microsoft.com/java/openjdk/download">此处</a> 下载 Microsoft JDK。
 game.crash.reason.unknown=原因未知。请点击日志按钮查看详细信息。
 game.crash.reason.unsatisfied_link_error=当前游戏由于缺少本地库，无法继续运行。\n这些本地库缺失：%1$s。\n如果你在“(全局/版本特定) 游戏设置 → 高级设置”中修改了本地库路径选项，请你修改回默认模式。\n如果你正在使用默认模式，请检查游戏文件夹路径是否只包含英文字母、数字和下划线。\n如果是，那么请检查是否为模组或 HMCL 导致了本地库缺失的问题。如果你确定是 HMCL 引起的，建议你向我们反馈。\n<b>对于 Windows 用户，你还可以尝试在“控制面板 → 时钟和区域 → 区域 → 管理 → 更改系统区域设置”中将“当前系统区域设置”修改为“中文(简体，中国大陆)”，并关闭“Beta 版：使用 Unicode UTF-8 提供全球语言支持”选项；</b>\n<b>或将游戏文件夹路径中的所有非英文字符的名称 (例如中文、空格等) 修改为英文字符。</b>\n如果你确实需要自定义本地库路径，你需要保证其中包含缺失的本地库！
 game.crash.title=游戏意外退出
@@ -587,10 +587,10 @@ lang.default=跟随系统语言
 
 launch.advice=%s 是否继续启动？
 launch.advice.multi=检测到以下问题：\n\n%s\n\n这些问题可能导致游戏无法正常启动或影响游戏体验，是否继续启动？\n你可以点击右上角帮助按钮进行求助。
-launch.advice.java.auto=当前选择的 Java 虚拟机版本不满足游戏要求。\n点击“是”即可由 HMCL 来自动选取合适的 Java 虚拟机版本。\n或者你可以在“(全局/版本特定) 游戏设置 → 游戏 Java”中选择一个合适的 Java 虚拟机版本。
+launch.advice.java.auto=当前选择的 Java 版本不满足游戏要求。\n点击“是”即可由 HMCL 来自动选取合适的 Java 版本。\n或者你可以在“(全局/版本特定) 游戏设置 → 游戏 Java”中选择一个合适的 Java 版本。
 launch.advice.java.modded_java_7=Minecraft 1.7.2 及更低版本需要 Java 7 及更低版本。
-launch.advice.corrected=我们已经修复了 Java 虚拟机版本问题。如果你确实希望使用你自定义的 Java 虚拟机，你可以在“(全局/版本特定) 游戏设置 → 高级设置”中往下滑，启用“不检查 JVM 与游戏的兼容性”。
-launch.advice.uncorrected=如果你确实希望使用你自定义的 Java 虚拟机，你可以在“(全局/版本特定) 游戏设置 → 高级设置”中往下滑，启用“不检查 JVM 与游戏的兼容性”。
+launch.advice.corrected=我们已经修复了 Java 版本问题。如果你确实希望使用你自定义的 Java，你可以在“(全局/版本特定) 游戏设置 → 高级设置”中往下滑，启用“不检查 Java 虚拟机与游戏的兼容性”。
+launch.advice.uncorrected=如果你确实希望使用你自定义的 Java，你可以在“(全局/版本特定) 游戏设置 → 高级设置”中往下滑，启用“不检查 Java 虚拟机与游戏的兼容性”。
 launch.advice.different_platform=你正在使用 32 位 Java 启动游戏。建议更换至 64 位 Java。
 launch.advice.forge2760_liteloader=Forge 14.23.5.2760 与 LiteLoader 不兼容。请更新 Forge 至 14.23.5.2773 或更高版本。
 launch.advice.forge28_2_2_optifine=Forge 28.2.2 及更高版本与 OptiFine 不兼容。请降级 Forge 至 28.2.1 或更低版本。
@@ -608,7 +608,7 @@ launch.advice.vanilla_linux_java_8=对于 Linux x86-64 平台，Minecraft 1.12.2
 launch.advice.vanilla_x86.translation=Minecraft 尚未为你的平台提供完善支持，所以可能影响游戏体验或无法启动游戏。\n你可以在 <a href="https://learn.microsoft.com/java/openjdk/download">这里</a> 下载 <b>x86-64</b> 架构的 Java 以获得更完整的体验。
 launch.advice.unknown=由于以下原因，无法继续启动游戏：
 launch.failed=启动失败
-launch.failed.cannot_create_jvm=无法创建 Java 虚拟机。可能是 Java 参数有问题，你可以在“(全局/版本特定) 游戏设置 → 高级设置 → Java 虚拟机设置”中移除所有 Java 虚拟机参数后，尝试再次启动游戏。
+launch.failed.cannot_create_jvm=无法创建 Java 虚拟机。可能是虚拟机参数有问题。你可以在“(全局/版本特定) 游戏设置 → 高级设置 → Java 虚拟机设置”中移除所有虚拟机参数后，尝试再次启动游戏。
 launch.failed.creating_process=启动失败。在创建新进程时发生错误，可能是 Java 路径错误。
 launch.failed.command_too_long=命令长度超过限制，无法创建批处理脚本。请导出为 PowerShell 脚本。
 launch.failed.decompressing_natives=未能解压游戏本地库。
@@ -619,7 +619,7 @@ launch.failed.execution_policy.failed_to_set=设置执行策略失败
 launch.failed.execution_policy.hint=当前执行策略阻止你执行 PowerShell 脚本。\n点击“确定”允许当前用户执行本地 PowerShell 脚本，或点击“取消”保持现状。
 launch.failed.exited_abnormally=游戏非正常退出。请查看日志文件，或联系他人寻求帮助。
 launch.failed.java_version_too_low=你所指定的 Java 版本过低。请重新设置 Java 版本。
-launch.failed.no_accepted_java=找不到适合当前游戏使用的 Java。是否使用默认 Java 启动游戏？点击“是”使用默认 Java 继续启动游戏，\n或者在“(全局/版本特定) 游戏设置 → 游戏 Java”中选择一个合适的 Java 虚拟机版本。\n你可以点击右上角帮助按钮进行求助。
+launch.failed.no_accepted_java=找不到适合当前游戏使用的 Java。是否使用默认 Java 启动游戏？点击“是”使用默认 Java 继续启动游戏，\n或者在“(全局/版本特定) 游戏设置 → 游戏 Java”中选择一个合适的 Java 版本。\n你可以点击右上角帮助按钮进行求助。
 launch.failed.sigkill=游戏被用户或系统强制终止。
 launch.state.dependencies=处理游戏依赖
 launch.state.done=启动完成
@@ -1054,7 +1054,7 @@ settings.advanced.jvm=Java 虚拟机设置
 settings.advanced.jvm_args=Java 虚拟机参数
 settings.advanced.jvm_args.prompt=\  · 若在“Java 虚拟机参数”输入的参数与默认参数相同，则不会添加；\n\
   \  · 若在“Java 虚拟机参数”输入任何 GC 参数，默认参数的 G1 参数会被禁用；\n\
-  \  · 开启下方“不添加默认的 JVM 参数”可在启动游戏时不添加默认参数。
+  \  · 开启下方“不添加默认的 Java 虚拟机参数”可在启动游戏时不添加默认参数。
 settings.advanced.launcher_visibility.close=游戏启动后结束启动器
 settings.advanced.launcher_visibility.hide=游戏启动后隐藏启动器
 settings.advanced.launcher_visibility.hide_and_reopen=隐藏启动器并在游戏结束后重新打开


### PR DESCRIPTION
- For Chinese, replace the relevant term with 'Java 虚拟机/虛擬機'.
- For other languages, replace the relevant term with 'JVM'.
- Replace 'JVM' with 'Java' in some cases where 'JVM' is inappropriate.