### PR TITLE
GitHub Action 按文件类型分别上传构建产物

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,8 +27,18 @@ jobs:
         CURSEFORGE_API_KEY: ${{ secrets.CURSEFORGE_API_KEY }}
     - name: Get short SHA
       run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
-    - name: Upload Artifacts
+    - name: Upload JAR
       uses: actions/upload-artifact@v4
       with:
-        name: HMCL-${{ env.SHORT_SHA }}
-        path: HMCL/build/libs
+        name: HMCL-${{ env.SHORT_SHA }}-jar
+        path: HMCL/build/libs/HMCL-*.jar*
+    - name: Upload EXE
+      uses: actions/upload-artifact@v4
+      with:
+        name: HMCL-${{ env.SHORT_SHA }}-exe
+        path: HMCL/build/libs/HMCL-*.exe*
+    - name: Upload SH
+      uses: actions/upload-artifact@v4
+      with:
+        name: HMCL-${{ env.SHORT_SHA }}-exe
+        path: HMCL/build/libs/HMCL-*.sh*

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,14 +31,20 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: HMCL-${{ env.SHORT_SHA }}-jar
-        path: HMCL/build/libs/HMCL-*.jar*
+        path: |
+          HMCL/build/libs/HMCL-*.jar
+          HMCL/build/libs/HMCL-*.jar.sha256
     - name: Upload EXE
       uses: actions/upload-artifact@v4
       with:
         name: HMCL-${{ env.SHORT_SHA }}-exe
-        path: HMCL/build/libs/HMCL-*.exe*
+        path: |
+          HMCL/build/libs/HMCL-*.exe
+          HMCL/build/libs/HMCL-*.exe.sha256
     - name: Upload SH
       uses: actions/upload-artifact@v4
       with:
-        name: HMCL-${{ env.SHORT_SHA }}-exe
-        path: HMCL/build/libs/HMCL-*.sh*
+        name: HMCL-${{ env.SHORT_SHA }}-sh
+        path: |
+          HMCL/build/libs/HMCL-*.sh
+          HMCL/build/libs/HMCL-*.sh.sha256


### PR DESCRIPTION
现在单个文件过大，下载 GitHub Action 的构建产物时经常非常缓慢。将这些文件拆分至不同文件中可以大大减少下载 GitHub Action 构建产物的时间。