### PR TITLE
修复部分 Linux 环境中未正确选择默认字体的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/FontManager.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/FontManager.java
@@ -163,6 +163,16 @@ public final class FontManager {
                         }
                     }
 
+                    if (family.indexOf(',') >= 0) {
+                        for (String candidateFamily : family.split(",")) {
+                            for (Font font : fonts) {
+                                if (font.getFamily().equalsIgnoreCase(candidateFamily)) {
+                                    return font;
+                                }
+                            }
+                        }
+                    }
+
                     LOG.warning(String.format("Family '%s' not found in font file '%s'", family, path));
                     return fonts[0];
                 } catch (NoSuchMethodException | IllegalAccessException ignored) {


### PR DESCRIPTION
有时候 `fc-match` 会返回一个 font family 列表，而不是单个 font family 名称。HMCL 应当处理这种情况。