### PR TITLE
修复 APNG Truecolour16Alpha 处理器克隆方法返回类型错误的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/image/apng/argb8888/Argb8888Processors.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/image/apng/argb8888/Argb8888Processors.java
@@ -453,7 +453,7 @@ public class Argb8888Processors {
 
         @Override
         public Argb8888ScanlineProcessor clone(int bytesPerRow, Argb8888Bitmap bitmap) {
-            return new Truecolour16(bytesPerRow, bitmap);
+            return new Truecolour16Alpha(bytesPerRow, bitmap);
         }
     }
 


### PR DESCRIPTION
本 PR 解决的应该就是 #4205 简介中提到的问题（至少症状是差不多的）

测试文件：[helloface.apng](https://github.com/user-attachments/assets/c0939d3e-1ccc-4249-89f9-61511354995d)（应该需要修改扩展名？）
编码命令行：`ffmpeg -i C:\Windows\SystemApps\Microsoft.Windows.CloudExperienceHost_cw5n1h2txyewy\media\HelloFaceAnimation.gif -plays 0 -pix_fmt rgba64be helloface.apng`

修复前
<img width="818" height="508" alt="java_Z8w4sAED9p" src="https://github.com/user-attachments/assets/df95b865-3387-420f-878b-639db8c55128" />

修复后
<img width="818" height="508" alt="image" src="https://github.com/user-attachments/assets/78b99078-b330-4389-8a8d-9c543b0e84d3" />

我不知道该不该提交上游