### PR TITLE
Fix #4556 :“在短时间内连续点击“行按钮”不会正常连续更改 是/否”

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/OptionToggleButton.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/OptionToggleButton.java
@@ -25,6 +25,8 @@ import javafx.beans.property.StringProperty;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
@@ -61,7 +63,12 @@ public class OptionToggleButton extends StackPane {
         toggleButton.setSize(8);
         FXUtils.setLimitHeight(toggleButton, 30);
 
-        FXUtils.onClicked(container, () -> toggleButton.setSelected(!toggleButton.isSelected()));
+        container.addEventHandler(MouseEvent.MOUSE_CLICKED, e -> {
+            if (e.getButton() == MouseButton.PRIMARY) {
+                toggleButton.setSelected(!toggleButton.isSelected());
+                e.consume();
+            }
+        });
 
         FXUtils.onChangeAndOperate(subtitleProperty(), subtitle -> {
             if (StringUtils.isNotBlank(subtitle)) {


### PR DESCRIPTION
- Close #4556

`FXUtils#onClicked`  会忽略连点事件

https://github.com/HMCL-dev/HMCL/blob/168c4ac708f5be1039d7ea0667dd5ec7f7dc7d78/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java#L1360-L1366