### PR TITLE
修复 InstallersPage 意外地显示滚动条的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
@@ -121,14 +121,19 @@ public abstract class AbstractInstallersPage extends Control implements WizardPa
                 InstallerItem[] libraries = control.group.getLibraries();
 
                 FlowPane libraryPane = new FlowPane(libraries);
-                libraryPane.setVgap(8);
+                libraryPane.setVgap(16);
                 libraryPane.setHgap(16);
 
-                ScrollPane scrollPane = new ScrollPane(libraryPane);
-                scrollPane.setFitToWidth(true);
-                scrollPane.setFitToHeight(true);
-                BorderPane.setMargin(scrollPane, new Insets(16, 0, 16, 0));
-                root.setCenter(scrollPane);
+                if (libraries.length <= 8) {
+                    BorderPane.setMargin(libraryPane, new Insets(16, 0, 16, 0));
+                    root.setCenter(libraryPane);
+                } else {
+                    ScrollPane scrollPane = new ScrollPane(libraryPane);
+                    scrollPane.setFitToWidth(true);
+                    scrollPane.setFitToHeight(true);
+                    BorderPane.setMargin(scrollPane, new Insets(16, 0, 16, 0));
+                    root.setCenter(scrollPane);
+                }
             }
 
             {


### PR DESCRIPTION
Reverts HMCL-dev/HMCL#4069

看起来使用 `ScrollPane` 会导致一些情况下意外的出现滚动条，所以先还原吧，之后再研究怎么彻底解决。