### PR TITLE
启动游戏时隐藏 GameAssetDownloadTask

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/DefaultDependencyManager.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/DefaultDependencyManager.java
@@ -85,7 +85,8 @@ public class DefaultDependencyManager extends AbstractDependencyManager {
                     else
                         return null;
                 }).thenComposeAsync(checkPatchCompletionAsync(version, integrityCheck)),
-                new GameAssetDownloadTask(this, version, GameAssetDownloadTask.DOWNLOAD_INDEX_IF_NECESSARY, integrityCheck),
+                new GameAssetDownloadTask(this, version, GameAssetDownloadTask.DOWNLOAD_INDEX_IF_NECESSARY, integrityCheck)
+                        .setSignificance(Task.TaskSignificance.MODERATE),
                 new GameLibrariesTask(this, version, integrityCheck)
         );
     }


### PR DESCRIPTION
`GameAssetDownloadTask` 设置了 `hmcl.install.assets` 作为 stage，但启动游戏时我们没有显示该 stage，这会导致 `GameAssetDownloadTask` 显示在 `TaskListPane` 的顶部。我们应该避免这个问题。