### PR TITLE
修复删除世界时无法删除zip格式世界的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/game/World.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/game/World.java
@@ -279,7 +279,7 @@ public final class World {
         if (isLocked()) {
             throw new WorldLockedException("The world " + getFile() + " has been locked");
         }
-        FileUtils.forceDelete(file.toFile());
+        FileUtils.forceDelete(file);
     }
 
     public CompoundTag readLevelDat() throws IOException {


### PR DESCRIPTION
使用`forceDelete`可以判断是文件还是文件夹进行删除，现在无法删除非文件夹的内容。

当前HMCL会把存档文件夹里的zip压缩世界都在列表中显示，实际上原版MC不会显示zip格式的世界

<img width="788" height="357" alt="屏幕截图 2025-09-17 200622" src="https://github.com/user-attachments/assets/741dd2d6-3020-456a-a8ce-34e6a0491aff" />

并且zip格式的还存在其他bug，如打开**世界文件夹**不会打开文件夹，虽然启动器不会崩溃，但是没有任何反应。

我建议删除zip格式的读取