### PR TITLE
Fix 4555 外观 - 不透明度滑块 刻度线在不同滑块位置时排布不统一

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
@@ -174,6 +174,7 @@ public class PersonalizationPage extends StackPane {
                 }
 
                 Label textOpacity = new Label();
+                FXUtils.setLimitWidth(textOpacity, 35);
 
                 StringBinding valueBinding = Bindings.createStringBinding(() -> ((int) slider.getValue()) + "%", slider.valueProperty());
                 textOpacity.textProperty().bind(valueBinding);


### PR DESCRIPTION
Close #4555
右侧的数值一直变化，数值宽度不等，导致左侧刻度线宽度变化