### PR TITLE
[release/3.6] 修复 RemoteMod::getIntegrityCheck 未选择正确的算法的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/RemoteMod.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/RemoteMod.java
@@ -302,11 +302,13 @@ public class RemoteMod {
 
         public FileDownloadTask.IntegrityCheck getIntegrityCheck() {
             if (hashes.containsKey("md5")) {
-                return new FileDownloadTask.IntegrityCheck("MD5", hashes.get("sha1"));
+                return new FileDownloadTask.IntegrityCheck("MD5", hashes.get("md5"));
             } else if (hashes.containsKey("sha1")) {
                 return new FileDownloadTask.IntegrityCheck("SHA-1", hashes.get("sha1"));
+            } else if (hashes.containsKey("sha256")) {
+                return new FileDownloadTask.IntegrityCheck("SHA-256", hashes.get("sha256"));
             } else if (hashes.containsKey("sha512")) {
-                return new FileDownloadTask.IntegrityCheck("SHA-256", hashes.get("sha1"));
+                return new FileDownloadTask.IntegrityCheck("SHA-512", hashes.get("sha512"));
             } else {
                 return null;
             }


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/pull/4238