### PR TITLE
进一步修复#4063：版本列表排序错误

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameRemoteVersion.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameRemoteVersion.java
@@ -54,15 +54,16 @@ public final class GameRemoteVersion extends RemoteVersion {
 
     @Override
     public int compareTo(RemoteVersion o) {
-        if (!(o instanceof GameRemoteVersion))
+        if (!(o instanceof GameRemoteVersion)) {
             return 0;
+        }
 
         int dateCompare = o.getReleaseDate().compareTo(getReleaseDate());
         if (dateCompare != 0) {
             return dateCompare;
         }
 
-        return GameVersionNumber.compare(getSelfVersion(), o.getSelfVersion());
+        return GameVersionNumber.compare(o.getSelfVersion(), getSelfVersion());
     }
 
     private static Type getReleaseType(ReleaseType type) {


### PR DESCRIPTION
我上次修的 https://github.com/HMCL-dev/HMCL/pull/4066/ 有个小bug，时间一样应该按照版本号大的来

<img width="387" height="228" alt="屏幕截图 2025-08-11 161432" src="https://github.com/user-attachments/assets/6323b236-0f3e-4fd5-a1e1-ef77855c400a" />

<img width="516" height="257" alt="屏幕截图 2025-08-11 162436" src="https://github.com/user-attachments/assets/fe8f8d23-fb53-491b-bb59-4873a638bc5c" />
