### PR TITLE
Fix #3851 当用户名为中文名时，离线账户 - LittleSkin 换肤 功能失效

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/offline/Skin.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/offline/Skin.java
@@ -167,7 +167,7 @@ public class Skin {
             case LITTLE_SKIN:
             case CUSTOM_SKIN_LOADER_API:
                 String realCslApi = type == Type.LITTLE_SKIN
-                        ? "https://littleskin.cn"
+                        ? "https://littleskin.cn/csl"
                         : StringUtils.removeSuffix(Lang.requireNonNullElse(cslApi, ""), "/");
                 return Task.composeAsync(() -> new GetTask(new URL(String.format("%s/%s.json", realCslApi, username))))
                         .thenComposeAsync(json -> {


### PR DESCRIPTION
Fix #3851
### 问题成因
访问```https://littleskin.cn/username.json```时默认会重定向至```https://littleskin.cn/csl/username.json```
然而当username包含中文的时候，编码方式不一致，导致无法获取皮肤相关的资料
网站在重定向时使用的编码是ISO_8859_1，而程序中采用的编码是UTF-8
### 解决方法
直接访问```https://littleskin.cn/csl/username.json```跳过重定向过程就可以解决这个问题