### PR TITLE
fix: prevent unexpected Button Animation when pressing BACK and FORWARD mouse button

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
@@ -173,10 +173,18 @@ public class DecoratorController {
 
         try {
             // For JavaFX 12+
-            MouseButton button = MouseButton.valueOf("BACK");
+            MouseButton backButton = MouseButton.valueOf("BACK");
+            MouseButton forwardButton = MouseButton.valueOf("FORWARD");
             navigator.addEventFilter(MouseEvent.MOUSE_CLICKED, e -> {
-                if (e.getButton() == button) {
+                if (e.getButton() == backButton) {
                     back();
+                    e.consume();
+                }
+            });
+
+            // Prevent unexpected button click animation when click BACK and FORWARD mouse button.
+            navigator.addEventFilter(MouseEvent.MOUSE_PRESSED, e -> {
+                if (e.getTarget() instanceof StackPane && (e.getButton() == forwardButton || e.getButton() == backButton)) {
                     e.consume();
                 }
             });


### PR DESCRIPTION
This patch fix the unexpected button animation triggered by BACK and FORWARD mouse button.

Before: click animation is triggered by press two button
![HMCL behavior before this patch](https://github.com/user-attachments/assets/c4d4ca6d-bc16-4051-ae59-0ce302d72716)

After: No more animation when press the two buttons.

Signed-off-by: KamijoToma <admin@misakacloud.net>