### PR TITLE
修复启动器在部分 Linux 发行版上无法正确识别用户地区的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
@@ -63,6 +63,7 @@ public final class AccountListPage extends DecoratorAnimatedPage implements Deco
 
     private static boolean isExemptedRegion() {
         String zoneId = ZoneId.systemDefault().getId();
+        // Although Asia/Beijing is not a legal name, Deepin uses it
         if ("Asia/Shanghai".equals(zoneId) || "Asia/Beijing".equals(zoneId))
             return true;
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
@@ -80,7 +80,6 @@ public final class AccountListPage extends DecoratorAnimatedPage implements Deco
                 return true;
         }
 
-
         return false;
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
@@ -63,18 +63,23 @@ public final class AccountListPage extends DecoratorAnimatedPage implements Deco
     static final BooleanProperty RESTRICTED = new SimpleBooleanProperty(true);
 
     private static boolean isExemptedRegion() {
-        if ("Asia/Shanghai".equals(ZoneId.systemDefault().getId()))
+        String zoneId = ZoneId.systemDefault().getId();
+        if ("Asia/Shanghai".equals(zoneId) || "Asia/Beijing".equals(zoneId))
             return true;
 
-        if (OperatingSystem.CURRENT_OS == OperatingSystem.WINDOWS
-                && NativeUtils.USE_JNA
-                && ZonedDateTime.now().getOffset().getTotalSeconds() == 8 * 3600) { // GMT+8
-            Kernel32 kernel32 = Kernel32.INSTANCE;
+        if (ZonedDateTime.now().getOffset().getTotalSeconds() == 8 * 3600) { // GMT+8
+            if (OperatingSystem.CURRENT_OS == OperatingSystem.WINDOWS && NativeUtils.USE_JNA) {
+                Kernel32 kernel32 = Kernel32.INSTANCE;
 
-            // https://learn.microsoft.com/windows/win32/intl/table-of-geographical-locations
-            if (kernel32 != null && kernel32.GetUserGeoID(WinConstants.GEOCLASS_NATION) == 45)
+                // https://learn.microsoft.com/windows/win32/intl/table-of-geographical-locations
+                if (kernel32 != null && kernel32.GetUserGeoID(WinConstants.GEOCLASS_NATION) == 45) // China
+                    return true;
+            } else if (OperatingSystem.CURRENT_OS == OperatingSystem.LINUX && "GMT+08:00".equals(zoneId))
+                // Some Linux distributions may use invalid time zone ids (e.g., Asia/Beijing)
+                // Java may not be able to resolve this name and use GMT+08:00 instead.
                 return true;
         }
+
 
         return false;
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
@@ -50,7 +50,6 @@ import org.jackhuang.hmcl.util.platform.windows.WinConstants;
 
 import java.net.URI;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.Locale;
 
 import static org.jackhuang.hmcl.setting.ConfigHolder.globalConfig;
@@ -67,18 +66,16 @@ public final class AccountListPage extends DecoratorAnimatedPage implements Deco
         if ("Asia/Shanghai".equals(zoneId) || "Asia/Beijing".equals(zoneId))
             return true;
 
-        if (ZonedDateTime.now().getOffset().getTotalSeconds() == 8 * 3600) { // GMT+8
-            if (OperatingSystem.CURRENT_OS == OperatingSystem.WINDOWS && NativeUtils.USE_JNA) {
-                Kernel32 kernel32 = Kernel32.INSTANCE;
+        if (OperatingSystem.CURRENT_OS == OperatingSystem.WINDOWS && NativeUtils.USE_JNA) {
+            Kernel32 kernel32 = Kernel32.INSTANCE;
 
-                // https://learn.microsoft.com/windows/win32/intl/table-of-geographical-locations
-                if (kernel32 != null && kernel32.GetUserGeoID(WinConstants.GEOCLASS_NATION) == 45) // China
-                    return true;
-            } else if (OperatingSystem.CURRENT_OS == OperatingSystem.LINUX && "GMT+08:00".equals(zoneId))
-                // Some Linux distributions may use invalid time zone ids (e.g., Asia/Beijing)
-                // Java may not be able to resolve this name and use GMT+08:00 instead.
+            // https://learn.microsoft.com/windows/win32/intl/table-of-geographical-locations
+            if (kernel32 != null && kernel32.GetUserGeoID(WinConstants.GEOCLASS_NATION) == 45) // China
                 return true;
-        }
+        } else if (OperatingSystem.CURRENT_OS == OperatingSystem.LINUX && "GMT+08:00".equals(zoneId))
+            // Some Linux distributions may use invalid time zone ids (e.g., Asia/Beijing)
+            // Java may not be able to resolve this name and use GMT+08:00 instead.
+            return true;
 
         return false;
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
@@ -50,6 +50,7 @@ import org.jackhuang.hmcl.util.platform.windows.WinConstants;
 
 import java.net.URI;
 import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.Locale;
 
 import static org.jackhuang.hmcl.setting.ConfigHolder.globalConfig;
@@ -63,8 +64,14 @@ public final class AccountListPage extends DecoratorAnimatedPage implements Deco
 
     private static boolean isExemptedRegion() {
         String zoneId = ZoneId.systemDefault().getId();
-        // Although Asia/Beijing is not a legal name, Deepin uses it
-        if ("Asia/Shanghai".equals(zoneId) || "Asia/Beijing".equals(zoneId))
+        if (Arrays.asList(
+                "Asia/Shanghai",
+                // Although Asia/Beijing is not a legal name, Deepin uses it
+                "Asia/Beijing",
+                "Asia/Chongqing",
+                "Asia/Chungking",
+                "Asia/Harbin"
+        ).contains(zoneId))
             return true;
 
         if (OperatingSystem.CURRENT_OS == OperatingSystem.WINDOWS && NativeUtils.USE_JNA) {


### PR DESCRIPTION
Deepin 因为某些原因，在中国大陆地区将时区名称设置为 `Asia/Beijing`，导致 HMCL 未能识别。本 PR 修复了此问题。