### PR TITLE
将日志 caller 信息中的 'org.jackhuang.hmcl.' 缩短为 '@.'

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/Logger.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/Logger.java
@@ -69,9 +69,15 @@ public final class Logger {
         builder.setLength(0);
         builder.append('[');
         TIME_FORMATTER.formatTo(Instant.ofEpochMilli(event.time), builder);
-        builder.append("] [")
-                .append(event.caller)
-                .append('/')
+        builder.append("] [");
+
+        if (event.caller == null || !event.caller.startsWith("org.jackhuang.hmcl.")) {
+            builder.append(event.caller);
+        } else {
+            builder.append("@.").append(event.caller, "org.jackhuang.hmcl.".length(), event.caller.length());
+        }
+
+        builder.append('/')
                 .append(event.level)
                 .append("] ")
                 .append(filterForbiddenToken(event.message));

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/Logger.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/Logger.java
@@ -42,7 +42,7 @@ public final class Logger {
         return message;
     }
 
-
+    static final String PACKAGE_PREFIX = "org.jackhuang.hmcl.";
     static final String CLASS_NAME = Logger.class.getName();
 
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss").withZone(ZoneId.systemDefault());
@@ -71,10 +71,10 @@ public final class Logger {
         TIME_FORMATTER.formatTo(Instant.ofEpochMilli(event.time), builder);
         builder.append("] [");
 
-        if (event.caller == null || !event.caller.startsWith("org.jackhuang.hmcl.")) {
-            builder.append(event.caller);
+        if (event.caller != null && event.caller.startsWith(PACKAGE_PREFIX)) {
+            builder.append("@.").append(event.caller, PACKAGE_PREFIX.length(), event.caller.length());
         } else {
-            builder.append("@.").append(event.caller, "org.jackhuang.hmcl.".length(), event.caller.length());
+            builder.append(event.caller);
         }
 
         builder.append('/')


### PR DESCRIPTION
`org.jackhuang.hmcl.` 太长了

```
[21:40:04] [@.Launcher.main/INFO] *** HMCL @develop@ ***
[21:40:04] [@.Launcher.main/INFO] Operating System: Windows 10 10.0.19045
[21:40:04] [@.Launcher.main/INFO] Processor Identifier: Intel64 Family 6 Model 78 Stepping 3, GenuineIntel
[21:40:04] [@.Launcher.main/INFO] System Architecture: x86-64
[21:40:04] [@.Launcher.main/INFO] Native Encoding: UTF-8
[21:40:04] [@.Launcher.main/INFO] JNU Encoding: GBK
[21:40:04] [@.Launcher.main/INFO] Code Page: 936
[21:40:04] [@.Launcher.main/INFO] Java Architecture: x86-64
[21:40:04] [@.Launcher.main/INFO] Java Version: 11.0.21, BellSoft
[21:40:04] [@.Launcher.main/INFO] Java VM Version: OpenJDK 64-Bit Server VM (mixed mode), BellSoft
```