### PR TITLE
Fix #4290: 在 macOS 上禁止最大化和全屏模式

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/Controllers.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/Controllers.java
@@ -217,8 +217,10 @@ public final class Controllers {
             if (targetProperty != null
                     && Controllers.stage != null
                     && !Controllers.stage.isIconified()
-                    && !Controllers.stage.isFullScreen()
-                    && !Controllers.stage.isMaximized()) {
+                    // https://github.com/HMCL-dev/HMCL/issues/4290
+                    && (OperatingSystem.CURRENT_OS == OperatingSystem.MACOS ||
+                    !Controllers.stage.isFullScreen() && !Controllers.stage.isMaximized())
+            ) {
                 targetProperty.set(sourceProperty.get());
             }
         };

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
@@ -58,6 +58,7 @@ import org.jackhuang.hmcl.ui.construct.JFXDialogPane;
 import org.jackhuang.hmcl.ui.wizard.Refreshable;
 import org.jackhuang.hmcl.ui.wizard.WizardProvider;
 import org.jackhuang.hmcl.util.Lang;
+import org.jackhuang.hmcl.util.platform.OperatingSystem;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
@@ -164,13 +165,16 @@ public class DecoratorController {
         // press ESC to go back
         onEscPressed(navigator, this::back);
 
-        // press F11 to toggle full screen
-        navigator.addEventHandler(KeyEvent.KEY_PRESSED, e -> {
-            if (e.getCode() == KeyCode.F11) {
-                stage.setFullScreen(!stage.isFullScreen());
-                e.consume();
-            }
-        });
+        // https://github.com/HMCL-dev/HMCL/issues/4290
+        if (OperatingSystem.CURRENT_OS != OperatingSystem.MACOS) {
+            // press F11 to toggle full screen
+            navigator.addEventHandler(KeyEvent.KEY_PRESSED, e -> {
+                if (e.getCode() == KeyCode.F11) {
+                    stage.setFullScreen(!stage.isFullScreen());
+                    e.consume();
+                }
+            });
+        }
 
         try {
             // For JavaFX 12+

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorSkin.java
@@ -47,6 +47,7 @@ import org.jackhuang.hmcl.ui.animation.AnimationProducer;
 import org.jackhuang.hmcl.ui.animation.ContainerAnimations;
 import org.jackhuang.hmcl.ui.animation.TransitionPane;
 import org.jackhuang.hmcl.ui.wizard.Navigation;
+import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
 public class DecoratorSkin extends SkinBase<Decorator> {
     private final StackPane root, parent;
@@ -89,22 +90,31 @@ public class DecoratorSkin extends SkinBase<Decorator> {
         EventHandler<MouseEvent> onMouseReleased = this::onMouseReleased;
         EventHandler<MouseEvent> onMouseDragged = this::onMouseDragged;
         EventHandler<MouseEvent> onMouseMoved = this::onMouseMoved;
-        onWindowsStatusChange = observable -> {
-            if (primaryStage.isIconified() || primaryStage.isFullScreen() || primaryStage.isMaximized()) {
-                root.removeEventFilter(MouseEvent.MOUSE_RELEASED, onMouseReleased);
-                root.removeEventFilter(MouseEvent.MOUSE_DRAGGED, onMouseDragged);
-                root.removeEventFilter(MouseEvent.MOUSE_MOVED, onMouseMoved);
-            } else {
-                root.addEventFilter(MouseEvent.MOUSE_RELEASED, onMouseReleased);
-                root.addEventFilter(MouseEvent.MOUSE_DRAGGED, onMouseDragged);
-                root.addEventFilter(MouseEvent.MOUSE_MOVED, onMouseMoved);
-            }
-        };
-        WeakInvalidationListener weakOnWindowsStatusChange = new WeakInvalidationListener(onWindowsStatusChange);
-        primaryStage.iconifiedProperty().addListener(weakOnWindowsStatusChange);
-        primaryStage.maximizedProperty().addListener(weakOnWindowsStatusChange);
-        primaryStage.fullScreenProperty().addListener(weakOnWindowsStatusChange);
-        onWindowsStatusChange.invalidated(null);
+
+        // https://github.com/HMCL-dev/HMCL/issues/4290
+        if (OperatingSystem.CURRENT_OS != OperatingSystem.MACOS) {
+            onWindowsStatusChange = observable -> {
+                if (primaryStage.isIconified() || primaryStage.isFullScreen() || primaryStage.isMaximized()) {
+                    root.removeEventFilter(MouseEvent.MOUSE_RELEASED, onMouseReleased);
+                    root.removeEventFilter(MouseEvent.MOUSE_DRAGGED, onMouseDragged);
+                    root.removeEventFilter(MouseEvent.MOUSE_MOVED, onMouseMoved);
+                } else {
+                    root.addEventFilter(MouseEvent.MOUSE_RELEASED, onMouseReleased);
+                    root.addEventFilter(MouseEvent.MOUSE_DRAGGED, onMouseDragged);
+                    root.addEventFilter(MouseEvent.MOUSE_MOVED, onMouseMoved);
+                }
+            };
+            WeakInvalidationListener weakOnWindowsStatusChange = new WeakInvalidationListener(onWindowsStatusChange);
+            primaryStage.iconifiedProperty().addListener(weakOnWindowsStatusChange);
+            primaryStage.maximizedProperty().addListener(weakOnWindowsStatusChange);
+            primaryStage.fullScreenProperty().addListener(weakOnWindowsStatusChange);
+            onWindowsStatusChange.invalidated(null);
+        } else {
+            onWindowsStatusChange = null;
+            root.addEventFilter(MouseEvent.MOUSE_RELEASED, onMouseReleased);
+            root.addEventFilter(MouseEvent.MOUSE_DRAGGED, onMouseDragged);
+            root.addEventFilter(MouseEvent.MOUSE_MOVED, onMouseMoved);
+        }
 
         shadowContainer.getChildren().setAll(parent);
         root.getChildren().setAll(shadowContainer);
@@ -177,12 +187,16 @@ public class DecoratorSkin extends SkinBase<Decorator> {
 
         BorderPane titleBar = new BorderPane();
         titleContainer.getChildren().add(titleBar);
-        titleBar.addEventHandler(MouseEvent.MOUSE_CLICKED, event -> {
-            if (event.getButton() == MouseButton.PRIMARY && event.getClickCount() == 2) {
-                primaryStage.setMaximized(!primaryStage.isMaximized());
-                event.consume();
-            }
-        });
+
+        // https://github.com/HMCL-dev/HMCL/issues/4290
+        if (OperatingSystem.CURRENT_OS != OperatingSystem.MACOS) {
+            titleBar.addEventHandler(MouseEvent.MOUSE_CLICKED, event -> {
+                if (event.getButton() == MouseButton.PRIMARY && event.getClickCount() == 2) {
+                    primaryStage.setMaximized(!primaryStage.isMaximized());
+                    event.consume();
+                }
+            });
+        }
 
         Rectangle buttonsContainerPlaceHolder = new Rectangle();
         {


### PR DESCRIPTION
macOS 对最大化/全屏模式的支持很奇怪。为了避免出现意外行为，我们暂时禁止在 macOS 上进入最大化和全屏模式。

本 PR 合并后我会尽快发布并推送新版本。