### PR TITLE
删除 InvocationDispatcher 中的 synchronized 块

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/InvocationDispatcher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/InvocationDispatcher.java
@@ -28,7 +28,7 @@ import java.util.function.Consumer;
 /// @author yushijinhun
 public final class InvocationDispatcher<T> implements Consumer<T> {
 
-
+    /// @param executor The executor must dispatch all tasks to a single thread.
     public static <T> InvocationDispatcher<T> runOn(Executor executor, Consumer<T> action) {
         return new InvocationDispatcher<>(executor, action);
     }


### PR DESCRIPTION
`InvocationDispatcher` 的所有用例的 `Executor` 都使用单个底层线程，所以我们可以移除 synchronized 块。