### PR TITLE
[release/3.6] 修复“下载线程数”的指示器被提示覆盖的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
@@ -124,6 +124,7 @@ public class DownloadSettingsPage extends StackPane {
 
                 {
                     HBox hbox = new HBox(8);
+                    hbox.setStyle("-fx-view-order: -1;"); // prevent the indicator from being covered by the hint
                     hbox.setAlignment(Pos.CENTER);
                     hbox.setPadding(new Insets(0, 0, 0, 30));
                     hbox.disableProperty().bind(config().autoDownloadThreadsProperty());


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/pull/4153