### PR TITLE
修复1.21.5以上的地图跳转种子地图错误

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/ChunkBaseApp.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/ChunkBaseApp.java
@@ -30,9 +30,9 @@ public final class ChunkBaseApp {
     private static final GameVersionNumber MIN_GAME_VERSION = GameVersionNumber.asGameVersion("1.7");
 
     private static final String[] SEED_MAP_GAME_VERSIONS = {
-            "1.21.5", "1.21.4", "1.21.2", "1.21", "1.20", "1.19.3", "1.19",
-            "1.18", "1.17", "1.16", "1.15", "1.14", "1.13", "1.12", "1.11",
-            "1.10", "1.9", "1.8", "1.7"
+            "1.21.6", "1.21.5", "1.21.4", "1.21.2", "1.21", "1.20", "1.19.3",
+            "1.19", "1.18", "1.17", "1.16", "1.15", "1.14", "1.13", "1.12",
+            "1.11", "1.10", "1.9", "1.8", "1.7"
     };
 
     public static final String[] STRONGHOLD_FINDER_GAME_VERSIONS = {


### PR DESCRIPTION
之前1.21.5+版本的地图跳转 Chunkbase 依然是1.21.5版本。这块以后可能要盯着点

<img width="772" height="777" alt="屏幕截图 2025-08-16 161656" src="https://github.com/user-attachments/assets/17414a88-9de6-426d-ac45-cb610f47b41f" />
