### PR TITLE
让 JavaFX 线程处于最高优先级运行

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
@@ -70,6 +70,7 @@ public final class Launcher extends Application {
 
     @Override
     public void start(Stage primaryStage) {
+        Thread.currentThread().setPriority(Thread.MAX_PRIORITY);
         Thread.currentThread().setUncaughtExceptionHandler(CRASH_REPORTER);
 
         CookieHandler.setDefault(COOKIE_MANAGER);


### PR DESCRIPTION
在我的设备上，这一行代码可以加速启动器从双击启动到显示 UI 的时间。

- [ ] 通过双盲实验，验证该更改是否具有普适性