### PR TITLE
Fix #4067: 修复使用 JavaFX 25 启动时下载界面布局错位的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
@@ -121,8 +121,8 @@ public abstract class AbstractInstallersPage extends Control implements WizardPa
                 InstallerItem[] libraries = control.group.getLibraries();
 
                 FlowPane libraryPane = new FlowPane(libraries);
-                libraryPane.setVgap(16);
-                libraryPane.setHgap(12);
+                libraryPane.setVgap(8);
+                libraryPane.setHgap(16);
 
                 ScrollPane scrollPane = new ScrollPane(libraryPane);
                 scrollPane.setFitToWidth(true);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
@@ -122,18 +122,13 @@ public abstract class AbstractInstallersPage extends Control implements WizardPa
 
                 FlowPane libraryPane = new FlowPane(libraries);
                 libraryPane.setVgap(16);
-                libraryPane.setHgap(16);
+                libraryPane.setHgap(12);
 
-                if (libraries.length <= 8) {
-                    BorderPane.setMargin(libraryPane, new Insets(16, 0, 16, 0));
-                    root.setCenter(libraryPane);
-                } else {
-                    ScrollPane scrollPane = new ScrollPane(libraryPane);
-                    scrollPane.setFitToWidth(true);
-                    scrollPane.setFitToHeight(true);
-                    BorderPane.setMargin(scrollPane, new Insets(16, 0, 16, 0));
-                    root.setCenter(scrollPane);
-                }
+                ScrollPane scrollPane = new ScrollPane(libraryPane);
+                scrollPane.setFitToWidth(true);
+                scrollPane.setFitToHeight(true);
+                BorderPane.setMargin(scrollPane, new Insets(16, 0, 16, 0));
+                root.setCenter(scrollPane);
             }
 
             {


### PR DESCRIPTION
不知道为什么，使用 JavaFX 25 时中央的 FlowPane 的高度会增加一倍，包装到 ScrollPane 里就好了……