### PR TITLE
Fix #4409: 修复导出的历史日志文件为空的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/SettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/SettingsPage.java
@@ -220,12 +220,11 @@ public final class SettingsPage extends SettingsView {
                             // If an exception occurs while decompressing the input file, we should
                             // ensure the input file and the current zip entry are closed.
 
-                            InputStream input = null;
+                            InputStream input;
                             try {
                                 input = Files.newInputStream(path);
                             } catch (Throwable ex) {
                                 LOG.warning("Failed to open log file " + path, ex);
-                                IOUtils.closeQuietly(input, ex);
                                 continue;
                             }
 


### PR DESCRIPTION
除此之外，我还进行了一些重构。现在在导出日志时不再需要创建临时文件，并且在原样复制日志文件的时候也不会因为读取日志文件发生错误而中断导出日志。