### PR TITLE
Fix #3627 离线账户皮肤界面选择本地皮肤后，切换模型不会使左侧 3D 预览即时生效

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
@@ -154,7 +154,7 @@ public class OfflineAccountSkinPane extends StackPane {
                                     result.getCape() != null ? result.getCape().getImage() : null);
                         }
                     }).start();
-        }, skinItem.selectedDataProperty(), cslApiField.textProperty(), skinSelector.valueProperty(), capeSelector.valueProperty());
+        }, skinItem.selectedDataProperty(), cslApiField.textProperty(), modelCombobox.valueProperty(), skinSelector.valueProperty(), capeSelector.valueProperty());
 
         FXUtils.onChangeAndOperate(skinItem.selectedDataProperty(), selectedData -> {
             GridPane gridPane = new GridPane();


### PR DESCRIPTION
Fix #https://github.com/HMCL-dev/HMCL/issues/3627