### PR TITLE
支持通过环境变量强制使用 GPU 渲染和控制动画帧率

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/EntryPoint.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/EntryPoint.java
@@ -44,15 +44,23 @@ public final class EntryPoint {
         System.getProperties().putIfAbsent("javafx.autoproxy.disable", "true");
         System.getProperties().putIfAbsent("http.agent", "HMCL/" + Metadata.VERSION);
 
+        createHMCLDirectories();
+        LOG.start(Metadata.HMCL_CURRENT_DIRECTORY.resolve("logs"));
+
         if ("true".equalsIgnoreCase(System.getenv("HMCL_FORCE_GPU")))
             System.getProperties().putIfAbsent("prism.forceGPU", "true");
 
         String animationFrameRate = System.getenv("HMCL_ANIMATION_FRAME_RATE");
-        if (animationFrameRate != null)
-            System.getProperties().putIfAbsent("javafx.animation.pulse", animationFrameRate);
+        if (animationFrameRate != null) {
+            try {
+                if (Integer.parseInt(animationFrameRate) <= 0)
+                    throw new NumberFormatException(animationFrameRate);
 
-        createHMCLDirectories();
-        LOG.start(Metadata.HMCL_CURRENT_DIRECTORY.resolve("logs"));
+                System.getProperties().putIfAbsent("javafx.animation.pulse", animationFrameRate);
+            } catch (NumberFormatException e) {
+                LOG.warning("Invalid animation frame rate: " + animationFrameRate);
+            }
+        }
 
         checkDirectoryPath();
 


### PR DESCRIPTION
本 PR 添加了两个新环境变量：

- `HMCL_FORCE_GPU`：将其设置为 `true` 时会强制使用 GPU 渲染；
- `HMCL_ANIMATION_FRAME_RATE`：用于控制 HMCL 动画帧率。
