### PR TITLE
optimize EventBus

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/event/EventManager.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/event/EventManager.java
@@ -69,7 +69,7 @@ public final class EventManager<T extends Event> {
         register(t -> runnable.run(), priority);
     }
 
-    public synchronized Event.Result fireEvent(T event) {
+    public Event.Result fireEvent(T event) {
         Consumer<T> compiled = this.compiled;
         if (compiled == null) {
             synchronized (this) {


### PR DESCRIPTION
- `EventPriority.values()` is cached to prevent allocation at each usage
- handlers will now be "compiled" to improve access performance. For 0 to 3 handler(s), the process of `map.get(priority)` and list iterating can be entirely eliminated. For EventManager with more handlers, all handlers will be put into a single array.
- `synchronized` is removed from `fireEvent(...)`, since compiling handlers is synchronized manually, and other codes in `fireEvent(...)` doesn't seem to need synchronization.