### PR TITLE
优化 Java 自动选择规则

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/java/JavaManager.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/java/JavaManager.java
@@ -264,16 +264,15 @@ public final class JavaManager {
         }
     }
 
-    private static int compareJavaVersion(JavaRuntime java1, JavaRuntime java2, GameJavaVersion suggestedJavaVersion) {
-        if (suggestedJavaVersion != null) {
-            boolean b1 = java1.getParsedVersion() == suggestedJavaVersion.getMajorVersion();
-            boolean b2 = java2.getParsedVersion() == suggestedJavaVersion.getMajorVersion();
+    private static JavaRuntime chooseJava(@Nullable JavaRuntime java1, JavaRuntime java2) {
+        if (java1 == null)
+            return java2;
 
-            if (b1 != b2)
-                return b1 ? 1 : -1;
-        }
-
-        return java1.getVersionNumber().compareTo(java2.getVersionNumber());
+        if (java1.getParsedVersion() != java2.getParsedVersion())
+            // Prefer the Java version that is closer to the game's recommended Java version
+            return java1.getParsedVersion() < java2.getParsedVersion() ? java1 : java2;
+        else
+            return java1.getVersionNumber().compareTo(java2.getVersionNumber()) > 0 ? java1 : java2;
     }
 
     @Nullable
@@ -288,9 +287,6 @@ public final class JavaManager {
         boolean forceX86 = Architecture.SYSTEM_ARCH == Architecture.ARM64
                 && (OperatingSystem.CURRENT_OS == OperatingSystem.WINDOWS || OperatingSystem.CURRENT_OS == OperatingSystem.MACOS)
                 && (gameVersion == null || gameVersion.compareTo("1.6") < 0);
-
-        GameJavaVersion suggestedJavaVersion =
-                (version != null && gameVersion != null && gameVersion.compareTo("1.7.10") >= 0) ? version.getJavaVersion() : null;
 
         JavaRuntime mandatory = null;
         JavaRuntime suggested = null;
@@ -319,15 +315,10 @@ public final class JavaManager {
             }
 
             if (!violationMandatory) {
-                if (mandatory == null) mandatory = java;
-                else if (compareJavaVersion(java, mandatory, suggestedJavaVersion) > 0)
-                    mandatory = java;
+                mandatory = chooseJava(mandatory, java);
 
-                if (!violationSuggested) {
-                    if (suggested == null) suggested = java;
-                    else if (compareJavaVersion(java, suggested, suggestedJavaVersion) > 0)
-                        suggested = java;
-                }
+                if (!violationSuggested)
+                    suggested = chooseJava(suggested, java);
             }
         }
 

--- a/HMCLCore/src/test/java/org/jackhuang/hmcl/util/platform/JavaRuntimeTest.java
+++ b/HMCLCore/src/test/java/org/jackhuang/hmcl/util/platform/JavaRuntimeTest.java
@@ -13,6 +13,7 @@ public final class JavaRuntimeTest {
     public void testParseVersion() {
         assertEquals(8, parseVersion("1.8.0_302"));
         assertEquals(8, parseVersion("1.8-internal"));
+        assertEquals(8, parseVersion("8.0"));
         assertEquals(11, parseVersion("11"));
         assertEquals(11, parseVersion("11.0.12"));
         assertEquals(11, parseVersion("11-internal"));


### PR DESCRIPTION
HMCL 旧的 Java 自动选择规则会优先匹配主版本号和游戏推荐 Java 版本号一致的版本，否则优先选择版本更高的 Java。

举个例子，对于 Minecraft 1.17，游戏推荐的 Java 版本为 16。如果用户同时安装了 Java 17 和 Java 25，那么 HMCL 会自动选择 Java 25。

本 PR 调整了 Java 版本匹配规则，现在 HMCL 会优先选择 Java 主版本号更低的 Java，让 Java 版本与游戏推荐 Java 更接近。