### PR TITLE
修复 Windows 平台 GPU 信息可能显示为"[B@xxx" 的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/windows/WindowsGPUDetector.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/windows/WindowsGPUDetector.java
@@ -27,6 +27,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -94,7 +95,14 @@ final class WindowsGPUDetector {
         } else if (object instanceof String[]) {
             return String.join(" ", (String[]) object);
         } else if (object instanceof byte[]) {
-            return new String((byte[])object);
+            String value = null;
+            try {
+                value = new String((byte[])object, "UTF-16LE");
+                value = value.replaceAll("\0", "");
+                return value;
+            } catch (UnsupportedEncodingException e) {
+                return object.toString();
+            }
         } else {
             return object.toString();
         }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/windows/WindowsGPUDetector.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/windows/WindowsGPUDetector.java
@@ -93,6 +93,8 @@ final class WindowsGPUDetector {
             return null;
         } else if (object instanceof String[]) {
             return String.join(" ", (String[]) object);
+        } else if (object instanceof byte[]) {
+            return new String((byte[])object);
         } else {
             return object.toString();
         }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/windows/WindowsGPUDetector.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/windows/WindowsGPUDetector.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -95,14 +95,8 @@ final class WindowsGPUDetector {
         } else if (object instanceof String[]) {
             return String.join(" ", (String[]) object);
         } else if (object instanceof byte[]) {
-            String value = null;
-            try {
-                value = new String((byte[])object, "UTF-16LE");
-                value = value.replaceAll("\0", "");
-                return value;
-            } catch (UnsupportedEncodingException e) {
-                return object.toString();
-            }
+            return new String((byte[]) object, StandardCharsets.UTF_16LE)
+                    .replace("\0", "");
         } else {
             return object.toString();
         }


### PR DESCRIPTION
#4286 修复Windows启动时注册表项目类型为`REG_BINARY`时输出的GPU信息不正常