### PR TITLE
遵循系统动画开关设置

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/animation/AnimationUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/animation/AnimationUtils.java
@@ -18,6 +18,7 @@
 package org.jackhuang.hmcl.ui.animation;
 
 import org.jackhuang.hmcl.setting.ConfigHolder;
+import org.jackhuang.hmcl.ui.FXUtils;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
 /**
@@ -36,7 +37,7 @@ public final class AnimationUtils {
     public static void init() {
     }
 
-    private static final boolean ENABLED = !ConfigHolder.config().isAnimationDisabled();
+    private static final boolean ENABLED = !ConfigHolder.config().isAnimationDisabled() && FXUtils.REDUCED_MOTION != Boolean.TRUE;
     private static final boolean PLAY_WINDOW_ANIMATION = ENABLED && !OperatingSystem.CURRENT_OS.isLinuxOrBSD();
 
     public static boolean isAnimationEnabled() {


### PR DESCRIPTION
在系统设置中禁用了 UI 动画时禁用 HMCL 的动画效果。

这项功能仅对 JavaFX 22+ 生效。