### PR TITLE
将 URI 中的错误代理对编码为 U+FFFD

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/NetworkUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/NetworkUtils.java
@@ -186,8 +186,8 @@ public final class NetworkUtils {
                         }
                     }
 
-                    // Invalid surrogate pair, encode as '?'
-                    builder.append("%3F");
+                    // Invalid surrogate pair, encode as U+FFF0
+                    encodeCodePoint(builder, 0xfff0);
                     continue;
                 }
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/NetworkUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/NetworkUtils.java
@@ -186,8 +186,8 @@ public final class NetworkUtils {
                         }
                     }
 
-                    // Invalid surrogate pair, encode as U+FFF0
-                    encodeCodePoint(builder, 0xfff0);
+                    // Invalid surrogate pair, encode as U+FFFD (replacement character)
+                    encodeCodePoint(builder, 0xfffd);
                     continue;
                 }
 

--- a/HMCLCore/src/test/java/org/jackhuang/hmcl/util/io/NetworkUtilsTest.java
+++ b/HMCLCore/src/test/java/org/jackhuang/hmcl/util/io/NetworkUtilsTest.java
@@ -45,10 +45,10 @@ public class NetworkUtilsTest {
         assertEquals("https://www.example.com/%E6%B5%8B%E8%AF%95?a=10+20", encodeLocation("https://www.example.com/测试?a=10 20"));
 
         // Invalid surrogate pair
-        assertEquals("https://www.example.com/%3F", encodeLocation("https://www.example.com/\uD83D"));
-        assertEquals("https://www.example.com/%3F", encodeLocation("https://www.example.com/\uDE07"));
-        assertEquals("https://www.example.com/%3Ftest", encodeLocation("https://www.example.com/\uD83Dtest"));
-        assertEquals("https://www.example.com/%3Ftest", encodeLocation("https://www.example.com/\uDE07test"));
+        assertEquals("https://www.example.com/%EF%BF%BD", encodeLocation("https://www.example.com/\uD83D"));
+        assertEquals("https://www.example.com/%EF%BF%BD", encodeLocation("https://www.example.com/\uDE07"));
+        assertEquals("https://www.example.com/%EF%BF%BDtest", encodeLocation("https://www.example.com/\uD83Dtest"));
+        assertEquals("https://www.example.com/%EF%BF%BDtest", encodeLocation("https://www.example.com/\uDE07test"));
     }
 
     @Test


### PR DESCRIPTION
相比 `?`(`%3F`)，U+FFFD (replacement character) 更能明确表示这是一个错误字符。