### PR TITLE
fix(ui): refine PromptDialogPane

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/PromptDialogPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/PromptDialogPane.java
@@ -49,6 +49,7 @@ public class PromptDialogPane extends DialogPane {
     public PromptDialogPane(Builder builder) {
         this.builder = builder;
         setTitle(builder.title);
+        setPrefWidth(560);
 
         GridPane body = new GridPane();
         body.setVgap(8);
@@ -72,13 +73,13 @@ public class PromptDialogPane extends DialogPane {
                 if (StringUtils.isNotBlank(question.question.get())) {
                     body.addRow(rowIndex++, new Label(question.question.get()), textField);
                 } else {
-                    GridPane.setColumnSpan(textField, 2);
+                    GridPane.setColumnSpan(textField, 1);
                     body.addRow(rowIndex++, textField);
                 }
                 GridPane.setMargin(textField, new Insets(0, 0, 20, 0));
             } else if (question instanceof Builder.BooleanQuestion) {
                 HBox hBox = new HBox();
-                GridPane.setColumnSpan(hBox, 2);
+                GridPane.setColumnSpan(hBox, 1);
                 JFXCheckBox checkBox = new JFXCheckBox();
                 hBox.getChildren().setAll(checkBox);
                 HBox.setMargin(checkBox, new Insets(0, 0, 0, -10));
@@ -95,12 +96,12 @@ public class PromptDialogPane extends DialogPane {
                 if (StringUtils.isNotBlank(question.question.get())) {
                     body.addRow(rowIndex++, new Label(question.question.get()), comboBox);
                 } else {
-                    GridPane.setColumnSpan(comboBox, 2);
+                    GridPane.setColumnSpan(comboBox, 1);
                     body.addRow(rowIndex++, comboBox);
                 }
             } else if (question instanceof Builder.HintQuestion) {
                 HintPane pane = new HintPane();
-                GridPane.setColumnSpan(pane, 2);
+                GridPane.setColumnSpan(pane, 1);
                 pane.textProperty().bind(question.question);
                 body.addRow(rowIndex++, pane);
             }


### PR DESCRIPTION
- Limit the dialog width to avoid too long a width
- Avoid accidental blank line in the information box (That blue bg box)

<details>
<summary>Preview</summary>

<br/>

| Before | After |
|--------|--------|
| ![image-1](https://github.com/user-attachments/assets/90ea7af4-36d3-4a9f-8c0e-95b3d3e37686) | ![image-2](https://github.com/user-attachments/assets/4cdc97cc-aa57-4568-a6b8-9d83f44e38a6) |
| ![image-3](https://github.com/user-attachments/assets/4c29c8eb-9ec7-4219-9028-06b26473bf81) | ![image-4](https://github.com/user-attachments/assets/bf53a367-aad8-48c1-b953-fb57cac95915) |
| ![image-5](https://github.com/user-attachments/assets/6502db7e-f434-4e12-8e6a-2918f3b58efd) | ![image-6](https://github.com/user-attachments/assets/34ab4cfa-e89f-49f6-9b54-df0d0b78263e) |

</details>