### PR TITLE
Fix: HMCL 更新界面有俩进度条

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateHandler.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateHandler.java
@@ -113,9 +113,8 @@ public final class UpdateHandler {
 
             Task<?> task = new HMCLDownloadTask(version, downloaded);
 
-            TaskExecutor executor = task.executor(false);
+            TaskExecutor executor = task.executor();
             Controllers.taskDialog(executor, i18n("message.downloading"), TaskCancellationAction.NORMAL);
-            executor.start();
             thread(() -> {
                 boolean success = executor.test();
 


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/commit/a2300279746937fa8ceb2f870183de0f8f57c85b#diff-a7bbca75803f7a45bfd7ada7c0005b4ed6609a908c1abeb72d54c30d693a89b7R107

`start` 和 `test` 都会发起任务，导致进度条被重复绘制。