### PR TITLE
fix(#4166): 新增内存显示条禁用样式

### DIFF
--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -106,12 +106,24 @@
     -fx-background-color: -fx-base-darker-color;
 }
 
+.memory-used:disabled {
+    -fx-opacity: 0.4;
+}
+
 .memory-allocate {
     -fx-background-color: derive(-fx-base-color, 100%);
 }
 
+.memory-allocate:disabled {
+    -fx-opacity: 0.4;
+}
+
 .memory-total {
     -fx-background-color: -fx-base-rippler-color;
+}
+
+.memory-total:disabled {
+    -fx-opacity: 0.4;
 }
 
 .update-label {


### PR DESCRIPTION
fix(#4166): 新增内存显示条禁用样式

before:
<img width="853" height="198" alt="image" src="https://github.com/user-attachments/assets/d267f0e8-36ed-4634-92c1-79a36d3944da" />

after: 
<img width="722" height="195" alt="image" src="https://github.com/user-attachments/assets/c524a7ca-0b46-4545-84f2-e2cbb831e319" />
