### PR TITLE
使用 readAllBytes 和 transferTo 简化代码

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/ExecutableHeaderHelper.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/ExecutableHeaderHelper.java
@@ -64,7 +64,7 @@ final class ExecutableHeaderHelper {
             ZipEntry entry = zip.getEntry(location);
             if (entry != null && !entry.isDirectory()) {
                 try (InputStream in = zip.getInputStream(entry)) {
-                    return Optional.of(IOUtils.readFullyAsByteArray(in));
+                    return Optional.of(IOUtils.readFully(in));
                 }
             }
         }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/IntegrityChecker.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/IntegrityChecker.java
@@ -55,7 +55,7 @@ public final class IntegrityChecker {
             if (in == null) {
                 throw new IOException("Public key not found");
             }
-            return KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(IOUtils.readFullyAsByteArray(in)));
+            return KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(IOUtils.readFully(in)));
         } catch (GeneralSecurityException e) {
             throw new IOException("Failed to load public key", e);
         }
@@ -76,7 +76,7 @@ public final class IntegrityChecker {
                     }
 
                     if (SIGNATURE_FILE.equals(filename)) {
-                        signature = IOUtils.readFullyAsByteArray(in);
+                        signature = IOUtils.readFully(in);
                     } else {
                         md.reset();
                         fileFingerprints.put(filename, DigestUtils.digest(md, in));

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeOldInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeOldInstallTask.java
@@ -25,7 +25,6 @@ import org.jackhuang.hmcl.game.Version;
 import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.util.gson.JsonUtils;
 import org.jackhuang.hmcl.util.io.FileUtils;
-import org.jackhuang.hmcl.util.io.IOUtils;
 
 import java.io.*;
 import java.nio.file.Path;
@@ -78,7 +77,7 @@ public class ForgeOldInstallTask extends Task<Version> {
 
             ZipEntry forgeEntry = zipFile.getEntry(installProfile.getInstall().getFilePath());
             try (InputStream is = zipFile.getInputStream(forgeEntry); OutputStream os = new FileOutputStream(forgeFile)) {
-                IOUtils.copyTo(is, os);
+                is.transferTo(os);
             }
 
             setResult(installProfile.getVersionInfo()

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/LibraryDownloadTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/LibraryDownloadTask.java
@@ -26,7 +26,6 @@ import org.jackhuang.hmcl.task.FileDownloadTask.IntegrityCheck;
 import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.util.DigestUtils;
 import org.jackhuang.hmcl.util.io.FileUtils;
-import org.jackhuang.hmcl.util.io.IOUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -164,7 +163,7 @@ public class LibraryDownloadTask extends Task<Void> {
         JarInputStream jar = new JarInputStream(new ByteArrayInputStream(data));
         JarEntry entry = jar.getNextJarEntry();
         while (entry != null) {
-            byte[] eData = IOUtils.readFullyWithoutClosing(jar);
+            byte[] eData = jar.readAllBytes();
             if (entry.getName().equals("checksums.sha1")) {
                 hashes = new String(eData, StandardCharsets.UTF_8).split("\n");
             }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
@@ -25,7 +25,6 @@ import org.jackhuang.hmcl.util.ServerAddress;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.gson.UUIDTypeAdapter;
 import org.jackhuang.hmcl.util.io.FileUtils;
-import org.jackhuang.hmcl.util.io.IOUtils;
 import org.jackhuang.hmcl.util.io.Unzipper;
 import org.jackhuang.hmcl.util.platform.Bits;
 import org.jackhuang.hmcl.util.platform.*;
@@ -420,7 +419,7 @@ public class DefaultLauncher extends Launcher {
         }
 
         try (InputStream input = source; OutputStream output = new FileOutputStream(targetFile)) {
-            IOUtils.copyTo(input, output);
+            input.transferTo(output);
         }
     }
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/HttpMultipartRequest.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/HttpMultipartRequest.java
@@ -52,7 +52,7 @@ public final class HttpMultipartRequest implements Closeable {
         addLine(String.format("Content-Disposition: form-data; name=\"%s\"; filename=\"%s\"", name, filename));
         addLine("Content-Type: " + contentType);
         addLine("");
-        IOUtils.copyTo(inputStream, stream);
+        inputStream.transferTo(stream);
         addLine("");
         return this;
     }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/IOUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/IOUtils.java
@@ -74,7 +74,7 @@ public final class IOUtils {
     }
 
     public static String readFullyAsStringWithClosing(InputStream stream) throws IOException {
-        return new String(readFullyWithoutClosing(stream), UTF_8);
+        return new String(stream.readAllBytes(), UTF_8);
     }
 
     public static byte[] readFully(InputStream stream) throws IOException {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/IOUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/IOUtils.java
@@ -70,46 +70,29 @@ public final class IOUtils {
      * @throws IOException if an I/O error occurs.
      */
     public static byte[] readFullyWithoutClosing(InputStream stream) throws IOException {
-        ByteArrayOutputStream result = new ByteArrayOutputStream(Math.max(stream.available(), 32));
-        copyTo(stream, result);
-        return result.toByteArray();
+        return stream.readAllBytes();
     }
 
     public static String readFullyAsStringWithClosing(InputStream stream) throws IOException {
-        ByteArrayOutputStream result = new ByteArrayOutputStream(Math.max(stream.available(), 32));
-        copyTo(stream, result);
-        return result.toString(UTF_8);
+        return new String(readFullyWithoutClosing(stream), UTF_8);
     }
 
-    /**
-     * Read all bytes to a buffer from given input stream, and close the input stream finally.
-     *
-     * @param stream the InputStream being read, closed finally.
-     * @return all bytes read from the stream
-     * @throws IOException if an I/O error occurs.
-     */
-    public static ByteArrayOutputStream readFully(InputStream stream) throws IOException {
-        try (InputStream is = stream) {
-            ByteArrayOutputStream result = new ByteArrayOutputStream(Math.max(is.available(), 32));
-            copyTo(is, result);
-            return result;
+    public static byte[] readFully(InputStream stream) throws IOException {
+        try (stream) {
+            return stream.readAllBytes();
         }
     }
 
-    public static byte[] readFullyAsByteArray(InputStream stream) throws IOException {
-        return readFully(stream).toByteArray();
-    }
-
     public static String readFullyAsString(InputStream stream) throws IOException {
-        return readFully(stream).toString(UTF_8);
+        return new String(readFully(stream), UTF_8);
     }
 
     public static String readFullyAsString(InputStream stream, Charset charset) throws IOException {
-        return readFully(stream).toString(charset);
+        return new String(readFully(stream), charset);
     }
 
     public static void copyTo(InputStream src, OutputStream dest) throws IOException {
-        copyTo(src, dest, new byte[DEFAULT_BUFFER_SIZE]);
+        src.transferTo(dest);
     }
 
     public static void copyTo(InputStream src, OutputStream dest, byte[] buf) throws IOException {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/IOUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/IOUtils.java
@@ -91,10 +91,6 @@ public final class IOUtils {
         return new String(readFully(stream), charset);
     }
 
-    public static void copyTo(InputStream src, OutputStream dest) throws IOException {
-        src.transferTo(dest);
-    }
-
     public static void copyTo(InputStream src, OutputStream dest, byte[] buf) throws IOException {
         while (true) {
             int len = src.read(buf);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/tree/TarFileTree.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/tree/TarFileTree.java
@@ -20,7 +20,6 @@ package org.jackhuang.hmcl.util.tree;
 
 import kala.compress.archivers.tar.TarArchiveEntry;
 import kala.compress.archivers.tar.TarArchiveReader;
-import org.jackhuang.hmcl.util.io.IOUtils;
 
 import java.io.*;
 import java.nio.file.Files;
@@ -42,7 +41,7 @@ public final class TarFileTree extends ArchiveFileTree<TarArchiveReader, TarArch
             try (GZIPInputStream input = new GZIPInputStream(Files.newInputStream(file));
                  OutputStream output = Files.newOutputStream(tempFile, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE)
             ) {
-                IOUtils.copyTo(input, output);
+                input.transferTo(output);
                 tarFile = new TarArchiveReader(tempFile);
             } catch (Throwable e) {
                 try {


### PR DESCRIPTION
这两个方法通常比 `IOUtils` 中的实现的更高效。