### PR TITLE
chore(docs&l10n): adjust preview update option text

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/SettingsView.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/SettingsView.java
@@ -152,6 +152,7 @@ public abstract class SettingsView extends StackPane {
                     previewPane = new OptionToggleButton();
                     previewPane.setTitle(i18n("update.preview"));
                     previewPane.selectedProperty().bindBidirectional(config().acceptPreviewUpdateProperty());
+                    FXUtils.installFastTooltip(previewPane, i18n("update.preview.tooltip"));
 
                     settingsPane.getContent().add(previewPane);
                 }

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -1515,7 +1515,8 @@ update.note=Beta and Nightly channels may have more features or fixes, but they 
 update.latest=This is the latest version
 update.no_browser=Cannot open in system browser. But we copied the link to your clipboard, and you can open it manually.
 update.tooltip=Update
-update.preview=Try out the HMCL version
+update.preview=Preview HMCL releases early
+update.preview.tooltip=Enable this option to receive new versions of HMCL early for testing before their official release.
 
 version=Games
 version.name=Instance Name

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -1299,7 +1299,8 @@ update.note=開發版與預覽版包含更多的功能以及錯誤修復，但�
 update.latest=目前版本為最新版本
 update.no_browser=無法開啟瀏覽器。網址已經複製到剪貼簿了，你可以手動複製網址開啟頁面。
 update.tooltip=更新
-update.preview=提前預覽 HMCL 版本
+update.preview=提前測試 HMCL 預覽版本
+update.preview.tooltip=啟用此選項，你將可以提前取得 HMCL 的新版本，以便在正式發布前進行測試。
 
 version=遊戲
 version.name=遊戲實例名稱

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -1310,6 +1310,7 @@ update.latest=当前版本为最新版本
 update.no_browser=无法打开浏览器。网址已经复制到剪贴板，你可以手动粘贴网址打开页面。
 update.tooltip=更新
 update.preview=提前预览 HMCL 版本
+update.preview.tooltip=启用此选项，你将可以提前获取 HMCL 的新版本，以便在正式发布前进行测试。
 
 version=游戏
 version.name=游戏实例名称

--- a/docs/ReleaseSchedule.md
+++ b/docs/ReleaseSchedule.md
@@ -42,7 +42,7 @@ HMCL has two main release channels: **Stable Channel** and **Development Channel
 They are used to release the HMCL stable and development versions, respectively.
 
 To test HMCL versions before official release, we will push updates to some users in advance.
-Users can enable the "Preview HMCL versions in advance" option on the "Settings > General" page to receive preview updates from the corresponding channel.
+Users can enable the "Preview HMCL releases early" option on the "Settings > General" page to receive preview updates from the corresponding channel.
 
 ## Release Model
 


### PR DESCRIPTION
- Revise the option text to make it clearer.
- Add a tooltip to explain the function of this option.

---

I think the original description wasn't particularly clear, especially in English.

So I revised it by referring to the descriptions of the relevant options on the Windows Update page.

related:
- https://github.com/HMCL-dev/HMCL/pull/4223

CC @Glavo, @burningtnt, and @zkitefly 