### PR TITLE
使用 Gradle 获取更新信息

### DIFF
--- a/.github/workflows/check-update.yml
+++ b/.github/workflows/check-update.yml
@@ -19,20 +19,7 @@ jobs:
       - name: Install tools
         run: sudo apt-get install -y jq
       - name: Fetch last version
-        run: |
-          wget -O ci.json https://ci.huangyuhui.net/job/HMCL/lastSuccessfulBuild/api/json
-          
-          export HMCL_EXE_FILE_NAME=`cat ci.json | jq -M -r '.artifacts[] | select(.fileName | endswith(".exe")) | .fileName'`
-          if [ -z `echo $HMCL_EXE_FILE_NAME | grep -E "^HMCL-[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?\.exe\$"` ]; then exit 1; fi
-          
-          export HMCL_VERSION=`echo "${HMCL_EXE_FILE_NAME%.exe}" | tail -c +6`
-          export HMCL_COMMIT_SHA=`cat ci.json | jq -M -r '.actions[] | select(._class == "hudson.plugins.git.util.BuildData") | .lastBuiltRevision.SHA1'`
-
-          if [ "${#HMCL_COMMIT_SHA}" != 40 ]; then exit 1; fi
-
-          echo "HMCL_VERSION=$HMCL_VERSION" >> $GITHUB_ENV
-          echo "HMCL_COMMIT_SHA=$HMCL_COMMIT_SHA" >> $GITHUB_ENV
-          echo "HMCL_TAG_NAME=v$HMCL_VERSION" >> $GITHUB_ENV
+        run: ./gradlew checkUpdateDev --no-daemon --info --stacktrace
       - name: Check for existing tags
         run: if [ -z "$(git tag -l "$HMCL_TAG_NAME")" ]; then echo "continue=true" >> $GITHUB_ENV; fi
       - name: Download artifacts
@@ -84,20 +71,7 @@ jobs:
       - name: Install tools
         run: sudo apt-get install -y jq
       - name: Fetch last version
