### PR TITLE
修复“下载线程数”的指示器被提示覆盖的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
@@ -123,6 +123,14 @@ public class DownloadSettingsPage extends StackPane {
                 }
 
                 {
+                    HintPane hintPane = new HintPane(MessageDialogPane.MessageType.INFO);
+                    VBox.setMargin(hintPane, new Insets(0, 0, 0, 30));
+                    hintPane.disableProperty().bind(config().autoDownloadThreadsProperty());
+                    hintPane.setText(i18n("settings.launcher.download.threads.hint"));
+                    downloadThreads.getChildren().add(hintPane);
+                }
+
+                {
                     HBox hbox = new HBox(8);
                     hbox.setAlignment(Pos.CENTER);
                     hbox.setPadding(new Insets(0, 0, 0, 30));
@@ -149,14 +157,6 @@ public class DownloadSettingsPage extends StackPane {
 
                     hbox.getChildren().setAll(label, slider, threadsField);
                     downloadThreads.getChildren().add(hbox);
-                }
-
-                {
-                    HintPane hintPane = new HintPane(MessageDialogPane.MessageType.INFO);
-                    VBox.setMargin(hintPane, new Insets(0, 0, 0, 30));
-                    hintPane.disableProperty().bind(config().autoDownloadThreadsProperty());
-                    hintPane.setText(i18n("settings.launcher.download.threads.hint"));
-                    downloadThreads.getChildren().add(hintPane);
                 }
             }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
@@ -123,15 +123,8 @@ public class DownloadSettingsPage extends StackPane {
                 }
 
                 {
-                    HintPane hintPane = new HintPane(MessageDialogPane.MessageType.INFO);
-                    VBox.setMargin(hintPane, new Insets(0, 0, 0, 30));
-                    hintPane.disableProperty().bind(config().autoDownloadThreadsProperty());
-                    hintPane.setText(i18n("settings.launcher.download.threads.hint"));
-                    downloadThreads.getChildren().add(hintPane);
-                }
-
-                {
                     HBox hbox = new HBox(8);
+                    hbox.setStyle("-fx-view-order: -1;"); // prevent the indicator from being covered by the hint
                     hbox.setAlignment(Pos.CENTER);
                     hbox.setPadding(new Insets(0, 0, 0, 30));
                     hbox.disableProperty().bind(config().autoDownloadThreadsProperty());
@@ -157,6 +150,14 @@ public class DownloadSettingsPage extends StackPane {
 
                     hbox.getChildren().setAll(label, slider, threadsField);
                     downloadThreads.getChildren().add(hbox);
+                }
+
+                {
+                    HintPane hintPane = new HintPane(MessageDialogPane.MessageType.INFO);
+                    VBox.setMargin(hintPane, new Insets(0, 0, 0, 30));
+                    hintPane.disableProperty().bind(config().autoDownloadThreadsProperty());
+                    hintPane.setText(i18n("settings.launcher.download.threads.hint"));
+                    downloadThreads.getChildren().add(hintPane);
                 }
             }
 


### PR DESCRIPTION
<img width="1227" height="762" alt="PixPin_2025-07-30_22-48-26" src="https://github.com/user-attachments/assets/72d6e7a3-cf8b-424d-9f3d-52f08b3aea3c" />
<img width="1227" height="762" alt="PixPin_2025-07-30_22-51-18" src="https://github.com/user-attachments/assets/d61c01d2-bdb1-451e-8f87-02113f46742a" />
