### PR TITLE
Fix #3694: 显示对话框时隐藏焦点

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/JFXDialogPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/JFXDialogPane.java
@@ -44,7 +44,6 @@ public final class JFXDialogPane extends StackPane {
         stack.add(node);
         getChildren().setAll(node);
 
-
         LOG.info(this + " " + stack);
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/JFXDialogPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/JFXDialogPane.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 
 import static org.jackhuang.hmcl.util.logging.Logger.LOG;
 
-public final class JFXDialogPane extends StackPane {
+public class JFXDialogPane extends StackPane {
     private final ArrayList<Node> stack = new ArrayList<>();
 
     public int size() {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/JFXDialogPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/JFXDialogPane.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 
 import static org.jackhuang.hmcl.util.logging.Logger.LOG;
 
-public class JFXDialogPane extends StackPane {
+public final class JFXDialogPane extends StackPane {
     private final ArrayList<Node> stack = new ArrayList<>();
 
     public int size() {
@@ -43,6 +43,7 @@ public class JFXDialogPane extends StackPane {
     public void push(Node node) {
         stack.add(node);
         getChildren().setAll(node);
+
 
         LOG.info(this + " " + stack);
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
@@ -397,21 +397,22 @@ public class DecoratorController {
         node.getProperties().put(PROPERTY_DIALOG_CLOSE_HANDLER, handler);
         node.addEventHandler(DialogCloseEvent.CLOSE, handler);
 
-        if (node instanceof DialogAware) {
-            DialogAware dialogAware = (DialogAware) node;
-            if (dialog.isVisible()) {
-                dialogAware.onDialogShown();
-            } else {
-                dialog.visibleProperty().addListener(new ChangeListener<Boolean>() {
-                    @Override
-                    public void changed(ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue) {
-                        if (newValue) {
-                            dialogAware.onDialogShown();
-                            observable.removeListener(this);
-                        }
+        if (dialog.isVisible()) {
+            dialog.requestFocus();
+            if (node instanceof DialogAware)
+                ((DialogAware) node).onDialogShown();
+        } else {
+            dialog.visibleProperty().addListener(new ChangeListener<Boolean>() {
+                @Override
+                public void changed(ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue) {
+                    if (newValue) {
+                        dialog.requestFocus();
+                        if (node instanceof DialogAware)
+                            ((DialogAware) node).onDialogShown();
+                        observable.removeListener(this);
                     }
-                });
-            }
+                }
+            });
         }
     }
 


### PR DESCRIPTION
打开对话框时应当隐藏控件焦点，仅当用户使用 TAB 开始遍历时才应显示焦点。