-        run: |
-          wget -O ci.json https://ci.huangyuhui.net/job/HMCL-stable/lastSuccessfulBuild/api/json
-          
-          export HMCL_EXE_FILE_NAME=`cat ci.json | jq -M -r '.artifacts[] | select(.fileName | endswith(".exe")) | .fileName'`
-          if [ -z `echo $HMCL_EXE_FILE_NAME | grep -E "^HMCL-[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?\.exe\$"` ]; then exit 1; fi
-          
-          export HMCL_VERSION=`echo "${HMCL_EXE_FILE_NAME%.exe}" | tail -c +6`
-          export HMCL_COMMIT_SHA=`cat ci.json | jq -M -r '.actions[] | select(._class == "hudson.plugins.git.util.BuildData") | .lastBuiltRevision.SHA1'`
-
-          if [ "${#HMCL_COMMIT_SHA}" != 40 ]; then exit 1; fi
-
-          echo "HMCL_VERSION=$HMCL_VERSION" >> $GITHUB_ENV
-          echo "HMCL_COMMIT_SHA=$HMCL_COMMIT_SHA" >> $GITHUB_ENV
-          echo "HMCL_TAG_NAME=release-$HMCL_VERSION" >> $GITHUB_ENV
+        run: ./gradlew checkUpdateStable --no-daemon --info --stacktrace
       - name: Check for existing tags
         run: if ! git tag -l | grep -q "$HMCL_TAG_NAME"; then echo "continue=true" >> $GITHUB_ENV; fi 
       - name: Download artifacts

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jackhuang.hmcl.gradle.ci.CheckUpdate
 import org.jackhuang.hmcl.gradle.docs.UpdateDocuments
 
 plugins {
@@ -66,4 +67,14 @@ defaultTasks("clean", "build")
 
 tasks.register<UpdateDocuments>("updateDocuments") {
     documentsDir.set(layout.projectDirectory.dir("docs"))
+}
+
+tasks.register<CheckUpdate>("checkUpdateDev") {
+    tagPrefix.set("v")
+    api.set("https://ci.huangyuhui.net/job/HMCL/lastSuccessfulBuild/api/json")
+}
+
+tasks.register<CheckUpdate>("checkUpdateStable") {
+    tagPrefix.set("release-")
+    api.set("https://ci.huangyuhui.net/job/HMCL-stable/lastSuccessfulBuild/api/json")
 }

--- a/buildSrc/src/main/java/org/jackhuang/hmcl/gradle/ci/CheckUpdate.java
+++ b/buildSrc/src/main/java/org/jackhuang/hmcl/gradle/ci/CheckUpdate.java
@@ -1,0 +1,136 @@
+/*
+ * Hello Minecraft! Launcher
+ * Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.jackhuang.hmcl.gradle.ci;
+
+import com.google.gson.Gson;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/// @author Glavo
+public abstract class CheckUpdate extends DefaultTask {
+    private static final Logger LOGGER = Logging.getLogger(CheckUpdate.class);
+
+    @Input
+    public abstract Property<String> getApi();
+
+    @Input
+    public abstract Property<String> getTagPrefix();
+
+    public CheckUpdate() {
+        getOutputs().upToDateWhen(task -> false);
+    }
+
+    private static <T> T fetch(URI uri, Class<T> clazz) throws IOException, InterruptedException {
+        // // HttpClient implements Closeable since Java 21
+        //noinspection resource
+        var client = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.ALWAYS)
+                .build();
+
+        HttpResponse<String> response = client.send(HttpRequest.newBuilder(uri).build(), HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() / 100 != 2) {
+            throw new IOException("Bad status code: " + response.statusCode());
+        }
+
+        return new Gson().fromJson(response.body(), clazz);
+    }
+
+    @TaskAction
+    public void run() throws IOException, InterruptedException {
+        String githubEnv = Objects.requireNonNullElse(System.getenv("GITHUB_ENV"), "");
+        if (githubEnv.isBlank())
+            LOGGER.warn("GITHUB_ENV is not set");
+
+        String uri = getApi().get();
+        LOGGER.info("Fetching metadata from {}", uri);
+        BuildInfo buildInfo = Objects.requireNonNull(fetch(URI.create(uri), BuildInfo.class),
+                "Could not fetch build info");
+
+        try (PrintWriter writer = githubEnv.isBlank()
+                ? null
+                : new PrintWriter(Files.newBufferedWriter(Path.of(githubEnv), StandardOpenOption.WRITE, StandardOpenOption.WRITE, StandardOpenOption.APPEND))) {
+
+            BiConsumer<String, String> addEnv = (name, value) -> {
+                String item = name + "=" + value;
+                LOGGER.info(item);
+                if (writer != null)
+                    writer.println(item);
+            };
+
+            String revision = Objects.requireNonNullElse(buildInfo.actions(), List.<BuildInfo.ActionInfo>of())
+                    .stream()
+                    .filter(action -> "hudson.plugins.git.util.BuildData".equals(action._class))
+                    .map(BuildInfo.ActionInfo::lastBuiltRevision)
+                    .map(BuildInfo.ActionInfo.BuiltRevision::SHA1)
+                    .findFirst()
+                    .orElseThrow(() -> new GradleException("Could not find  revision"));
+            if (revision.matches("[0-9a-z]{40}"))
+                addEnv.accept("HMCL_COMMIT_SHA", revision);
+            else
+                throw new GradleException("Invalid revision: " + revision);
+
+            Pattern fileNamePattern = Pattern.compile("HMCL-(?<version>\\d+(?:\\.\\d+)+)\\.jar");
+            String version = Objects.requireNonNullElse(buildInfo.artifacts(), List.<BuildInfo.ArtifactInfo>of())
+                    .stream()
+                    .map(BuildInfo.ArtifactInfo::fileName)
+                    .map(fileNamePattern::matcher)
+                    .filter(Matcher::matches)
+                    .map(matcher -> matcher.group("version"))
+                    .findFirst()
+                    .orElseThrow(() -> new GradleException("Could not find .jar artifact"));
+            addEnv.accept("HMCL_VERSION", version);
+            addEnv.accept("HMCL_TAG_NAME", getTagPrefix().get() + version);
+        }
+    }
+
+    private record BuildInfo(long number,
+                             List<ArtifactInfo> artifacts,
+                             List<ActionInfo> actions
+    ) {
+
+        record ArtifactInfo(String fileName) {
+        }
+
+        record ActionInfo(String _class, BuiltRevision lastBuiltRevision) {
+            record BuiltRevision(String SHA1) {
+
+            }
+        }
+    }
+
+}

--- a/buildSrc/src/main/java/org/jackhuang/hmcl/gradle/ci/CheckUpdate.java
+++ b/buildSrc/src/main/java/org/jackhuang/hmcl/gradle/ci/CheckUpdate.java
@@ -55,7 +55,7 @@ public abstract class CheckUpdate extends DefaultTask {
         getOutputs().upToDateWhen(task -> false);
     }
 
-    private static <T> T fetch(URI uri, Class<T> clazz) throws IOException, InterruptedException {
+    private static <T> T fetch(URI uri, Class<T> type) throws IOException, InterruptedException {
         // // HttpClient implements Closeable since Java 21
         //noinspection resource
         var client = HttpClient.newBuilder()
@@ -67,7 +67,7 @@ public abstract class CheckUpdate extends DefaultTask {
             throw new IOException("Bad status code: " + response.statusCode());
         }
 
-        return new Gson().fromJson(response.body(), clazz);
+        return new Gson().fromJson(response.body(), type);
     }
 
     @TaskAction
@@ -128,7 +128,6 @@ public abstract class CheckUpdate extends DefaultTask {
 
         record ActionInfo(String _class, BuiltRevision lastBuiltRevision) {
             record BuiltRevision(String SHA1) {
-
             }
         }
     }


### PR DESCRIPTION
将相关代码从 bash 迁移至 Java 以降低维护成本。

在 #4075 完成后，检查稳定版更新的代码会更加复杂，继续使用 bash 和 jq 进行检查更新的话维护成本会大幅增高，将其迁移至 Java 更便于未来维护。
