### PR TITLE
修复单选选项中间的点不居中

### DIFF
--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -641,9 +641,9 @@
  *                                                                             *
  ******************************************************************************/
 
- .jfx-radio-button {
+.jfx-radio-button {
     -jfx-selected-color: -fx-base-check-color;
- }
+}
 
 .jfx-radio-button .radio {
     -fx-stroke-width: 2.0px;
@@ -652,6 +652,8 @@
 
 .jfx-radio-button .dot {
     -fx-fill: -fx-base-check-color;
+    -fx-translate-x: 0;
+    -fx-translate-y: 0;
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Fix #4107 

<img width="1385" height="769" alt="image" src="https://github.com/user-attachments/assets/16fb9a5e-daa3-424d-97d4-b82f6ef1371b" />

虽然感觉看起来还是有点不居中，但仔细比对像素似乎基本没问题）