### PR TITLE
支持自定义 CurseForge API 和 Modrinth API

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseAddon.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseAddon.java
@@ -23,6 +23,7 @@ import org.jackhuang.hmcl.mod.RemoteModRepository;
 import org.jackhuang.hmcl.util.Immutable;
 import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.Pair;
+import org.jackhuang.hmcl.util.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
@@ -519,12 +520,20 @@ public class CurseAddon implements RemoteMod.IMod {
         }
 
         public String getDownloadUrl() {
+            String url;
             if (downloadUrl == null) {
                 // This addon is not allowed for distribution, and downloadUrl will be null.
                 // We try to find its download url.
-                return String.format("https://edge.forgecdn.net/files/%d/%d/%s", id / 1000, id % 1000, fileName);
+                url = String.format("https://edge.forgecdn.net/files/%d/%d/%s", id / 1000, id % 1000, fileName);
+            } else {
+                url = downloadUrl;
             }
-            return downloadUrl;
+
+            String downloadPrefix = System.getProperty("hmcl.curseforge.download.prefix", "");
+            if (!StringUtils.isBlank(downloadPrefix)) {
+                return StringUtils.replaceSitePrefix(url, downloadPrefix);
+            }
+            return url;
         }
 
         public List<String> getGameVersions() {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseForgeRemoteModRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseForgeRemoteModRepository.java
@@ -44,6 +44,7 @@ public final class CurseForgeRemoteModRepository implements RemoteModRepository 
 
     private static final String DEFAULT_PREFIX = "https://api.curseforge.com";
     private static final String PREFIX = System.getProperty("hmcl.curseforge.prefix", DEFAULT_PREFIX);
+    private static final String DOWNLOAD_PREFIX = System.getProperty("hmcl.curseforge.download.prefix", "");
     private static final String apiKey = System.getProperty("hmcl.curseforge.apikey", JarUtils.getManifestAttribute("CurseForge-Api-Key", ""));
 
     private static final int WORD_PERFECT_MATCH_WEIGHT = 5;
@@ -204,7 +205,16 @@ public final class CurseForgeRemoteModRepository implements RemoteModRepository 
         }
 
         Response<CurseAddon.LatestFile> response = request.getJson(Response.typeOf(CurseAddon.LatestFile.class));
-        return response.getData().toVersion().getFile();
+        RemoteMod.File file = response.getData().toVersion().getFile();
+        
+        if (!DOWNLOAD_PREFIX.isEmpty()) {
+            return new RemoteMod.File(
+                file.getHashes(), 
+                StringUtils.replaceSitePrefix(file.getUrl(), DOWNLOAD_PREFIX),
+                file.getFilename()
+            );
+        }
+        return file;
     }
 
     @Override

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseManifestFile.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseManifestFile.java
@@ -19,6 +19,7 @@ package org.jackhuang.hmcl.mod.curse;
 
 import com.google.gson.JsonParseException;
 import com.google.gson.annotations.SerializedName;
+import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.Immutable;
 import org.jackhuang.hmcl.util.gson.Validation;
 import org.jackhuang.hmcl.util.io.NetworkUtils;
@@ -85,15 +86,23 @@ public final class CurseManifestFile implements Validation {
 
     @Nullable
     public URL getUrl() {
+        String urlStr;
         if (url == null) {
             if (fileName != null) {
-                return NetworkUtils.toURL(NetworkUtils.encodeLocation(String.format("https://edge.forgecdn.net/files/%d/%d/%s", fileID / 1000, fileID % 1000, fileName)));
+                urlStr = String.format("https://edge.forgecdn.net/files/%d/%d/%s", fileID / 1000, fileID % 1000, fileName);
             } else {
                 return null;
             }
         } else {
-            return NetworkUtils.toURL(NetworkUtils.encodeLocation(url));
+            urlStr = url;
         }
+
+        String downloadPrefix = System.getProperty("hmcl.curseforge.download.prefix", "");
+        if (!StringUtils.isBlank(downloadPrefix)) {
+            urlStr = StringUtils.replaceSitePrefix(urlStr, downloadPrefix);
+        }
+        
+        return NetworkUtils.toURL(NetworkUtils.encodeLocation(urlStr));
     }
 
     public CurseManifestFile withFileName(String fileName) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java
@@ -47,7 +47,7 @@ public final class ModrinthRemoteModRepository implements RemoteModRepository {
     public static final ModrinthRemoteModRepository MODPACKS = new ModrinthRemoteModRepository("modpack");
     public static final ModrinthRemoteModRepository RESOURCE_PACKS = new ModrinthRemoteModRepository("resourcepack");
 
-    private static final String PREFIX = "https://api.modrinth.com";
+    private static final String PREFIX = System.getProperty("hmcl.modrinth.prefix", "https://api.modrinth.com");
 
     private final String projectType;
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java
@@ -48,6 +48,7 @@ public final class ModrinthRemoteModRepository implements RemoteModRepository {
     public static final ModrinthRemoteModRepository RESOURCE_PACKS = new ModrinthRemoteModRepository("resourcepack");
 
     private static final String PREFIX = System.getProperty("hmcl.modrinth.prefix", "https://api.modrinth.com");
+    private static final String DOWNLOAD_PREFIX = System.getProperty("hmcl.modrinth.download.prefix", "");
 
     private final String projectType;
 
@@ -561,6 +562,13 @@ public final class ModrinthRemoteModRepository implements RemoteModRepository {
         }
 
         public RemoteMod.File toFile() {
+            if (!DOWNLOAD_PREFIX.isEmpty()) {
+                return new RemoteMod.File(
+                    hashes,
+                    StringUtils.replaceSitePrefix(url, DOWNLOAD_PREFIX),
+                    filename
+                );
+            }
             return new RemoteMod.File(hashes, url, filename);
         }
     }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/StringUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/StringUtils.java
@@ -405,6 +405,29 @@ public final class StringUtils {
         return true;
     }
 
+    /**
+     * Replace the URL prefix with a new one.
+     * @param originalUrl the original URL
+     * @param newPrefix the new prefix to replace with 
+     * @return the URL with the new prefix, or the original URL if newPrefix is empty
+     */
+    public static String replaceSitePrefix(String originalUrl, String newPrefix) {
+        if (isBlank(newPrefix)) return originalUrl;
+        
+        int pathStart = originalUrl.indexOf("://");
+        if (pathStart >= 0) {
+            pathStart += 3;
+        } else {
+            pathStart = 0;
+        }
+        
+        int firstSlash = originalUrl.indexOf('/', pathStart);
+        if (firstSlash < 0) return originalUrl;
+        
+        String path = originalUrl.substring(firstSlash);
+        return newPrefix + path;
+    }
+
     public static class LevCalculator {
         private int[][] lev;
 


### PR DESCRIPTION
`hmcl.curseforge.prefix` CurseForge API 前缀替换，请求时不带 apiKey


`hmcl.curseforge.download.prefix` CurseForge 下载地址前缀替换


`hmcl.modrinth.prefix` Modrinth API 前缀替换

`hmcl.modrinth.download.prefix` Modrinth 下载地址前缀替换

