### PR TITLE
Feature: Smooth image rendering

### DIFF
--- a/HMCL/build.gradle.kts
+++ b/HMCL/build.gradle.kts
@@ -149,6 +149,7 @@ tasks.shadowJar {
                 "javafx.graphics/javafx.css",
                 "javafx.graphics/com.sun.javafx.stage",
                 "javafx.graphics/com.sun.prism",
+                "javafx.graphics/com.sun.javafx.scene",
                 "javafx.controls/com.sun.javafx.scene.control",
                 "javafx.controls/com.sun.javafx.scene.control.behavior",
                 "javafx.controls/javafx.scene.control.skin",

--- a/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
@@ -35,6 +35,7 @@ import org.jackhuang.hmcl.upgrade.UpdateChecker;
 import org.jackhuang.hmcl.upgrade.UpdateHandler;
 import org.jackhuang.hmcl.util.CrashReporter;
 import org.jackhuang.hmcl.util.Lang;
+import org.jackhuang.hmcl.util.ImageUtils;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.io.JarUtils;
 import org.jackhuang.hmcl.util.platform.Architecture;
@@ -111,6 +112,8 @@ public final class Launcher extends Application {
 
             // runLater to ensure ConfigHolder.init() finished initialization
             Platform.runLater(() -> {
+                ImageUtils.enableSmoothImageRendering();
+
                 // When launcher visibility is set to "hide and reopen" without Platform.implicitExit = false,
                 // Stage.show() cannot work again because JavaFX Toolkit have already shut down.
                 Platform.setImplicitExit(false);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/ImageUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/ImageUtils.java
@@ -1,0 +1,104 @@
+package org.jackhuang.hmcl.util;
+
+import com.sun.javafx.geom.BaseBounds;
+import com.sun.javafx.geom.transform.BaseTransform;
+import com.sun.javafx.scene.ImageViewHelper;
+import com.sun.javafx.sg.prism.NGImageView;
+import com.sun.javafx.sg.prism.NGNode;
+import com.sun.prism.Graphics;
+import com.sun.prism.Texture;
+import javafx.scene.Node;
+import javafx.scene.image.ImageView;
+import org.jackhuang.hmcl.ui.FXUtils;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+
+import static org.jackhuang.hmcl.util.logging.Logger.LOG;
+
+public final class ImageUtils {
+    private ImageUtils() {
+    }
+
+    public static void enableSmoothImageRendering() {
+        FXUtils.checkFxUserThread();
+
+        try {
+            new ImageView(); // Trigger class initialization.
+
+            Field field = ImageViewHelper.class.getDeclaredField("imageViewAccessor");
+            field.setAccessible(true);
+
+            ImageViewHelper.ImageViewAccessor delegate = (ImageViewHelper.ImageViewAccessor) field.get(null);
+            if (delegate == null) {
+                throw new IllegalStateException("ImageViewHelper.imageViewAccessor should be set!");
+            }
+
+            field.set(null, new SmoothImageViewHelper(delegate));
+        } catch (Throwable e) {
+            LOG.warning("Cannot enable smooth image rendering.", e);
+        }
+    }
+
+    private static final class SmoothImageViewHelper implements ImageViewHelper.ImageViewAccessor {
+        private static final MethodHandle GET_IMAGE;
+
+        static {
+            try {
+                Field field = NGImageView.class.getDeclaredField("image");
+                field.setAccessible(true);
+                GET_IMAGE = MethodHandles.lookup().unreflectGetter(field);
+            } catch (ReflectiveOperationException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private final ImageViewHelper.ImageViewAccessor delegate;
+
+        public SmoothImageViewHelper(ImageViewHelper.ImageViewAccessor delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public NGNode doCreatePeer(Node node) {
+            return new NGImageView() {
+                private boolean smooth = ImageView.SMOOTH_DEFAULT;
+
+                @Override
+                public void setSmooth(boolean s) {
+                    smooth = s;
+                    super.setSmooth(s);
+                }
+
+                @Override
+                protected void renderContent(Graphics g) {
+                    try {
+                        Texture tex = g.getResourceFactory().getCachedTexture((com.sun.prism.Image) GET_IMAGE.invokeExact((NGImageView) this), Texture.WrapMode.CLAMP_TO_EDGE);
+                        tex.setLinearFiltering(smooth);
+                        tex.unlock();
+                    } catch (Throwable e) {
+                        throw new RuntimeException(e);
+                    }
+
+                    super.renderContent(g);
+                }
+            };
+        }
+
+        @Override
+        public void doUpdatePeer(Node node) {
+            delegate.doUpdatePeer(node);
+        }
+
+        @Override
+        public BaseBounds doComputeGeomBounds(Node node, BaseBounds bounds, BaseTransform tx) {
+            return delegate.doComputeGeomBounds(node, bounds, tx);
+        }
+
+        @Override
+        public boolean doComputeContains(Node node, double localX, double localY) {
+            return delegate.doComputeContains(node, localX, localY);
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/openjdk/jfx/blob/master/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGImageView.java#L174

JavaFX 的 `Image.setSmooth` 功能完全无效