### PR TITLE
Fix #3825 修复 NeoForge 愚人节版本无法正常解析的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/neoforge/NeoForgeOfficialVersionList.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/neoforge/NeoForgeOfficialVersionList.java
@@ -3,7 +3,6 @@ package org.jackhuang.hmcl.download.neoforge;
 import org.jackhuang.hmcl.download.DownloadProvider;
 import org.jackhuang.hmcl.download.VersionList;
 import org.jackhuang.hmcl.util.io.HttpRequest;
-import org.jackhuang.hmcl.util.logging.Logger;
 
 import java.util.Collections;
 import java.util.List;
@@ -11,6 +10,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static org.jackhuang.hmcl.util.Lang.wrap;
+import static org.jackhuang.hmcl.util.logging.Logger.LOG;
 
 public final class NeoForgeOfficialVersionList extends VersionList<NeoForgeRemoteVersion> {
     private final DownloadProvider downloadProvider;
@@ -68,7 +68,7 @@ public final class NeoForgeOfficialVersionList extends VersionList<NeoForgeRemot
                             mcVersion = "1." + version.substring(0, Integer.parseInt(version.substring(si1 + 1, si2)) == 0 ? si1 : si2);
                         }
                     } catch (RuntimeException e) {
-                        Logger.LOG.warning(String.format("Cannot parse NeoForge version %s for cracking its mc version.", version), e);
+                        LOG.warning(String.format("Cannot parse NeoForge version %s for cracking its mc version.", version), e);
                         continue;
                     }
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/neoforge/NeoForgeOfficialVersionList.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/neoforge/NeoForgeOfficialVersionList.java
@@ -3,6 +3,7 @@ package org.jackhuang.hmcl.download.neoforge;
 import org.jackhuang.hmcl.download.DownloadProvider;
 import org.jackhuang.hmcl.download.VersionList;
 import org.jackhuang.hmcl.util.io.HttpRequest;
+import org.jackhuang.hmcl.util.logging.Logger;
 
 import java.util.Collections;
 import java.util.List;
@@ -56,8 +57,18 @@ public final class NeoForgeOfficialVersionList extends VersionList<NeoForgeRemot
                 }
 
                 for (String version : results[1].versions) {
-                    int si1 = version.indexOf('.'), si2 = version.indexOf('.', version.indexOf('.') + 1);
-                    String mcVersion = "1." + version.substring(0, Integer.parseInt(version.substring(si1 + 1, si2)) == 0 ? si1 : si2);
+                    String mcVersion;
+                    if (version.equals("0.25w14craftmine.3-beta")) {
+                        mcVersion = "25w14craftmine";
+                    } else {
+                        try {
+                            int si1 = version.indexOf('.'), si2 = version.indexOf('.', version.indexOf('.') + 1);
+                            mcVersion = "1." + version.substring(0, Integer.parseInt(version.substring(si1 + 1, si2)) == 0 ? si1 : si2);
+                        } catch (RuntimeException e) {
+                            Logger.LOG.warning(String.format("Cannot parse NeoForge version %s for cracking its mc version.", version), e);
+                            continue;
+                        }
+                    }
 
                     versions.put(mcVersion, new NeoForgeRemoteVersion(
                             mcVersion, NeoForgeRemoteVersion.normalize(version),

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/neoforge/NeoForgeOfficialVersionList.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/neoforge/NeoForgeOfficialVersionList.java
@@ -58,16 +58,18 @@ public final class NeoForgeOfficialVersionList extends VersionList<NeoForgeRemot
 
                 for (String version : results[1].versions) {
                     String mcVersion;
-                    if (version.equals("0.25w14craftmine.3-beta")) {
-                        mcVersion = "25w14craftmine";
-                    } else {
-                        try {
-                            int si1 = version.indexOf('.'), si2 = version.indexOf('.', version.indexOf('.') + 1);
+
+                    try {
+                        int si1 = version.indexOf('.'), si2 = version.indexOf('.', version.indexOf('.') + 1);
+                        int majorVersion = Integer.parseInt(version.substring(0, si1));
+                        if (majorVersion == 0) { // Snapshot version.
+                            mcVersion = version.substring(si1 + 1, si2);
+                        } else {
                             mcVersion = "1." + version.substring(0, Integer.parseInt(version.substring(si1 + 1, si2)) == 0 ? si1 : si2);
-                        } catch (RuntimeException e) {
-                            Logger.LOG.warning(String.format("Cannot parse NeoForge version %s for cracking its mc version.", version), e);
-                            continue;
                         }
+                    } catch (RuntimeException e) {
+                        Logger.LOG.warning(String.format("Cannot parse NeoForge version %s for cracking its mc version.", version), e);
+                        continue;
                     }
 
                     versions.put(mcVersion, new NeoForgeRemoteVersion(


### PR DESCRIPTION
介于 0.25w14craftmine.3-beta 是 NF 的第一个愚人节版本，我们完全可以直接 ———— 特判！