### PR TITLE
使用独立线程保存设置

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
@@ -27,6 +27,7 @@ import javafx.scene.input.DataFormat;
 import javafx.stage.Stage;
 import org.jackhuang.hmcl.setting.ConfigHolder;
 import org.jackhuang.hmcl.setting.SambaException;
+import org.jackhuang.hmcl.setting.SettingsSaver;
 import org.jackhuang.hmcl.task.AsyncTaskExecutor;
 import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.ui.Controllers;
@@ -215,6 +216,7 @@ public final class Launcher extends Application {
     public void stop() throws Exception {
         Controllers.onApplicationStop();
         LOG.shutdown();
+        SettingsSaver.shutdown();
     }
 
     public static void main(String[] args) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/Main.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Main.java
@@ -19,6 +19,7 @@ package org.jackhuang.hmcl;
 
 import javafx.application.Platform;
 import javafx.scene.control.Alert;
+import org.jackhuang.hmcl.setting.SettingsSaver;
 import org.jackhuang.hmcl.ui.AwtUtils;
 import org.jackhuang.hmcl.util.ModuleHelper;
 import org.jackhuang.hmcl.util.SelfDependencyPatcher;
@@ -80,6 +81,7 @@ public final class Main {
 
     public static void exit(int exitCode) {
         LOG.shutdown();
+        SettingsSaver.shutdown();
         System.exit(exitCode);
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Accounts.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Accounts.java
@@ -35,9 +35,6 @@ import org.jackhuang.hmcl.auth.offline.OfflineAccountFactory;
 import org.jackhuang.hmcl.auth.yggdrasil.RemoteAuthenticationException;
 import org.jackhuang.hmcl.game.OAuthServer;
 import org.jackhuang.hmcl.task.Schedulers;
-import org.jackhuang.hmcl.util.InvocationDispatcher;
-import org.jackhuang.hmcl.util.Lang;
-import org.jackhuang.hmcl.util.io.FileUtils;
 import org.jackhuang.hmcl.util.skin.InvalidSkinException;
 
 import javax.net.ssl.SSLException;
@@ -184,21 +181,8 @@ public final class Accounts {
             }
         }
 
-        InvocationDispatcher<String> dispatcher = InvocationDispatcher.runOn(Lang::thread, json -> {
-            LOG.info("Saving global accounts");
-            synchronized (globalAccountsFile) {
-                try {
-                    synchronized (globalAccountsFile) {
-                        FileUtils.saveSafely(globalAccountsFile, json);
-                    }
-                } catch (IOException e) {
-                    LOG.error("Failed to save global accounts", e);
-                }
-            }
-        });
-
         globalAccountStorages.addListener(onInvalidating(() ->
-                dispatcher.accept(Config.CONFIG_GSON.toJson(globalAccountStorages))));
+                SettingsSaver.save(globalAccountsFile, Config.CONFIG_GSON.toJson(globalAccountStorages))));
     }
 
     private static Account parseAccount(Map<Object, Object> storage) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
@@ -19,8 +19,6 @@ package org.jackhuang.hmcl.setting;
 
 import com.google.gson.JsonParseException;
 import org.jackhuang.hmcl.Metadata;
-import org.jackhuang.hmcl.util.InvocationDispatcher;
-import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.i18n.I18n;
 import org.jackhuang.hmcl.util.io.FileUtils;
 import org.jackhuang.hmcl.util.io.JarUtils;
