### PR TITLE
Feature: 嵌入 ZipFS

### DIFF
--- a/HMCLCore/build.gradle.kts
+++ b/HMCLCore/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     api(libs.chardet)
     api(libs.jna)
     api(libs.pci.ids)
+    api(libs.zipfs)
 
     compileOnlyApi(libs.jetbrains.annotations)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ twelvemonkeys = "3.12.0"
 jna = "5.17.0"
 pci-ids = "0.4.0"
 java-info = "1.0"
-zipfs = "31fb19a23d"
+zipfs = "c4cfc75446"
 
 # plugins
 shadow = "8.3.6"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ twelvemonkeys = "3.12.0"
 jna = "5.17.0"
 pci-ids = "0.4.0"
 java-info = "1.0"
-zipfs = "d42ec5024f"
+zipfs = "31fb19a23d"
 
 # plugins
 shadow = "8.3.6"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ twelvemonkeys = "3.12.0"
 jna = "5.17.0"
 pci-ids = "0.4.0"
 java-info = "1.0"
+zipfs = "d42ec5024f"
 
 # plugins
 shadow = "8.3.6"
@@ -38,6 +39,7 @@ jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 jna-platform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }
 pci-ids = { module = "org.glavo:pci-ids", version.ref = "pci-ids" }
 java-info = { module = "org.glavo:java-info", version.ref = "java-info" }
+zipfs = {module = "com.github.burningtnt:ZipFS", version.ref = "zipfs"}
 
 [plugins]
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }


### PR DESCRIPTION
目前 HMCL 依赖 jdk ZipFS。依照在崩溃分析群的观察，部分玩家在使用损坏的 ZipFS 实现时会出现无法解析整合包、模组信息等问题。将这一仅有 120K 的库嵌入 HMCL 中可以解决这一问题，并不再需要面对不同发行版中 zipfs 的不同表现。此外，这将给予我们自定义报错信息等方面更大自由度。