### PR TITLE
Gradle run task 应使用 HMCL_JAVA_HOME 所指向的 Java

### DIFF
--- a/HMCL/build.gradle.kts
+++ b/HMCL/build.gradle.kts
@@ -251,8 +251,15 @@ tasks.create<JavaExec>("run") {
     val vmOptions = parseToolOptions(System.getenv("HMCL_JAVA_OPTS"))
     jvmArgs(vmOptions)
 
+    val hmclJavaHome = System.getenv("HMCL_JAVA_HOME")
+    if (hmclJavaHome != null) {
+        this.executable(file(hmclJavaHome).resolve("bin")
+            .resolve(if (System.getProperty("os.name").lowercase().startsWith("windows")) "java.exe" else "java"))
+    }
+
     doFirst {
-        logger.quiet("HMCL_JAVA_OPTS: $vmOptions")
+        logger.quiet("HMCL_JAVA_OPTS: {}", vmOptions)
+        logger.quiet("HMCL_JAVA_HOME: {}", hmclJavaHome ?: System.getProperty("java.home"))
     }
 }
 


### PR DESCRIPTION
这样便于开发时切换测试用 Java。尤其是在 #3803 完成后，这将成为开发者使用 Java 8 测试启动器的首选途径。