### PR TITLE
Fix #3865 游戏版本名称在游戏版本更换时报红

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
@@ -1,0 +1,135 @@
+package org.jackhuang.hmcl.ui.download;
+
+import com.jfoenix.controls.JFXButton;
+import com.jfoenix.controls.JFXTextField;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.*;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
+import org.jackhuang.hmcl.download.DownloadProvider;
+import org.jackhuang.hmcl.download.LibraryAnalyzer;
+import org.jackhuang.hmcl.ui.Controllers;
+import javafx.scene.layout.BorderPane;
+import org.jackhuang.hmcl.ui.FXUtils;
+import org.jackhuang.hmcl.ui.InstallerItem;
+import org.jackhuang.hmcl.ui.construct.MessageDialogPane;
+import org.jackhuang.hmcl.ui.wizard.WizardController;
+import org.jackhuang.hmcl.ui.wizard.WizardPage;
+
+import java.util.Map;
+
+import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
+
+public abstract class AbstractInstallersPage extends Control implements WizardPage {
+    protected final WizardController controller;
+
+    protected InstallerItem.InstallerItemGroup group;
+    protected JFXTextField txtName = new JFXTextField();
+
+    protected BooleanProperty installable = new SimpleBooleanProperty();
+
+    public AbstractInstallersPage(WizardController controller, String gameVersion, DownloadProvider downloadProvider) {
+        this.controller = controller;
+        this.group = new InstallerItem.InstallerItemGroup(gameVersion, getInstallerItemStyle());
+
+        for (InstallerItem library : group.getLibraries()) {
+            String libraryId = library.getLibraryId();
+            if (libraryId.equals(LibraryAnalyzer.LibraryType.MINECRAFT.getPatchId())) continue;
+            library.setOnInstall(() -> {
+                if (LibraryAnalyzer.LibraryType.FABRIC_API.getPatchId().equals(libraryId)) {
+                    Controllers.dialog(i18n("install.installer.fabric-api.warning"), i18n("message.warning"), MessageDialogPane.MessageType.WARNING);
+                }
+
+                if (!(library.resolvedStateProperty().get() instanceof InstallerItem.IncompatibleState))
+                    controller.onNext(new VersionsPage(controller, i18n("install.installer.choose", i18n("install.installer." + libraryId)), gameVersion, downloadProvider, libraryId, () -> controller.onPrev(false)));
+            });
+            library.setOnRemove(() -> {
+                controller.getSettings().remove(libraryId);
+                reload();
+            });
+        }
+    }
+
+    protected InstallerItem.Style getInstallerItemStyle() {
+        return InstallerItem.Style.CARD;
+    }
+
+    @Override
+    public abstract String getTitle();
+
+    protected abstract void reload();
+
+    @Override
+    public void onNavigate(Map<String, Object> settings) {
+        reload();
+    }
+
+    @Override
+    public abstract void cleanup(Map<String, Object> settings);
+
+    protected abstract void onInstall();
+
+    @Override
+    protected Skin<?> createDefaultSkin() {
+        return new InstallersPage.InstallersPageSkin(this);
+    }
+
+    protected static class InstallersPageSkin extends SkinBase<AbstractInstallersPage> {
+        /**
+         * Constructor for all SkinBase instances.
+         *
+         * @param control The control for which this Skin should attach to.
+         */
+        protected InstallersPageSkin(AbstractInstallersPage control) {
+            super(control);
+
+            BorderPane root = new BorderPane();
+            root.setPadding(new Insets(16));
+
+            {
+                HBox versionNamePane = new HBox(8);
+                versionNamePane.getStyleClass().add("card-non-transparent");
+                versionNamePane.setStyle("-fx-padding: 20 8 20 16");
+                versionNamePane.setAlignment(Pos.CENTER_LEFT);
+
+                control.txtName.setMaxWidth(300);
+                versionNamePane.getChildren().setAll(new Label(i18n("version.name")), control.txtName);
+                root.setTop(versionNamePane);
+            }
+
+            {
+                InstallerItem[] libraries = control.group.getLibraries();
+
+                FlowPane libraryPane = new FlowPane(libraries);
+                libraryPane.setVgap(16);
+                libraryPane.setHgap(16);
+
+                if (libraries.length <= 8) {
+                    BorderPane.setMargin(libraryPane, new Insets(16, 0, 16, 0));
+                    root.setCenter(libraryPane);
+                } else {
+                    ScrollPane scrollPane = new ScrollPane(libraryPane);
+                    scrollPane.setFitToWidth(true);
+                    scrollPane.setFitToHeight(true);
+                    BorderPane.setMargin(scrollPane, new Insets(16, 0, 16, 0));
+                    root.setCenter(scrollPane);
+                }
+            }
+
+            {
+                JFXButton installButton = FXUtils.newRaisedButton(i18n("button.install"));
+                installButton.disableProperty().bind(control.installable.not());
+                installButton.setPrefWidth(100);
+                installButton.setPrefHeight(40);
+                installButton.setOnAction(e -> control.onInstall());
+                BorderPane.setAlignment(installButton, Pos.CENTER_RIGHT);
+                root.setBottom(installButton);
+            }
+
+            getChildren().setAll(root);
+        }
+    }
+}

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AdditionalInstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AdditionalInstallersPage.java
@@ -17,7 +17,6 @@
  */
 package org.jackhuang.hmcl.ui.download;
 
