### PR TITLE
消除 JEP 498 引入的弃用警告

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/Main.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Main.java
@@ -32,6 +32,8 @@ import javax.net.ssl.TrustManagerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -71,6 +73,7 @@ public final class Main {
         checkJavaFX();
         verifyJavaFX();
         addEnableNativeAccess();
+        enableUnsafeMemoryAccess();
 
         Launcher.main(args);
     }
@@ -130,6 +133,20 @@ public final class Main {
             } catch (ClassNotFoundException e) {
                 e.printStackTrace(System.err);
                 showErrorAndExit(i18n("fatal.javafx.incomplete"));
+            }
+        }
+    }
+
+    private static void enableUnsafeMemoryAccess() {
+        // https://openjdk.org/jeps/498
+        if (JavaRuntime.CURRENT_VERSION == 24 || JavaRuntime.CURRENT_VERSION == 25) {
+            try {
+                Class<?> clazz = Class.forName("sun.misc.Unsafe");
+                Method trySetMemoryAccessWarned = clazz.getDeclaredMethod("trySetMemoryAccessWarned");
+                trySetMemoryAccessWarned.setAccessible(true);
+                trySetMemoryAccessWarned.invoke(null);
+            } catch (Throwable e) {
+                e.printStackTrace(System.err);
             }
         }
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/Main.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Main.java
@@ -32,7 +32,6 @@ import javax.net.ssl.TrustManagerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;


### PR DESCRIPTION
当 HMCL 运行在 JDK 24 上时，由于 [JEP 498](https://openjdk.org/jeps/498)，JavaFX 会引发弃用警告。

本 PR 为 JDK 24/25 抑制了此警告。未来 JavaFX 解决该警告后可以移除相关代码。