### PR TITLE
添加 Apache Maven 中央仓库的镜像地址

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/BMCLAPIDownloadProvider.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/BMCLAPIDownloadProvider.java
@@ -78,6 +78,7 @@ public final class BMCLAPIDownloadProvider implements DownloadProvider {
                 pair("https://maven.fabricmc.net", apiRoot + "/maven"),
                 pair("https://authlib-injector.yushi.moe", apiRoot + "/mirrors/authlib-injector"),
                 pair("https://repo1.maven.org/maven2", "https://mirrors.cloud.tencent.com/nexus/repository/maven-public"),
+                pair("https://repo.maven.apache.org/maven2", "https://mirrors.cloud.tencent.com/nexus/repository/maven-public"),
                 pair("https://zkitefly.github.io/unlisted-versions-of-minecraft", "https://alist.8mi.tech/d/mirror/unlisted-versions-of-minecraft/Auto")
 //                // https://github.com/mcmod-info-mirror/mcim-rust-api
 //                pair("https://api.modrinth.com", "https://mod.mcimirror.top/modrinth"),


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/pull/4272

Cleanroom 的 libraries 中包含大量 `https://repo.maven.apache.org/maven2` 的地址