### PR TITLE
删除不必要的 System.gc() 调用

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java
@@ -125,9 +125,6 @@ public class HMCLGameRepository extends DefaultGameRepository {
         } catch (IOException ex) {
             LOG.warning("Unable to create launcher_profiles.json, Forge/LiteLoader installer will not work.", ex);
         }
-
-        // https://github.com/HMCL-dev/HMCL/issues/938
-        System.gc();
     }
 
     public void changeDirectory(File newDirectory) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DatapackListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DatapackListPage.java
@@ -74,9 +74,6 @@ public final class DatapackListPage extends ListPageBase<DatapackListPageSkin.Da
         Task.runAsync(datapack::loadFromDir)
                 .withRunAsync(Schedulers.javafx(), () -> {
                     setLoading(false);
-
-                    // https://github.com/HMCL-dev/HMCL/issues/938
-                    System.gc();
                 })
                 .start();
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPage.java
@@ -110,9 +110,6 @@ public final class ModListPage extends ListPageBase<ModListPageSkin.ModInfoObjec
                 itemsProperty().setAll(list.stream().map(ModListPageSkin.ModInfoObject::new).sorted().collect(Collectors.toList()));
             else
                 getProperties().remove(ModListPage.class);
-
-            // https://github.com/HMCL-dev/HMCL/issues/938
-            System.gc();
         }, Platform::runLater);
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/WorldListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/WorldListPage.java
@@ -99,9 +99,6 @@ public final class WorldListPage extends ListPageBase<WorldListItem> implements 
                     } else {
                         LOG.warning("Failed to load world list page", exception);
                     }
-
-                    // https://github.com/HMCL-dev/HMCL/issues/938
-                    System.gc();
                 }).start();
     }
 


### PR DESCRIPTION
这些 `System.gc()` 是为了解决 Java 8～11 不支持内存 uncommit，导致启动器所占的系统内存不断增大的问题而插入的。

现在我们已经弃用了对 Java 11 的支持，这些调用可以删除了。删除这些 `System.gc()` 调用还能减少  full gc 造成的 UI 卡顿。