### PR TITLE
Fix #3896: 下载界面对于多行信息显示错误

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
@@ -212,10 +212,7 @@ public class DownloadPage extends Control implements DecoratorPage {
             scrollPane.setFitToHeight(true);
 
             HBox descriptionPane = new HBox(8);
-            descriptionPane.minHeightProperty().bind(Bindings.createDoubleBinding(
-                    () -> descriptionPane.prefHeight(-1),
-                    descriptionPane.prefHeightProperty(), descriptionPane.widthProperty()
-            ));
+            descriptionPane.setMinHeight(Region.USE_PREF_SIZE);
             descriptionPane.setAlignment(Pos.CENTER);
             pane.getChildren().add(descriptionPane);
             descriptionPane.getStyleClass().add("card-non-transparent");

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
@@ -212,6 +212,10 @@ public class DownloadPage extends Control implements DecoratorPage {
             scrollPane.setFitToHeight(true);
 
             HBox descriptionPane = new HBox(8);
+            descriptionPane.minHeightProperty().bind(Bindings.createDoubleBinding(
+                    () -> descriptionPane.prefHeight(-1),
+                    descriptionPane.prefHeightProperty(), descriptionPane.widthProperty()
+            ));
             descriptionPane.setAlignment(Pos.CENTER);
             pane.getChildren().add(descriptionPane);
             descriptionPane.getStyleClass().add("card-non-transparent");


### PR DESCRIPTION
Fix #3896
## 问题成因
信息栏没有设置最低高度导致被版本列表挤压，只要是多行信息且版本列表超出界面高度就能复现

## 解决方法
將信息栏的高度綁定到```prefHeight(-1)```自动调节

## 效果展示
左边为修复前，右边为修复后
![image](https://github.com/user-attachments/assets/007ada7c-dbec-4b0b-9579-bd09e39db90a)
![image](https://github.com/user-attachments/assets/3dec8a98-2558-4507-ad34-1d9d8c4c488a)
