### PR TITLE
Bump Shadow Plugin to 9.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ java-info = "1.0"
 junit = "5.13.4"
 
 # plugins
-shadow = "8.3.6"
+shadow = "9.0.0"
 
 [libraries]
 hmclauncher = { module = "org.glavo.hmcl:HMCLauncher", version.ref = "hmclauncher" }


### PR DESCRIPTION
由于 https://github.com/GradleUp/shadow/issues/1610 ，在更新插件后 HMCL 无法正常构建。我们需要等上游修复这个问题。