### PR TITLE
Bump Gson to 2.13.0

### DIFF
--- a/HMCLCore/build.gradle.kts
+++ b/HMCLCore/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
     api("org.glavo.kala:kala-compress-archivers-zip:$kalaCompressVersion")
     api("org.glavo.kala:kala-compress-archivers-tar:$kalaCompressVersion")
     api("org.glavo:simple-png-javafx:0.3.0")
-    api("com.google.code.gson:gson:2.12.1")
+    api("com.google.code.gson:gson:2.13.0")
     api("com.moandjiezana.toml:toml4j:0.7.2")
     api("org.tukaani:xz:1.10")
     api("org.hildan.fxgson:fx-gson:5.0.0")


### PR DESCRIPTION
https://github.com/google/gson/releases/tag/gson-parent-2.13.0