### PR TITLE
Bump authlib-injector to 1.2.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ twelvemonkeys = "3.12.0"
 jna = "5.18.0"
 pci-ids = "0.4.0"
 java-info = "1.0"
-authlib-injector = "1.2.5"
+authlib-injector = "1.2.6"
 
 # testing
 junit = "5.13.4"


### PR DESCRIPTION
https://github.com/yushijinhun/authlib-injector/releases/tag/v1.2.6
目前无法构建
```
 > Could not find org.glavo.hmcl:authlib-injector:1.2.6.
   Searched in the following locations:
     - file:/lib/authlib-injector-1.2.6.jar
     - file:/lib/authlib-injector.jar
     - https://repo.maven.apache.org/maven2/org/glavo/hmcl/authlib-injector/1.2.6/authlib-injector-1.2.6.pom
     - https://jitpack.io/org/glavo/hmcl/authlib-injector/1.2.6/authlib-injector-1.2.6.pom
     - https://libraries.minecraft.net/org/glavo/hmcl/authlib-injector/1.2.6/authlib-injector-1.2.6.pom
   Required by:
       project ':HMCL'
```
需要等待 maven `org.glavo.hmcl.authlib-injector` 同步