### PR TITLE
Fix: MultiMC 允许有相同描述符的游戏库

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/multimc/MultiMCInstancePatch.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/multimc/MultiMCInstancePatch.java
@@ -47,7 +47,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -190,12 +189,14 @@ public final class MultiMCInstancePatch {
         return value != null && !value.isEmpty() ? value : Collections.emptyList();
     }
 
-    private static <T, K> List<T> dropDuplicate(List<T> original, Function<T, K> mapper) {
-        Set<K> values = new HashSet<>();
+    private static <T> List<T> dropDuplicate(List<T> original) {
+        // TODO: Maybe new ArrayList(new LinkedHashSet(original)) ?
+
+        Set<T> values = new HashSet<>();
         List<T> result = new ArrayList<>();
 
         for (T item : original) {
-            if (values.add(mapper.apply(item))) {
+            if (values.add(item)) {
                 result.add(item);
             }
         }
@@ -285,6 +286,8 @@ public final class MultiMCInstancePatch {
         Library mainJar;
         List<String> traits;
         List<String> tweakers;
+        /* TODO: MultiMC use a slightly different way to store jars containing jni files.
+            Transforming them to Official Scheme might boost compatibility with other launchers. */
         List<Library> libraries;
         List<Library> mavenOnlyFiles;
         List<String> jarModFileNames;
@@ -338,10 +341,9 @@ public final class MultiMCInstancePatch {
             }
         }
 
-        traits = dropDuplicate(traits, Function.identity());
-        tweakers = dropDuplicate(tweakers, Function.identity());
-        libraries = dropDuplicate(libraries, Library::getName);
-        jarModFileNames = dropDuplicate(jarModFileNames, Function.identity());
+        traits = dropDuplicate(traits);
+        tweakers = dropDuplicate(tweakers);
+        jarModFileNames = dropDuplicate(jarModFileNames);
 
         for (String tweaker : tweakers) {
             minecraftArguments.add("--tweakClass");


### PR DESCRIPTION
MultiMC 允许多个游戏库共享同一个 artifact descriptor 字符串。如下，两个库均为 `org.lwjgl:lwjgl-glfw:3.3.1`

```
[
  {
    "downloads": {
      "artifact": {
        "sha1": "cbac1b8d30cb4795149c1ef540f912671a8616d0",
        "size": 128801,
        "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar"
      }
    },
    "name": "org.lwjgl:lwjgl-glfw:3.3.1"
  },
  {
    "downloads": {
      "artifact": {
        "sha1": "cbac1b8d30cb4795149c1ef540f912671a8616d0",
        "size": 128801,
        "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar"
      },
      "classifiers": {
        "natives-linux": {
          "sha1": "81716978214ecbda15050ca394b06ef61501a49e",
          "size": 119817,
          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-linux.jar"
        },
        "natives-macos": {
          "sha1": "9ec4ce1fc8c85fdef03ef4ff2aace6f5775fb280",
          "size": 131655,
          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-macos.jar"
        },
        "natives-windows": {
          "sha1": "ed892f945cf7e79c8756796f32d00fa4ceaf573b",
          "size": 145512,
          "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-windows.jar"
        }
      }
    },
    "name": "org.lwjgl:lwjgl-glfw:3.3.1",
    "natives": {
      "linux": "natives-linux",
      "osx": "natives-macos",
      "windows": "natives-windows"
    }
  }
]
```