@@ -83,18 +81,20 @@ public final class ConfigHolder {
         LOG.info("Config location: " + configLocation);
 
         configInstance = loadConfig();
-        configInstance.addListener(source -> markConfigDirty());
+        configInstance.addListener(source -> SettingsSaver.save(configLocation, configInstance.toJson()));
 
         globalConfigInstance = loadGlobalConfig();
-        globalConfigInstance.addListener(source -> markGlobalConfigDirty());
+        globalConfigInstance.addListener(source -> SettingsSaver.save(GLOBAL_CONFIG_PATH, globalConfigInstance.toJson()));
 
         Locale.setDefault(config().getLocalization().getLocale());
         I18n.setLocale(configInstance.getLocalization());
         LOG.setLogRetention(globalConfig().getLogRetention());
         Settings.init();
 
-        if (newlyCreated)
-            saveConfigSync();
+        if (newlyCreated) {
+            LOG.info("Creating config file " + configLocation);
+            FileUtils.saveSafely(configLocation, configInstance.toJson());
+        }
 
         if (!Files.isWritable(configLocation)) {
             if (OperatingSystem.CURRENT_OS == OperatingSystem.WINDOWS
@@ -169,32 +169,8 @@ public final class ConfigHolder {
             }
         }
 
-        LOG.info("Creating an empty config");
         newlyCreated = true;
         return new Config();
-    }
-
-    private static final InvocationDispatcher<String> configWriter = InvocationDispatcher.runOn(Lang::thread, content -> {
-        try {
-            writeToConfig(content);
-        } catch (IOException e) {
-            LOG.error("Failed to save config", e);
-        }
-    });
-
-    private static void writeToConfig(String content) throws IOException {
-        LOG.info("Saving config");
-        synchronized (configLocation) {
-            FileUtils.saveSafely(configLocation, content);
-        }
-    }
-
-    private static void markConfigDirty() {
-        configWriter.accept(configInstance.toJson());
-    }
-
-    private static void saveConfigSync() throws IOException {
-        writeToConfig(configInstance.toJson());
     }
 
     // Global Config
@@ -218,22 +194,4 @@ public final class ConfigHolder {
         return new GlobalConfig();
     }
 
-    private static final InvocationDispatcher<String> globalConfigWriter = InvocationDispatcher.runOn(Lang::thread, content -> {
-        try {
-            writeToGlobalConfig(content);
-        } catch (IOException e) {
-            LOG.error("Failed to save config", e);
-        }
-    });
-
-    private static void writeToGlobalConfig(String content) throws IOException {
-        LOG.info("Saving global config");
-        synchronized (GLOBAL_CONFIG_PATH) {
-            FileUtils.saveSafely(GLOBAL_CONFIG_PATH, content);
-        }
-    }
-
-    private static void markGlobalConfigDirty() {
-        globalConfigWriter.accept(globalConfigInstance.toJson());
-    }
 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/SettingsSaver.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/SettingsSaver.java
@@ -1,0 +1,140 @@
+/*
+ * Hello Minecraft! Launcher
+ * Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.jackhuang.hmcl.setting;
+
+import org.jackhuang.hmcl.util.Pair;
+import org.jackhuang.hmcl.util.io.FileUtils;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.jackhuang.hmcl.util.logging.Logger.LOG;
+
+/**
+ * @author Glavo
+ */
+public final class SettingsSaver extends Thread {
+
+    private static final Pair<Path, String> SHUTDOWN = Pair.pair(null, null);
+
+    private static final BlockingQueue<Pair<Path, String>> queue = new LinkedBlockingQueue<>();
+
+    private static volatile boolean running = false;
+    private static final ReentrantLock runningLock = new ReentrantLock();
+    private static boolean installedShutdownHook;
+
+    private static void doSave(Map<Path, String> map) {
+        for (Map.Entry<Path, String> entry : map.entrySet()) {
+            Path file = entry.getKey();
+            LOG.info("Saving settings: " + file);
+            try {
+                FileUtils.saveSafely(file, entry.getValue());
+            } catch (Throwable e) {
+                LOG.warning("Failed to save " + file, e);
+            }
+        }
+    }
+
+    private static void onExit() {
+        shutdown();
+        runningLock.lock();
+        try {
+            IdentityHashMap<Path, String> map = new IdentityHashMap<>();
+            for (Pair<Path, String> pair : queue) {
+                if (pair != SHUTDOWN)
+                    map.put(pair.getKey(), pair.getValue());
+            }
+            doSave(map);
+        } finally {
+            runningLock.unlock();
+        }
+    }
+
+    public static void save(Path file, String content) {
+        Objects.requireNonNull(file);
+        Objects.requireNonNull(content);
+
+        queue.add(Pair.pair(file, content));
+        if (!running) {
+            runningLock.lock();
+            try {
+                if (!running) {
+                    SettingsSaver saver = new SettingsSaver();
+                    saver.start();
+                    running = true;
+                }
+
+                if (!installedShutdownHook) {
+                    installedShutdownHook = true;
+                    Runtime.getRuntime().addShutdownHook(new Thread(SettingsSaver::onExit, "SettingsSaverShutdownHook"));
+                }
+            } finally {
+                runningLock.unlock();
+            }
+        }
+    }
+
+    public static void shutdown() {
+        queue.add(SHUTDOWN);
+    }
+
+    private SettingsSaver() {
+        super("SettingsSaver");
+    }
+
+    @Override
+    public void run() {
+        runningLock.lock();
+        try {
+            IdentityHashMap<Path, String> map = new IdentityHashMap<>();
+            ArrayList<Pair<Path, String>> buffer = new ArrayList<>();
+
+            while (running) {
+                Pair<Path, String> head = queue.poll(10, TimeUnit.SECONDS);
+                if (head == null || head == SHUTDOWN) {
+                    running = false;
+                } else {
+                    map.put(head.getKey(), head.getValue());
+                    //noinspection BusyWait
+                    Thread.sleep(100); // Waiting for more changes
+                }
+
+                while (queue.drainTo(buffer) > 0) {
+                    for (Pair<Path, String> pair : buffer) {
+                        if (pair == SHUTDOWN)
+                            running = false;
+                        else
+                            map.put(pair.getKey(), pair.getValue());
+                    }
+                    buffer.clear();
+                }
+
+                doSave(map);
+                map.clear();
+            }
+        } catch (InterruptedException e) {
+            throw new AssertionError("This thread cannot be interrupted", e);
+        } finally {
+            runningLock.unlock();
+        }
+    }
+}

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/SettingsSaver.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/SettingsSaver.java
@@ -79,7 +79,7 @@ public final class SettingsSaver extends Thread {
             Schedulers.defaultScheduler().execute(() -> {
                 runningLock.lock();
                 try {
-                    if (!running && !queue.isEmpty()) {
+                    if (!running) {
                         SettingsSaver saver = new SettingsSaver();
                         saver.start();
                         running = true;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/SettingsSaver.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/SettingsSaver.java
@@ -112,7 +112,7 @@ public final class SettingsSaver extends Thread {
             ArrayList<Pair<Path, String>> buffer = new ArrayList<>();
 
             while (running) {
-                Pair<Path, String> head = queue.poll(10, TimeUnit.SECONDS);
+                Pair<Path, String> head = queue.poll(60, TimeUnit.SECONDS);
                 if (head == null || head == SHUTDOWN) {
                     running = false;
                 } else {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/SettingsSaver.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/SettingsSaver.java
@@ -79,7 +79,7 @@ public final class SettingsSaver extends Thread {
             Schedulers.defaultScheduler().execute(() -> {
                 runningLock.lock();
                 try {
-                    if (!running) {
+                    if (!running && !queue.isEmpty()) {
                         SettingsSaver saver = new SettingsSaver();
                         saver.start();
                         running = true;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/SettingsSaver.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/SettingsSaver.java
@@ -121,7 +121,7 @@ public final class SettingsSaver extends Thread {
                     Thread.sleep(100); // Waiting for more changes
                 }
 
-                if (queue.drainTo(buffer) > 0) {
+                while (queue.drainTo(buffer) > 0) {
                     for (Pair<Path, String> pair : buffer) {
                         if (pair == SHUTDOWN)
                             running = false;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/CrashReporter.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/CrashReporter.java
@@ -22,6 +22,7 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
 import org.jackhuang.hmcl.Metadata;
 import org.jackhuang.hmcl.countly.CrashReport;
+import org.jackhuang.hmcl.setting.SettingsSaver;
 import org.jackhuang.hmcl.ui.CrashWindow;
 import org.jackhuang.hmcl.upgrade.IntegrityChecker;
 import org.jackhuang.hmcl.upgrade.UpdateChecker;
@@ -112,6 +113,7 @@ public final class CrashReporter implements Thread.UncaughtExceptionHandler {
         }
 
         LOG.shutdown();
+        SettingsSaver.shutdown();
     }
 
     private void reportToServer(CrashReport crashReport) {


### PR DESCRIPTION
本 PR 重构了保存设置的方式。本次重构的目的是：

1. 降低保存设置的开销。
  目前 HMCL 每次保存设置都会创建一个新的线程，开销较大；
  本 PR 使用单一线程保存所有设置，并在一分钟内缓存该线程，这段时间内修改其他设置时无需创建新的线程，从而降低保存设置的开销。
2. 短时间内多次修改设置时，仅保存最后一次变化。
  目前如果 HMCL 在将设置保存到硬盘时发生了多次变化，则 HMCL 只会保存最后一次变化。但由于保存设置非常快，这种优化往往难以有明显效果，例如修改一些设置项时会同时让 `Config` 多个字段发生变化，导致设置被保存多次。
  本 PR 改进了这项优化，遇到更改后不会立即将内容写入硬盘，而会等待 100 毫秒并仅写入最后一次变化。这解决了一些通过滑块设置的设置项在拖动滑块时会快速保存几十上百次配置的问题。因此这也是合并 #3205 的先决条件。