### PR TITLE
修复`download.hint`翻译条目未添加`光影`的说明

### DIFF
--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -331,7 +331,7 @@ curse.sort.total_downloads=Total Downloads
 datetime.format=MMM d, yyyy, h\:mm\:ss a
 
 download=Download
-download.hint=Install games and modpacks or download mods, resource packs, and worlds.
+download.hint=Install games and modpacks or download mods, resource packs, shaders, and worlds.
 download.code.404=File "%s" not found on the remote server.
 download.content=Addons
 download.shader=Shaders

--- a/HMCL/src/main/resources/assets/lang/I18N_es.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_es.properties
@@ -332,7 +332,7 @@ curse.sort.total_downloads=Descargas totales
 datetime.format=d MMM yyyy, H\:mm\:ss
 
 download=Descargar
-download.hint=Instalar juegos y modpacks o descargar mods, paquetes de recursos y mundos.
+download.hint=Instalar juegos y modpacks o descargar mods, paquetes de recursos, sombreadores y mundos.
 download.code.404=Archivo no encontrado en el servidor remoto: %s
 download.content=Complementos
 download.shader=Sombreadores

--- a/HMCL/src/main/resources/assets/lang/I18N_ja.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_ja.properties
@@ -286,7 +286,7 @@ curse.sort.total_downloads=合計ダウンロード数
 datetime.format=yyyy/MM/dd H:mm:ss
 
 download=ダウンロード
-download.hint=ゲームや modpack をインストールするか、mod、リソース パック、マップをダウンロードします
+download.hint=ゲームや modpack をインストールするか、mod、リソース パック、マップ、シェーダーをダウンロードします
 download.code.404=リモートサーバーにファイルが見つかりません：%s
 download.content=ゲームコンテンツ
 download.shader=シェーダー

--- a/HMCL/src/main/resources/assets/lang/I18N_lzh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_lzh.properties
@@ -341,7 +341,7 @@ curse.sort.total_downloads=引數
 datetime.format=yyyy 年 MM 月 dd 日 HH:mm:ss
 
 download=引
-download.hint=裝戯事、改囊集，引改囊、資囊與輿圖
+download.hint=裝戯事、改囊集，引改囊、資囊、光影與輿圖
 download.code.404=伺服器無案曰：%s\n君可求助於右上之鈕。
 download.content=戲案
 download.shader=光影

--- a/HMCL/src/main/resources/assets/lang/I18N_ru.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_ru.properties
@@ -333,7 +333,7 @@ curse.sort.total_downloads=Скачиваний
 datetime.format=d MMM yyyy г., HH\:mm\:ss
 
 download=Скачать
-download.hint=Установить игры и модпаки или скачать моды, пакеты ресурсов и миры.
+download.hint=Установить игры и модпаки или скачать моды, пакеты ресурсов, шейдеры и миры.
 download.code.404=Файл «%s» не найден на удаленном сервере.
 download.content=Аддоны
 download.shader=Шейдеры

--- a/HMCL/src/main/resources/assets/lang/I18N_uk.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_uk.properties
@@ -330,7 +330,7 @@ curse.sort.total_downloads=Всього завантажень
 datetime.format=dd.MM.yyyy, HH:mm:ss
 
 download=Завантажити
-download.hint=Встановіть ігри та модпаки або завантажте моди, пакети ресурсів та світи.
+download.hint=Встановіть ігри та модпаки або завантажте моди, пакети ресурсів, шейдери та світи.
 download.code.404=Файл "%s" не знайдено на віддаленому сервері.
 download.content=Додатки
 download.shader=Шейдери

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -333,7 +333,7 @@ curse.sort.total_downloads=下載量
 datetime.format=yyyy 年 MM 月 dd 日 HH:mm:ss
 
 download=下載
-download.hint=安裝遊戲和模組包或下載模組、資源包和地圖
+download.hint=安裝遊戲和模組包或下載模組、資源包、光影和地圖
 download.code.404=遠端伺服器沒有需要下載的檔案：%s
 download.content=遊戲內容
 download.shader=光影

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -341,7 +341,7 @@ curse.sort.total_downloads=下载量
 datetime.format=yyyy 年 MM 月 dd 日 HH:mm:ss
 
 download=下载
-download.hint=安装游戏和整合包或下载模组、资源包和地图
+download.hint=安装游戏和整合包或下载模组、资源包、光影和地图
 download.code.404=远程服务器不包含需要下载的文件: %s\n你可以点击右上角帮助按钮进行求助。
 download.content=游戏内容
 download.shader=光影


### PR DESCRIPTION
正好下面两行有光影的译文，这样就问题不大了，也请了AI核查
```
download.hint=安裝遊戲和模組包或下載模組、資源包、光影和地圖
download.shader=光影
```
<img width="572" height="107" alt="屏幕截图 2025-09-13 203255" src="https://github.com/user-attachments/assets/07a7aed1-52c5-48b9-8819-73c7548ee241" />

另外我还发现tooltip里是“地图”，下载页中叫“世界”，有必要统一它们吗？