### PR TITLE
默认限制离线账户功能

### DIFF
--- a/HMCL/build.gradle.kts
+++ b/HMCL/build.gradle.kts
@@ -190,9 +190,9 @@ tasks.build {
     dependsOn(makeExecutables)
 }
 
-fun parseToolOptions(options: String?): List<String> {
+fun parseToolOptions(options: String?): MutableList<String> {
     if (options == null)
-        return listOf()
+        return mutableListOf()
 
     val builder = StringBuilder()
     val result = mutableListOf<String>()
@@ -249,6 +249,9 @@ tasks.create<JavaExec>("run") {
     workingDir = rootProject.rootDir
 
     val vmOptions = parseToolOptions(System.getenv("HMCL_JAVA_OPTS"))
+    if (vmOptions.none { it.startsWith("-Dhmcl.offline.auth.restricted=") })
+        vmOptions += "-Dhmcl.offline.auth.restricted=false"
+
     jvmArgs(vmOptions)
 
     val hmclJavaHome = System.getenv("HMCL_JAVA_HOME")

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Accounts.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Accounts.java
@@ -291,15 +291,15 @@ public final class Accounts {
             accounts.addListener(new ListChangeListener<Account>() {
                 @Override
                 public void onChanged(Change<? extends Account> change) {
-                    while (change.next())
-                        if (change.wasAdded())
-                            for (Account account : change.getAddedSubList()) {
-                                if (account instanceof MicrosoftAccount) {
-                                    accounts.removeListener(this);
-                                    globalConfig().setEnableOfflineAccount(true);
-                                    return;
-                                }
+                    while (change.next()) {
+                        for (Account account : change.getAddedSubList()) {
+                            if (account instanceof MicrosoftAccount) {
+                                accounts.removeListener(this);
+                                globalConfig().setEnableOfflineAccount(true);
+                                return;
                             }
+                        }
+                    }
                 }
             });
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Accounts.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Accounts.java
@@ -291,12 +291,15 @@ public final class Accounts {
             accounts.addListener(new ListChangeListener<Account>() {
                 @Override
                 public void onChanged(Change<? extends Account> change) {
-                    for (Account account : change.getAddedSubList()) {
-                        if (account instanceof MicrosoftAccount) {
-                            accounts.removeListener(this);
-                            globalConfig().setEnableOfflineAccount(true);
-                        }
-                    }
+                    while (change.next())
+                        if (change.wasAdded())
+                            for (Account account : change.getAddedSubList()) {
+                                if (account instanceof MicrosoftAccount) {
+                                    accounts.removeListener(this);
+                                    globalConfig().setEnableOfflineAccount(true);
+                                    return;
+                                }
+                            }
                 }
             });
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Accounts.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Accounts.java
@@ -22,6 +22,7 @@ import javafx.beans.Observable;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import org.jackhuang.hmcl.Metadata;
 import org.jackhuang.hmcl.auth.*;
@@ -50,6 +51,7 @@ import java.util.*;
 import static java.util.stream.Collectors.toList;
 import static javafx.collections.FXCollections.observableArrayList;
 import static org.jackhuang.hmcl.setting.ConfigHolder.config;
+import static org.jackhuang.hmcl.setting.ConfigHolder.globalConfig;
 import static org.jackhuang.hmcl.ui.FXUtils.onInvalidating;
 import static org.jackhuang.hmcl.util.Lang.immutableListOf;
 import static org.jackhuang.hmcl.util.Lang.mapOf;
@@ -276,6 +278,27 @@ public final class Accounts {
         if (selected == null && !accounts.isEmpty()) {
             selected = accounts.get(0);
         }
+
+        if (!globalConfig().isEnableOfflineAccount())
+            for (Account account : accounts) {
+                if (account instanceof MicrosoftAccount) {
+                    globalConfig().setEnableOfflineAccount(true);
+                    break;
+                }
+            }
+
+        if (!globalConfig().isEnableOfflineAccount())
+            accounts.addListener(new ListChangeListener<Account>() {
+                @Override
+                public void onChanged(Change<? extends Account> change) {
+                    for (Account account : change.getAddedSubList()) {
+                        if (account instanceof MicrosoftAccount) {
+                            accounts.removeListener(this);
+                            globalConfig().setEnableOfflineAccount(true);
+                        }
+                    }
+                }
+            });
 
         selectedAccount.set(selected);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/GlobalConfig.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/GlobalConfig.java
@@ -21,7 +21,9 @@ import com.google.gson.*;
 import com.google.gson.annotations.JsonAdapter;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableSet;
@@ -52,6 +54,8 @@ public final class GlobalConfig implements Observable {
     private final IntegerProperty platformPromptVersion = new SimpleIntegerProperty();
 
     private final IntegerProperty logRetention = new SimpleIntegerProperty();
+
+    private final BooleanProperty enableOfflineAccount = new SimpleBooleanProperty(false);
 
     private final ObservableSet<String> userJava = FXCollections.observableSet(new LinkedHashSet<>());
 
@@ -115,6 +119,18 @@ public final class GlobalConfig implements Observable {
         this.logRetention.set(logRetention);
     }
 
+    public boolean isEnableOfflineAccount() {
+        return enableOfflineAccount.get();
+    }
+
+    public BooleanProperty enableOfflineAccountProperty() {
+        return enableOfflineAccount;
+    }
+
+    public void setEnableOfflineAccount(boolean value) {
+        enableOfflineAccount.set(value);
+    }
+
     public ObservableSet<String> getUserJava() {
         return userJava;
     }
@@ -129,7 +145,8 @@ public final class GlobalConfig implements Observable {
                 "platformPromptVersion",
                 "logRetention",
                 "userJava",
-                "disabledJava"
+                "disabledJava",
+                "enableOfflineAccount"
         ));
 
         @Override
@@ -142,6 +159,9 @@ public final class GlobalConfig implements Observable {
             jsonObject.add("agreementVersion", context.serialize(src.getAgreementVersion()));
             jsonObject.add("platformPromptVersion", context.serialize(src.getPlatformPromptVersion()));
             jsonObject.add("logRetention", context.serialize(src.getLogRetention()));
+            if (src.enableOfflineAccount.get())
+                jsonObject.addProperty("enableOfflineAccount", true);
+
             if (!src.getUserJava().isEmpty())
                 jsonObject.add("userJava", context.serialize(src.getUserJava()));
 
@@ -165,6 +185,7 @@ public final class GlobalConfig implements Observable {
             config.setAgreementVersion(Optional.ofNullable(obj.get("agreementVersion")).map(JsonElement::getAsInt).orElse(0));
             config.setPlatformPromptVersion(Optional.ofNullable(obj.get("platformPromptVersion")).map(JsonElement::getAsInt).orElse(0));
             config.setLogRetention(Optional.ofNullable(obj.get("logRetention")).map(JsonElement::getAsInt).orElse(20));
+            config.setEnableOfflineAccount(Optional.ofNullable(obj.get("enableOfflineAccount")).map(JsonElement::getAsBoolean).orElse(false));
 
             JsonElement userJava = obj.get("userJava");
             if (userJava != null && userJava.isJsonArray()) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
@@ -185,9 +185,9 @@ public final class AccountListPage extends DecoratorAnimatedPage implements Deco
 
                         holder = FXUtils.onWeakChange(RESTRICTED, value -> {
                             if (!value) {
+                                holder = null;
                                 offlineItem.setDisable(false);
                                 boxAuthServers.setDisable(false);
-
                                 boxMethods.getChildren().setAll(title, microsoftItem, offlineItem, boxAuthServers);
                             }
                         });

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
@@ -143,7 +143,6 @@ public final class AccountListPage extends DecoratorAnimatedPage implements Deco
                         item.getStyleClass().add("navigation-drawer-item");
                         item.setLeftGraphic(wrap(SVG.DRESSER));
                         item.setOnAction(e -> Controllers.dialog(new CreateAccountPane(server)));
-                        item.disableProperty().bind(RESTRICTED);
 
                         JFXButton btnRemove = new JFXButton();
                         btnRemove.setOnAction(e -> {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
@@ -72,7 +72,7 @@ public final class AccountListPage extends DecoratorAnimatedPage implements Deco
                 }
             }
 
-            if (!RESTRICTED.get()) {
+            if (RESTRICTED.get()) {
                 Accounts.getAccounts().addListener(new InvalidationListener() {
                     @Override
                     public void invalidated(Observable observable) {
@@ -142,7 +142,6 @@ public final class AccountListPage extends DecoratorAnimatedPage implements Deco
                     microsoftItem.setTitle(i18n("account.methods.microsoft"));
                     microsoftItem.setLeftGraphic(wrap(SVG.MICROSOFT));
                     microsoftItem.setOnAction(e -> Controllers.dialog(new CreateAccountPane(Accounts.FACTORY_MICROSOFT)));
-                    boxMethods.getChildren().add(microsoftItem);
 
                     AdvancedListItem offlineItem = new AdvancedListItem();
                     offlineItem.getStyleClass().add("navigation-drawer-item");
@@ -200,15 +199,15 @@ public final class AccountListPage extends DecoratorAnimatedPage implements Deco
                         boxMethods.getChildren().setAll(title, microsoftItem, wrapper);
 
                         holder = FXUtils.onWeakChange(RESTRICTED, value -> {
-                            if (value) {
+                            if (!value) {
                                 offlineItem.setDisable(false);
                                 boxAuthServers.setDisable(false);
 
-                                boxMethods.getChildren().addAll(title, microsoftItem, offlineItem,  boxAuthServers);
+                                boxMethods.getChildren().setAll(title, microsoftItem, offlineItem,  boxAuthServers);
                             }
                         });
                     } else {
-                        boxMethods.getChildren().addAll(title, microsoftItem, offlineItem, boxAuthServers);
+                        boxMethods.getChildren().setAll(title, microsoftItem, offlineItem, boxAuthServers);
                     }
                 }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
@@ -151,7 +151,6 @@ public final class AccountListPage extends DecoratorAnimatedPage implements Deco
                     offlineItem.setOnAction(e -> Controllers.dialog(new CreateAccountPane(Accounts.FACTORY_OFFLINE)));
 
                     VBox boxAuthServers = new VBox();
-
                     authServerItems = MappedObservableList.create(skinnable.authServersProperty(), server -> {
                         AdvancedListItem item = new AdvancedListItem();
                         item.getStyleClass().add("navigation-drawer-item");

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
@@ -203,7 +203,7 @@ public final class AccountListPage extends DecoratorAnimatedPage implements Deco
                                 offlineItem.setDisable(false);
                                 boxAuthServers.setDisable(false);
 
-                                boxMethods.getChildren().setAll(title, microsoftItem, offlineItem,  boxAuthServers);
+                                boxMethods.getChildren().setAll(title, microsoftItem, offlineItem, boxAuthServers);
                             }
                         });
                     } else {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/CreateAccountPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/CreateAccountPane.java
@@ -108,12 +108,17 @@ public class CreateAccountPane extends JFXDialogLayout implements DialogAware {
 
     public CreateAccountPane(AccountFactory<?> factory) {
         if (factory == null) {
-            showMethodSwitcher = true;
-            String preferred = config().getPreferredLoginType();
-            try {
-                factory = Accounts.getAccountFactory(preferred);
-            } catch (IllegalArgumentException e) {
-                factory = Accounts.FACTORY_OFFLINE;
+            if (AccountListPage.RESTRICTED.get()) {
+                showMethodSwitcher = false;
+                factory = Accounts.FACTORY_MICROSOFT;
+            } else {
+                showMethodSwitcher = true;
+                String preferred = config().getPreferredLoginType();
+                try {
+                    factory = Accounts.getAccountFactory(preferred);
+                } catch (IllegalArgumentException e) {
+                    factory = Accounts.FACTORY_OFFLINE;
+                }
             }
         } else {
             showMethodSwitcher = false;

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -88,6 +88,7 @@ account.login.skip=Log in offline
 account.login.retry=Retry
 account.login.refresh=Log in again
 account.login.refresh.microsoft.hint=You need to log in to your Microsoft account again because the account authorization is invalid.
+account.login.restricted=Sign in to your Microsoft account to enable this feature
 account.logout=Logout
 account.register=Register
 account.manage=Account List

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -91,6 +91,7 @@ account.login.skip=跳過重新整理帳戶
 account.login.retry=再次重新整理帳戶
 account.login.refresh=重新登入
 account.login.refresh.microsoft.hint=由於帳戶授權失效，你需要重新加入 Microsoft 帳戶
+account.login.restricted=登入微軟帳戶以啟用此功能
 account.logout=登出
 account.register=註冊
 account.manage=帳戶清單

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -92,6 +92,7 @@ account.login.skip=跳过账户刷新
 account.login.retry=再次刷新账户
 account.login.refresh=重新登录
 account.login.refresh.microsoft.hint=由于账户授权失效，你需要重新添加微软账户。
+account.login.restricted=登录微软账户以启用此功能
 account.logout=登出
 account.register=注册
 account.manage=账户列表


### PR DESCRIPTION
当用户未登录微软账户时，禁止用户使用离线账户和外置登录。

默认情况下中国大陆用户不会受到此限制，但用户可以通过 JVM 选项 `-Dhmcl.offline.auth.restricted=true` 主动启用此限制。