### PR TITLE
清理  org.jackhuang.hmcl.util.logging

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/Level.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/Level.java
@@ -1,8 +1,0 @@
-package org.jackhuang.hmcl.util.logging;
-
-/**
- * @author Glavo
- */
-public enum Level {
-    ERROR, WARNING, INFO, DEBUG, TRACE
-}

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/LogEvent.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/LogEvent.java
@@ -11,11 +11,11 @@ abstract class LogEvent {
     static final class DoLog extends LogEvent {
         final long time;
         final String caller;
-        final Level level;
+        final System.Logger.Level level;
         final String message;
         final Throwable exception;
 
-        DoLog(long time, String caller, Level level, String message, Throwable exception) {
+        DoLog(long time, String caller, System.Logger.Level level, String message, Throwable exception) {
             this.time = time;
             this.caller = caller;
             this.level = level;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/LogEvent.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/LogEvent.java
@@ -7,24 +7,16 @@ import java.util.concurrent.CountDownLatch;
 /**
  * @author Glavo
  */
-abstract class LogEvent {
-    static final class DoLog extends LogEvent {
-        final long time;
-        final String caller;
-        final System.Logger.Level level;
-        final String message;
-        final Throwable exception;
-
-        DoLog(long time, String caller, System.Logger.Level level, String message, Throwable exception) {
-            this.time = time;
-            this.caller = caller;
-            this.level = level;
-            this.message = message;
-            this.exception = exception;
-        }
+sealed interface LogEvent {
+    record DoLog(long time,
+                 String caller,
+                 System.Logger.Level level,
+                 String message,
+                 Throwable exception
+    ) implements LogEvent {
     }
 
-    static final class ExportLog extends LogEvent {
+    final class ExportLog implements LogEvent {
         final CountDownLatch latch = new CountDownLatch(1);
 
         final OutputStream output;
@@ -39,6 +31,6 @@ abstract class LogEvent {
         }
     }
 
-    static final class Shutdown extends LogEvent {
+    final class Shutdown implements LogEvent {
     }
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/LogEvent.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/LogEvent.java
@@ -1,3 +1,20 @@
+/*
+ * Hello Minecraft! Launcher
+ * Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.jackhuang.hmcl.util.logging;
 
 import java.io.IOException;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/Logger.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/Logger.java
@@ -23,6 +23,7 @@ import org.tukaani.xz.LZMA2Options;
 import org.tukaani.xz.XZOutputStream;
 
 import java.io.*;
+import java.lang.System.Logger.Level;
 import java.nio.file.*;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -114,8 +115,7 @@ public final class Logger {
             logWriter.println(log);
             if (exception != null)
                 exception.printStackTrace(logWriter);
-        } else if (event instanceof LogEvent.ExportLog) {
-            LogEvent.ExportLog exportEvent = (LogEvent.ExportLog) event;
+        } else if (event instanceof LogEvent.ExportLog exportEvent) {
             logWriter.flush();
             try {
                 if (logFile != null) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/Logger.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/Logger.java
@@ -87,26 +87,26 @@ public final class Logger {
         StringBuilder builder = this.builder;
         builder.setLength(0);
         builder.append('[');
-        TIME_FORMATTER.formatTo(Instant.ofEpochMilli(event.time), builder);
+        TIME_FORMATTER.formatTo(Instant.ofEpochMilli(event.time()), builder);
         builder.append("] [");
 
-        if (event.caller != null && event.caller.startsWith(PACKAGE_PREFIX)) {
-            builder.append("@.").append(event.caller, PACKAGE_PREFIX.length(), event.caller.length());
+        if (event.caller() != null && event.caller().startsWith(PACKAGE_PREFIX)) {
+            builder.append("@.").append(event.caller(), PACKAGE_PREFIX.length(), event.caller().length());
         } else {
-            builder.append(event.caller);
+            builder.append(event.caller());
         }
 
         builder.append('/')
-                .append(event.level)
+                .append(event.level())
                 .append("] ")
-                .append(filterForbiddenToken(event.message));
+                .append(filterForbiddenToken(event.message()));
         return builder.toString();
     }
 
     private void handle(LogEvent event) {
         if (event instanceof LogEvent.DoLog) {
             String log = format((LogEvent.DoLog) event);
-            Throwable exception = ((LogEvent.DoLog) event).exception;
+            Throwable exception = ((LogEvent.DoLog) event).exception();
 
             System.out.println(log);
             if (exception != null)

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/Logger.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/logging/Logger.java
@@ -104,9 +104,9 @@ public final class Logger {
     }
 
     private void handle(LogEvent event) {
-        if (event instanceof LogEvent.DoLog) {
-            String log = format((LogEvent.DoLog) event);
-            Throwable exception = ((LogEvent.DoLog) event).exception();
+        if (event instanceof LogEvent.DoLog doLog) {
+            String log = format(doLog);
+            Throwable exception = doLog.exception();
 
             System.out.println(log);
             if (exception != null)
@@ -368,7 +368,9 @@ public final class Logger {
         log(Level.TRACE, CallerFinder.getCaller(), msg, exception);
     }
 
-    private static final class LogFile implements Comparable<LogFile> {
+    private record LogFile(Path file,
+                           int year, int month, int day, int hour, int minute, int second,
+                           int n) implements Comparable<LogFile> {
         private static final Pattern FILE_NAME_PATTERN = Pattern.compile("(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})T(?<hour>\\d{2})-(?<minute>\\d{2})-(?<second>\\d{2})(\\.(?<n>\\d+))?\\.log(\\.(gz|xz))?");
 
         private static @Nullable LogFile ofFile(Path file) {
@@ -390,26 +392,6 @@ public final class Logger {
             return new LogFile(file, year, month, day, hour, minute, second, n);
         }
 
-        private final Path file;
-        private final int year;
-        private final int month;
-        private final int day;
-        private final int hour;
-        private final int minute;
-        private final int second;
-        private final int n;
-
-        private LogFile(Path file, int year, int month, int day, int hour, int minute, int second, int n) {
-            this.file = file;
-            this.year = year;
-            this.month = month;
-            this.day = day;
-            this.hour = hour;
-            this.minute = minute;
-            this.second = second;
-            this.n = n;
-        }
-
         @Override
         public int compareTo(@NotNull Logger.LogFile that) {
             if (this.year != that.year) return Integer.compare(this.year, that.year);
@@ -429,7 +411,7 @@ public final class Logger {
 
         @Override
         public boolean equals(Object obj) {
-            return obj instanceof LogFile && compareTo((LogFile) obj) == 0;
+            return obj instanceof LogFile that && compareTo(that) == 0;
         }
     }
 }


### PR DESCRIPTION
这个类是为了在 Java 8 中替代 `java.lang.System.Logger.Level` 而引入的，现在我们可以直接使用 `java.lang.System.Logger.Level` 了，所以没有必要保留它。