### PR TITLE
修复未正确处理 EnumBackgroundImage.TRANSLUCENT 的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/EnumBackgroundImage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/EnumBackgroundImage.java
@@ -22,6 +22,6 @@ public enum EnumBackgroundImage {
     CUSTOM,
     CLASSIC,
     NETWORK,
-    TRANSLUCENT,
+    TRANSLUCENT, // Deprecated
     PAINT
 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
@@ -234,7 +234,7 @@ public class DecoratorController {
                 image = newBuiltinImage("/assets/img/background-classic.jpg");
                 break;
             case TRANSLUCENT:
-                return new Background(new BackgroundFill(new Color(1, 1, 1, Lang.clamp(0, config().getBackgroundImageOpacity(), 100) / 100.), CornerRadii.EMPTY, Insets.EMPTY));
+                return new Background(new BackgroundFill(new Color(1, 1, 1, 0.5), CornerRadii.EMPTY, Insets.EMPTY));
             case PAINT:
                 Paint paint = config().getBackgroundPaint();
                 double opacity = Lang.clamp(0, config().getBackgroundImageOpacity(), 100) / 100.;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
@@ -233,7 +233,7 @@ public class DecoratorController {
             case CLASSIC:
                 image = newBuiltinImage("/assets/img/background-classic.jpg");
                 break;
-            case TRANSLUCENT:
+            case TRANSLUCENT: // Deprecated
                 return new Background(new BackgroundFill(new Color(1, 1, 1, 0.5), CornerRadii.EMPTY, Insets.EMPTY));
             case PAINT:
                 Paint paint = config().getBackgroundPaint();


### PR DESCRIPTION
应当保证其行为和旧版本 HMCL 一致。