### PR TITLE
Bump HMCLauncher to 3.6.0.4

### DIFF
--- a/HMCL/build.gradle.kts
+++ b/HMCL/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     implementation(libs.java.info)
 
     if (launcherExe == null) {
-        implementation("org.glavo.hmcl:HMCLauncher:3.6.0.3")
+        implementation("org.glavo.hmcl:HMCLauncher:3.6.0.4")
     }
 }
 


### PR DESCRIPTION
应该彻底修好 HMCLauncher 无法找到 PATH 中的 Java 的问题了。