### PR TITLE
[release/3.6] 修复启用代理身份认证且未设置密码时启动器崩溃的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/ProxyManager.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/ProxyManager.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.net.*;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 import static org.jackhuang.hmcl.util.logging.Logger.LOG;
@@ -61,8 +60,8 @@ public final class ProxyManager {
 
             if (username != null || password != null)
                 return new SimpleAuthenticator(
-                        Objects.requireNonNullElse(username, ""),
-                        Objects.requireNonNullElse(password, "").toCharArray()
+                        Lang.requireNonNullElse(username, ""),
+                        Lang.requireNonNullElse(password, "").toCharArray()
                 );
             else
                 return null;


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/pull/4465