### PR TITLE
feat:增强数据包/资源包`mcmeta`的解析能力

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modinfo/PackMcMeta.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modinfo/PackMcMeta.java
@@ -166,8 +166,13 @@ public class PackMcMeta implements Validation {
                 parts.add(new LocalModFile.Description.Part(parseText(json)));
             } else if (json.isJsonArray()) {
                 for (JsonElement element : json.getAsJsonArray()) {
-                    JsonObject descriptionPart = element.getAsJsonObject();
-                    parts.add(new LocalModFile.Description.Part(descriptionPart.get("text").getAsString(), Optional.ofNullable(descriptionPart.get("color")).map(JsonElement::getAsString).orElse("")));
+                    if (element.isJsonPrimitive()) {
+                        parts.add(new LocalModFile.Description.Part(parseText(element)));
+                    } else {
+                        JsonObject descriptionPart = element.getAsJsonObject();
+                        parts.add(new LocalModFile.Description.Part(descriptionPart.get("text").getAsString(), Optional.ofNullable(descriptionPart.get("color")).map(JsonElement::getAsString).orElse("")));
+                    }
+
                 }
             } else {
                 throw new JsonParseException("pack.mcmeta::pack::json should be String or array of text objects with text and color fields");

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modinfo/PackMcMeta.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modinfo/PackMcMeta.java
@@ -36,6 +36,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 @Immutable
 public class PackMcMeta implements Validation {
@@ -65,24 +66,43 @@ public class PackMcMeta implements Validation {
         @SerializedName("pack_format")
         private final int packFormat;
 
+        @SerializedName("min_format")
+        private final PackVersion minPackVersion;
+        @SerializedName("max_format")
+        private final PackVersion maxPackVersion;
+
         @SerializedName("description")
         private final LocalModFile.Description description;
 
         public PackInfo() {
-            this(0, new LocalModFile.Description(Collections.emptyList()));
+            this(0, new PackVersion(0,0), new PackVersion(0,0), new LocalModFile.Description(Collections.emptyList()));
         }
 
-        public PackInfo(int packFormat, LocalModFile.Description description) {
+        public PackInfo(int packFormat,PackVersion minPackVersion,PackVersion maxPackVersion, LocalModFile.Description description) {
             this.packFormat = packFormat;
+            this.minPackVersion = minPackVersion;
+            this.maxPackVersion = maxPackVersion;
             this.description = description;
         }
 
-        public int getPackFormat() {
-            return packFormat;
+        public PackVersion getEffectiveMinVersion() {
+            return minPackVersion.majorVersion != 0 ? minPackVersion : new PackVersion(packFormat,0);
+        }
+
+        public PackVersion getEffectiveMaxVersion() {
+            return maxPackVersion.majorVersion != 0 ? maxPackVersion : new PackVersion(packFormat,0);
         }
 
         public LocalModFile.Description getDescription() {
             return description;
+        }
+    }
+
+    public record PackVersion(int majorVersion, int minorVersion) {
+
+        @Override
+        public String toString(){
+            return majorVersion + "." + minorVersion;
         }
     }
 
@@ -112,35 +132,49 @@ public class PackMcMeta implements Validation {
             }
         }
 
-        public LocalModFile.Description.Part deserialize(JsonElement json, JsonDeserializationContext context) throws JsonParseException {
-            if (json.isJsonPrimitive()) {
-                return new LocalModFile.Description.Part(parseText(json));
-            } else if (json.isJsonObject()) {
-                JsonObject obj = json.getAsJsonObject();
-                String text = parseText(obj.get("text"));
-                return new LocalModFile.Description.Part(text);
-            } else {
-                throw new JsonParseException("pack.mcmeta Raw JSON text should be string or an object");
+        private PackVersion parseVersion(JsonElement json) throws JsonParseException {
+            if (json == null || json.isJsonNull()) {
+                return new PackVersion(0, 0);
             }
+
+            if (json.isJsonPrimitive() && json.getAsJsonPrimitive().isNumber()) {
+                return new PackVersion(json.getAsInt(), 0);
+            }
+
+            if (json.isJsonArray()) {
+                JsonArray arr = json.getAsJsonArray();
+                if (arr.size() == 1) {
+                    return new PackVersion(arr.get(0).getAsInt(), 0);
+                } else if (arr.size() == 2) {
+                    return new PackVersion(arr.get(0).getAsInt(), arr.get(1).getAsInt());
+                } else {
+                    throw new JsonParseException("Datapack version array must have 1 or 2 elements, but got " + arr.size());
+                }
+            }
+
+            throw new JsonParseException("Datapack version format must be a number or a [major, minor] array.");
         }
 
         @Override
         public PackInfo deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
             List<LocalModFile.Description.Part> parts = new ArrayList<>();
             JsonObject packInfo = json.getAsJsonObject();
-            int packFormat = packInfo.get("pack_format").getAsInt();
+            int packFormat = Optional.ofNullable(packInfo.get("pack_format")).map(JsonElement::getAsInt).orElse(0);
+            PackVersion minVersion = parseVersion(packInfo.get("min_format"));
+            PackVersion maxVersion = parseVersion(packInfo.get("max_format"));
+
             JsonElement description = packInfo.get("description");
             if (description.isJsonPrimitive()) {
                 parts.add(new LocalModFile.Description.Part(parseText(description)));
             } else if (description.isJsonArray()) {
                 for (JsonElement element : description.getAsJsonArray()) {
                     JsonObject descriptionPart = element.getAsJsonObject();
-                    parts.add(new LocalModFile.Description.Part(descriptionPart.get("text").getAsString(), descriptionPart.get("color").getAsString()));
+                    parts.add(new LocalModFile.Description.Part(descriptionPart.get("text").getAsString(), Optional.ofNullable(descriptionPart.get("color")).map(JsonElement::getAsString).orElse("")));
                 }
             } else {
                 throw new JsonParseException("pack.mcmeta::pack::description should be String or array of text objects with text and color fields");
             }
-            return new PackInfo(packFormat, new LocalModFile.Description(parts));
+            return new PackInfo(packFormat, minVersion, maxVersion, new LocalModFile.Description(parts));
         }
     }
 


### PR DESCRIPTION
- [X] 添加1.21.9新字段`min_format`和`max_format`支持 参考[资源包](https://zh.minecraft.wiki/w/%E8%B5%84%E6%BA%90%E5%8C%85#%E8%B5%84%E6%BA%90%E5%8C%85%E5%85%83%E6%95%B0%E6%8D%AE)，[数据包](https://zh.minecraft.wiki/w/%E6%95%B0%E6%8D%AE%E5%8C%85#-{}-pack.mcmeta)
- [ ] 添加完整的文本组件解析文本支持（在过去会直接出错）