### PR TITLE
修复世界管理不支持显示极限模式

### DIFF
--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -1140,6 +1140,7 @@ world.info.player.food_level=Hunger Level
 world.info.player.game_type=Game Mode
 world.info.player.game_type.adventure=Adventure
 world.info.player.game_type.creative=Creative
+world.info.player.game_type.hardcore=Hardcore
 world.info.player.game_type.spectator=Spectator
 world.info.player.game_type.survival=Survival
 world.info.player.health=Health

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -945,6 +945,7 @@ world.info.player.food_level=饑餓值
 world.info.player.game_type=遊戲模式
 world.info.player.game_type.adventure=冒險
 world.info.player.game_type.creative=創造
+world.info.player.game_type.hardcore=極限
 world.info.player.game_type.spectator=旁觀者
 world.info.player.game_type.survival=生存
 world.info.player.health=生命值

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -956,6 +956,7 @@ world.info.player.food_level=饥饿值
 world.info.player.game_type=游戏模式
 world.info.player.game_type.adventure=冒险
 world.info.player.game_type.creative=创造
+world.info.player.game_type.hardcore=极限
 world.info.player.game_type.spectator=旁观者
 world.info.player.game_type.survival=生存
 world.info.player.health=生命值


### PR DESCRIPTION
之前即使世界已经是极限模式，会被显示为生存模式

AI的解释是这样的：

在 Minecraft 的 `level.dat` 里，Hardcore 并不是一个单独的 `GameType`，而是由两个 NBT 字段共同决定的：

* `hardcore` (ByteTag) = 1 → 世界是极限模式
* `playerGameType` (IntTag) = 存储基础模式（通常是 0 = 生存），但 UI 上应显示为 **极限模式**

这个PR修复了这个问题，下拉框添加了极限模式。经过测试，无论是将已存在的世界更改为极限模式还是识别极限极限模式都没有问题。

<img width="732" height="251" alt="屏幕截图 2025-08-23 110655" src="https://github.com/user-attachments/assets/3990bb91-745b-46eb-85b1-d80560cd7734" />


<img width="547" height="187" alt="屏幕截图 2025-08-23 110844" src="https://github.com/user-attachments/assets/8f40854c-89b5-4939-87ad-bb1685554b8d" />