### PR TITLE
忽略 %ProgramFiles%\Common Files\Oracle\Java 中的 Java

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/java/JavaManager.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/java/JavaManager.java
@@ -411,8 +411,15 @@ public final class JavaManager {
         if (System.getenv("PATH") != null) {
             String[] paths = System.getenv("PATH").split(File.pathSeparator);
             for (String path : paths) {
+                // https://github.com/HMCL-dev/HMCL/issues/4079
+                // https://github.com/Meloong-Git/PCL/issues/4261
+                if (OperatingSystem.CURRENT_OS == OperatingSystem.WINDOWS && path.toLowerCase(Locale.ROOT)
+                        .contains("\\common files\\oracle\\java\\")) {
+                    continue;
+                }
+
                 try {
-                    tryAddJavaExecutable(javaRuntimes, Paths.get(path, OperatingSystem.CURRENT_OS.getJavaExecutable()));
+                    tryAddJavaExecutable(javaRuntimes, Path.of(path, OperatingSystem.CURRENT_OS.getJavaExecutable()));
                 } catch (InvalidPathException ignored) {
                 }
             }


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/issues/4079
https://github.com/Meloong-Git/PCL/issues/4261

这个文件夹中的 Java 实际上是一个别名，有些时候行为很怪异，我们应该忽略它。