### PR TITLE
自动安装页面隐藏 `mcbbs` 项

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/InstallerListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/InstallerListPage.java
@@ -114,6 +114,7 @@ public class InstallerListPage extends ListPageBase<InstallerItem> implements Ve
             for (LibraryAnalyzer.LibraryMark mark : analyzer) {
                 String libraryId = mark.getLibraryId();
                 String libraryVersion = mark.getLibraryVersion();
+                if("mcbbs".equals(libraryId)) continue;
 
                 // we have done this library above.
                 if (LibraryAnalyzer.LibraryType.fromPatchId(libraryId) != null)


### PR DESCRIPTION
mcbbs 格式的整合包安装后自动安装页面会出现 `mcbbs` 项
放置在这里没啥意义，而且会让玩家产生困惑，并且和其他项不搭，比较丑

![PixPin_2025-04-19_08-53-27](https://github.com/user-attachments/assets/ba3b55cd-a23c-40a1-a7bb-f80394383bd9)
