### PR TITLE
Fix #4063: 修复游戏版本列表去重问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameRemoteVersion.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameRemoteVersion.java
@@ -56,7 +56,12 @@ public final class GameRemoteVersion extends RemoteVersion {
         if (!(o instanceof GameRemoteVersion))
             return 0;
 
-        return o.getReleaseDate().compareTo(getReleaseDate());
+        int dateCompare = o.getReleaseDate().compareTo(getReleaseDate());
+        if (dateCompare != 0) {
+            return dateCompare;
+        }
+
+        return getSelfVersion().compareTo(o.getSelfVersion());
     }
 
     private static Type getReleaseType(ReleaseType type) {


### PR DESCRIPTION
> 被吞的版本共同点是 **有发布时间一致的另一个版本**，
> 查阅源码发现内部是使用 TreeSet **基于发布时间** 比较版本、排序


![屏幕截图 2025-07-05 084714](https://github.com/user-attachments/assets/70e27b61-2568-4ec3-b3aa-03c4e8760999)

![屏幕截图 2025-07-05 084754](https://github.com/user-attachments/assets/ec0936d5-4f11-4807-b76b-3b0118948736)
