### PR TITLE
在 Linux 平台通过 fc-match 查询默认字体

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/SystemUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/SystemUtils.java
@@ -21,6 +21,7 @@ import org.jackhuang.hmcl.java.JavaRuntime;
 import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.function.ExceptionalFunction;
+import org.jackhuang.hmcl.util.io.IOUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
@@ -73,6 +74,11 @@ public final class SystemUtils {
         managedProcess.pumpInputStream(SystemUtils::onLogLine);
         managedProcess.pumpErrorStream(SystemUtils::onLogLine);
         return managedProcess.getProcess().waitFor();
+    }
+
+    public static String run(String... command) throws Exception {
+        return run(Arrays.asList(command),
+                inputStream -> IOUtils.readFullyAsString(inputStream, OperatingSystem.NATIVE_CHARSET));
     }
 
     public static <T> T run(List<String> command, ExceptionalFunction<InputStream, T, ?> convert) throws Exception {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/macos/MacOSHardwareDetector.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/macos/MacOSHardwareDetector.java
@@ -103,8 +103,7 @@ public final class MacOSHardwareDetector extends HardwareDetector {
 
         String json = null;
         try {
-            json = SystemUtils.run(Arrays.asList("/usr/sbin/system_profiler", "SPDisplaysDataType", "-json"),
-                    inputStream -> IOUtils.readFullyAsString(inputStream, OperatingSystem.NATIVE_CHARSET));
+            json = SystemUtils.run("/usr/sbin/system_profiler", "SPDisplaysDataType", "-json");
 
             JsonObject object = JsonUtils.GSON.fromJson(json, JsonObject.class);
             JsonArray spDisplaysDataType = object.getAsJsonArray("SPDisplaysDataType");


### PR DESCRIPTION
通过这种方式也许能够解决 Linux 平台上字符乱码的问题。