### PR TITLE
[Bug] 内存泄漏，在调试启动数十次游戏后内存耗尽

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/LauncherHelper.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/LauncherHelper.java
@@ -126,17 +126,9 @@ public final class LauncherHelper {
     }
 
     private void launch0() {
-		int _stale = 0;
-		for (var iterator = PROCESSES.iterator(); iterator.hasNext(); ) {
-			var process = iterator.next();
-			if (process.get() == null) {
-				iterator.remove();
-				_stale++;
-			}
-		}
-        if (_stale > 0)
-            LOG.warning("Removed stale ManagedProcess objects: "+_stale);
-        
+        // https://github.com/HMCL-dev/HMCL/pull/4121
+        PROCESSES.removeIf(it -> it.get() == null);
+
         HMCLGameRepository repository = profile.getRepository();
         DefaultDependencyManager dependencyManager = profile.getDependency();
         AtomicReference<Version> version = new AtomicReference<>(MaintainTask.maintain(repository, repository.getResolvedVersion(selectedVersion)));


### PR DESCRIPTION
游戏退出后直接点击叉号关闭日志窗口，几十次后（JVM启动时间：55小时），内存耗尽
经过VisualVM的分析，至少ManagedProcess对象存在内存泄漏，我的PR修复了这个问题，同样经过VisualVM的分析确认

