### PR TITLE
Fix #3864 游戏内容下载的分页按钮不重置

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadListPage.java
@@ -454,9 +454,7 @@ public class DownloadListPage extends Control implements DecoratorPage, VersionP
                     });
 
                     FXUtils.onChange(control.pageOffset, pageCountN -> {
-                        if (changeButton.value != null) {
-                            changeButton.value.run();
-                        }
+                        changeButton.value.run();
                     });
 
                     Pane placeholder = new Pane();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadListPage.java
@@ -453,6 +453,12 @@ public class DownloadListPage extends Control implements DecoratorPage, VersionP
                         changeButton.value.run();
                     });
 
+                    FXUtils.onChange(control.pageOffset, pageCountN -> {
+                        if (changeButton.value != null) {
+                            changeButton.value.run();
+                        }
+                    });
+
                     Pane placeholder = new Pane();
                     HBox.setHgrow(placeholder, Priority.SOMETIMES);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadListPage.java
@@ -453,7 +453,7 @@ public class DownloadListPage extends Control implements DecoratorPage, VersionP
                         changeButton.value.run();
                     });
 
-                    FXUtils.onChange(control.pageOffset, pageCountN -> {
+                    FXUtils.onChange(control.pageOffset, pageOffsetN -> {
                         changeButton.value.run();
                     });
 


### PR DESCRIPTION
经过实测，原issue复现不需要指定游戏版本，只需要在搜索结果的基础上再搜索就可以复现了

下面是视频，左修复后，右最新HMCL预览版：

https://github.com/user-attachments/assets/ad92c7e2-186d-4e6f-98f3-c911f0b59eda

