### PR TITLE
chore(l10n): revise description of copy code option on terracotta page

### DIFF
--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -1464,7 +1464,10 @@ terracotta.status.host_ok=Room created
 terracotta.status.host_ok.code=Invitation code (Copied)
 terracotta.status.host_ok.code.copy=Copy invitation code
 terracotta.status.host_ok.code.copy.toast=Invitation code has been copied to clipboard
-terracotta.status.host_ok.code.desc=Please remind your friends to select Guest mode in HMCL - Multiplayer or PCL CE and enter this invitation code.
+terracotta.status.host_ok.code.desc=Please remind your friends to follow these steps to join:\n\
+   - For HMCL Users: Go to the Multiplayer page and select "I want to join a session".\n\
+   - For PCL CE Users: Go to the "联机" page and select "大厅 → 加入大厅".\n\
+   Finally, enter this invitation code.
 terracotta.status.host_ok.back=This will also close the room, other guests will leave and cannot rejoin.
 terracotta.status.guest_starting=Joining room
 terracotta.status.guest_starting.back=This will not stop other guests from joining the room.

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -1252,7 +1252,10 @@ terracotta.status.host_ok=已建立房間
 terracotta.status.host_ok.code=邀請碼 (已自動複製到剪貼簿)
 terracotta.status.host_ok.code.copy=複製邀請碼
 terracotta.status.host_ok.code.copy.toast=已將邀請碼複製到剪貼簿
-terracotta.status.host_ok.code.desc=請提醒您的朋友在 HMCL 或 PCL CE 多人遊戲功能中選擇房客模式，並輸入該邀請碼。
+terracotta.status.host_ok.code.desc=務必提醒您的朋友們：請先確認並選擇正確的啟動器選項，再輸入邀請碼。\n\
+  - HMCL 使用者：請前往 HMCL 的「多人遊戲」頁面，選擇「我想當房客」。\n\
+  - PCL CE 使用者：請前往 PCL CE 的「联机 → 大厅」頁面，找到「加入大厅」。\n\
+  接著，輸入此邀請碼即可。
 terracotta.status.host_ok.back=這將同時徹底關閉房間，其他房客將退出並不再能重新加入該房間。
 terracotta.status.guest_starting=正在加入房間
 terracotta.status.guest_starting.back=這不會影響其他房客加入目前房間。

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -1262,7 +1262,10 @@ terracotta.status.host_ok=已启动房间
 terracotta.status.host_ok.code=邀请码 (已自动复制到剪贴板)
 terracotta.status.host_ok.code.copy=复制邀请码
 terracotta.status.host_ok.code.copy.toast=已将邀请码复制到剪贴板
-terracotta.status.host_ok.code.desc=请提醒您的朋友在 HMCL 或 PCL CE 多人联机功能中选择房客模式，并输入该邀请码。
+terracotta.status.host_ok.code.desc=务必提醒您的朋友们：请先确认并选择正确的启动器选项，再输入邀请码。\n\
+  - HMCL 用户：请前往 HMCL 的“多人联机”页面，选择“我想当房客”。\n\
+  - PCL CE 用户：请前往 PCL CE 的“联机 → 大厅”页面，然后找到“加入大厅”。\n\
+  最后，输入此邀请码即可。
 terracotta.status.host_ok.back=这将同时彻底关闭房间，其他房客将退出并不再能重新加入该房间。
 terracotta.status.guest_starting=正在加入房间
 terracotta.status.guest_starting.back=这不会影响其他房客加入当前房间。


### PR DESCRIPTION
Revise to make it clearer for new users.

The relevant text remains in Simplified Chinese characters in Traditional Chinese, as PCL CE is currently only available in Simplified Chinese.

Remove the description of PCL CE in English due to the excessive length of the text and the language situation of PCL CE mentioned in the previous paragraph.

related:
- https://github.com/HMCL-dev/HMCL/pull/4215

CC @burningtnt and @Pigeon0v0 