### PR TITLE
优化模组信息对话框 UI 宽高

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
@@ -37,6 +37,7 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
 import javafx.util.Duration;
 import org.jackhuang.hmcl.mod.LocalModFile;
 import org.jackhuang.hmcl.mod.ModLoaderType;
@@ -418,6 +419,9 @@ final class ModListPageSkin extends SkinBase<ModListPage> {
             HBox titleContainer = new HBox();
             titleContainer.setSpacing(8);
 
+            Stage stage = Controllers.getStage();
+            maxWidthProperty().bind(stage.widthProperty().multiply(0.5));
+
             ImageView imageView = new ImageView();
             FXUtils.limitSize(imageView, 40, 40);
             loadModIcon(modInfo.getModInfo(), 40)
@@ -456,6 +460,11 @@ final class ModListPageSkin extends SkinBase<ModListPage> {
             descriptionPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
             descriptionPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
             descriptionPane.setFitToWidth(true);
+            description.heightProperty().addListener((obs, oldVal, newVal) -> {
+                double maxHeight = stage.getHeight() * 0.3;
+                double targetHeight = Math.min(newVal.doubleValue(), maxHeight);
+                descriptionPane.setPrefHeight(targetHeight);
+            });
 
             setBody(descriptionPane);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
@@ -420,7 +420,7 @@ final class ModListPageSkin extends SkinBase<ModListPage> {
             titleContainer.setSpacing(8);
 
             Stage stage = Controllers.getStage();
-            maxWidthProperty().bind(stage.widthProperty().multiply(0.5));
+            maxWidthProperty().bind(stage.widthProperty().multiply(0.7));
 
             ImageView imageView = new ImageView();
             FXUtils.limitSize(imageView, 40, 40);
@@ -461,9 +461,9 @@ final class ModListPageSkin extends SkinBase<ModListPage> {
             descriptionPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
             descriptionPane.setFitToWidth(true);
             description.heightProperty().addListener((obs, oldVal, newVal) -> {
-                double maxHeight = stage.getHeight() * 0.3;
+                double maxHeight = stage.getHeight() * 0.5;
                 double targetHeight = Math.min(newVal.doubleValue(), maxHeight);
-                descriptionPane.setPrefHeight(targetHeight);
+                descriptionPane.setPrefViewportHeight(targetHeight);
             });
 
             setBody(descriptionPane);


### PR DESCRIPTION
现在的模组信息对话框会直接占领整个窗口的最大宽度，尤其是近期推出启动器最大化功能后，这个效果太糟糕了

我把对话框的最大宽度限制为启动器窗口宽度的 70%，且高度可以根据模组简介长度自适应，不会对其他短简介的模组造成不良影响。如图
<details>
现在：

<img width="1023" height="635" alt="image" src="https://github.com/user-attachments/assets/99eeddea-8e7d-428d-becf-a799a8ede2ff" />

<img width="1920" height="1062" alt="image" src="https://github.com/user-attachments/assets/bbfe6041-9052-4d9a-9e7f-c5c476fc4be5" />

修改后：

<img width="1022" height="635" alt="image" src="https://github.com/user-attachments/assets/a6073a65-6634-4353-8288-4d9c6366bc5a" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7f79d49c-d429-4cb4-839f-a8f839faeb85" />
</details>

以我写的 [Texture Locale Redirector](https://www.curseforge.com/minecraft/mc-mods/texture-locale-redirector) 模组为例，在高度基本不变下简介显示完全了