-import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import org.jackhuang.hmcl.download.DownloadProvider;
@@ -36,25 +35,20 @@ import java.util.Optional;
 import static org.jackhuang.hmcl.download.LibraryAnalyzer.LibraryType.MINECRAFT;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
-class AdditionalInstallersPage extends InstallersPage {
+class AdditionalInstallersPage extends AbstractInstallersPage {
     protected final BooleanProperty compatible = new SimpleBooleanProperty();
     protected final GameRepository repository;
     protected final String gameVersion;
     protected final Version version;
 
     public AdditionalInstallersPage(String gameVersion, Version version, WizardController controller, HMCLGameRepository repository, DownloadProvider downloadProvider) {
-        super(controller, repository, gameVersion, downloadProvider);
+        super(controller, gameVersion, downloadProvider);
         this.gameVersion = gameVersion;
         this.version = version;
         this.repository = repository;
 
-        txtName.getValidators().clear();
         txtName.setText(version.getId());
         txtName.setEditable(false);
-
-        installable.bind(Bindings.createBooleanBinding(
-                () -> compatible.get() && txtName.validate(),
-                txtName.textProperty(), compatible));
 
         for (InstallerItem library : group.getLibraries()) {
             String libraryId = library.getLibraryId();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java
@@ -17,28 +17,16 @@
  */
 package org.jackhuang.hmcl.ui.download;
 
-import com.jfoenix.controls.JFXButton;
-import com.jfoenix.controls.JFXTextField;
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.SimpleBooleanProperty;
-import javafx.geometry.Insets;
-import javafx.geometry.Pos;
-import javafx.scene.control.*;
-import javafx.scene.layout.BorderPane;
-import javafx.scene.layout.FlowPane;
-import javafx.scene.layout.HBox;
 import org.jackhuang.hmcl.download.DownloadProvider;
 import org.jackhuang.hmcl.download.LibraryAnalyzer;
 import org.jackhuang.hmcl.download.RemoteVersion;
 import org.jackhuang.hmcl.game.HMCLGameRepository;
 import org.jackhuang.hmcl.ui.Controllers;
-import org.jackhuang.hmcl.ui.FXUtils;
 import org.jackhuang.hmcl.ui.InstallerItem;
 import org.jackhuang.hmcl.ui.construct.MessageDialogPane;
 import org.jackhuang.hmcl.ui.construct.RequiredValidator;
 import org.jackhuang.hmcl.ui.construct.Validator;
 import org.jackhuang.hmcl.ui.wizard.WizardController;
-import org.jackhuang.hmcl.ui.wizard.WizardPage;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -46,18 +34,12 @@ import java.util.Map;
 import static javafx.beans.binding.Bindings.createBooleanBinding;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
-public class InstallersPage extends Control implements WizardPage {
-    protected final WizardController controller;
-
-    protected InstallerItem.InstallerItemGroup group;
-    protected JFXTextField txtName = new JFXTextField();
-    protected BooleanProperty installable = new SimpleBooleanProperty();
+public class InstallersPage extends AbstractInstallersPage {
 
     private boolean isNameModifiedByUser = false;
 
     public InstallersPage(WizardController controller, HMCLGameRepository repository, String gameVersion, DownloadProvider downloadProvider) {
-        this.controller = controller;
-        this.group = new InstallerItem.InstallerItemGroup(gameVersion, getInstallerItemStyle());
+        super(controller, gameVersion, downloadProvider);
 
         txtName.getValidators().addAll(
                 new RequiredValidator(),
@@ -66,27 +48,6 @@ public class InstallersPage extends Control implements WizardPage {
         installable.bind(createBooleanBinding(txtName::validate, txtName.textProperty()));
 
         txtName.textProperty().addListener((obs, oldText, newText) -> isNameModifiedByUser = true);
-
-        for (InstallerItem library : group.getLibraries()) {
-            String libraryId = library.getLibraryId();
-            if (libraryId.equals(LibraryAnalyzer.LibraryType.MINECRAFT.getPatchId())) continue;
-            library.setOnInstall(() -> {
-                if (LibraryAnalyzer.LibraryType.FABRIC_API.getPatchId().equals(libraryId)) {
-                    Controllers.dialog(i18n("install.installer.fabric-api.warning"), i18n("message.warning"), MessageDialogPane.MessageType.WARNING);
-                }
-
-                if (!(library.resolvedStateProperty().get() instanceof InstallerItem.IncompatibleState))
-                    controller.onNext(new VersionsPage(controller, i18n("install.installer.choose", i18n("install.installer." + libraryId)), gameVersion, downloadProvider, libraryId, () -> controller.onPrev(false)));
-            });
-            library.setOnRemove(() -> {
-                controller.getSettings().remove(libraryId);
-                reload();
-            });
-        }
-    }
-
-    protected InstallerItem.Style getInstallerItemStyle() {
-        return InstallerItem.Style.CARD;
     }
 
     @Override
@@ -113,11 +74,6 @@ public class InstallersPage extends Control implements WizardPage {
     }
 
     @Override
-    public void onNavigate(Map<String, Object> settings) {
-        reload();
-    }
-
-    @Override
     public void cleanup(Map<String, Object> settings) {
     }
 
@@ -141,11 +97,6 @@ public class InstallersPage extends Control implements WizardPage {
             controller.getSettings().put("name", name);
             controller.onFinish();
         }
-    }
-
-    @Override
-    protected Skin<?> createDefaultSkin() {
-        return new InstallersPageSkin(this);
     }
 
     private void setTxtNameWithLoaders() {
@@ -189,63 +140,5 @@ public class InstallersPage extends Control implements WizardPage {
 
         txtName.setText(nameBuilder.toString());
         isNameModifiedByUser = false;
-    }
-
-    protected static class InstallersPageSkin extends SkinBase<InstallersPage> {
-
-        /**
-         * Constructor for all SkinBase instances.
-         *
-         * @param control The control for which this Skin should attach to.
-         */
-        protected InstallersPageSkin(InstallersPage control) {
-            super(control);
-
-            BorderPane root = new BorderPane();
-            root.setPadding(new Insets(16));
-
-            {
-                HBox versionNamePane = new HBox(8);
-                versionNamePane.getStyleClass().add("card-non-transparent");
-                versionNamePane.setStyle("-fx-padding: 20 8 20 16");
-                versionNamePane.setAlignment(Pos.CENTER_LEFT);
-
-                control.txtName.setMaxWidth(300);
-                versionNamePane.getChildren().setAll(new Label(i18n("version.name")), control.txtName);
-                root.setTop(versionNamePane);
-            }
-
-            {
-                InstallerItem[] libraries = control.group.getLibraries();
-
-                FlowPane libraryPane = new FlowPane(libraries);
-                libraryPane.setVgap(16);
-                libraryPane.setHgap(16);
-
-                if (libraries.length <= 8) {
-                    BorderPane.setMargin(libraryPane, new Insets(16, 0, 16, 0));
-                    root.setCenter(libraryPane);
-                } else {
-                    ScrollPane scrollPane = new ScrollPane(libraryPane);
-                    scrollPane.setFitToWidth(true);
-                    scrollPane.setFitToHeight(true);
-                    BorderPane.setMargin(scrollPane, new Insets(16, 0, 16, 0));
-                    root.setCenter(scrollPane);
-                }
-            }
-
-
-            {
-                JFXButton installButton = FXUtils.newRaisedButton(i18n("button.install"));
-                installButton.disableProperty().bind(control.installable.not());
-                installButton.setPrefWidth(100);
-                installButton.setPrefHeight(40);
-                installButton.setOnAction(e -> control.onInstall());
-                BorderPane.setAlignment(installButton, Pos.CENTER_RIGHT);
-                root.setBottom(installButton);
-            }
-
-            getChildren().setAll(root);
-        }
     }
 }


### PR DESCRIPTION
Fix #3865

### 問題
原本設計為AdditionalInstallersPage繼承InstallersPage，在建構AdditionalInstallersPage時會先建構InstallersPage，然後再移除InstallersPage加入的Validator，Validator加入的時候因為命名重複所以報紅了
在移除Validator後沒有恢復版本名稱的顏色，所以會出現了這個問題

### 解決方法
重構了AdditionalInstallersPage和InstallersPage，改為兩者都是從AbstractInstallersPage繼承，再分別進行處理，避免了AdditionalInstallersPage加入Validator再移除的情況