### PR TITLE
Bump HMCLauncher to 3.7.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-hmclauncher = "3.6.0.6"
+hmclauncher = "3.7.0.0"
 jetbrains-annotations = "26.0.1"
 kala-compress = "1.27.1-1"
 simple-png-javafx = "0.3.0"


### PR DESCRIPTION
此版本的 HMCLauncher 不再会选择 Java 8~10 启动 HMCL。