### PR TITLE
优化模组加载器检测机制

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/LauncherHelper.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/LauncherHelper.java
@@ -191,7 +191,7 @@ public final class LauncherHelper {
                     LaunchOptions launchOptions = repository.getLaunchOptions(
                             selectedVersion, javaVersionRef.get(), profile.getGameDir(), javaAgents, javaArguments, scriptFile != null);
 
-                    LOG.info("Here's the structure of game mod directory:\n" + FileUtils.printFileStructure(repository.getModManager(selectedVersion).getModsDirectory(), 10));
+                    LOG.info("Here's the structure of game mod directory:\n" + FileUtils.printFileStructure(repository.getModsDirectory(selectedVersion), 10));
 
                     return new HMCLGameLauncher(
                             repository,

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/game/DefaultGameRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/game/DefaultGameRepository.java
@@ -150,6 +150,11 @@ public class DefaultGameRepository implements GameRepository {
     }
 
     @Override
+    public Path getModsDirectory(String id) {
+        return getRunDirectory(id).resolve("mods");
+    }
+
+    @Override
     public Path getVersionRoot(String id) {
         return getBaseDirectory().resolve("versions/" + id);
     }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/game/GameRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/game/GameRepository.java
@@ -112,7 +112,7 @@ public interface GameRepository extends VersionProvider {
      * This method allows versions and libraries that are not loaded by this game repository.
      *
      * @param version the reference of game version
-     * @param lib     the library, {@link Version#getLibraries()}
+     * @param lib the library, {@link Version#getLibraries()}
      * @return the library file
      */
     Path getLibraryFile(Version version, Library lib);
@@ -125,7 +125,7 @@ public interface GameRepository extends VersionProvider {
      * If you do want to return a temporary directory, make {@link org.jackhuang.hmcl.launch.Launcher#makeLaunchScript}
      * always fail({@code UnsupportedOperationException}) and not to use it.
      *
-     * @param id       version id
+     * @param id version id
      * @param platform the platform of native libraries
      * @return the native directory
      */
@@ -183,9 +183,9 @@ public interface GameRepository extends VersionProvider {
      * Rename given version to new name.
      *
      * @param from The id of original version
-     * @param to   The new id of the version
-     * @return true if the operation is done successfully, false if version `from` not found, version json is malformed or I/O errors occurred.
+     * @param to The new id of the version
      * @throws UnsupportedOperationException if this game repository does not support renaming a version
+     * @return true if the operation is done successfully, false if version `from` not found, version json is malformed or I/O errors occurred.
      */
     boolean renameVersion(String from, String to);
 
@@ -214,9 +214,9 @@ public interface GameRepository extends VersionProvider {
      *
      * @param version the id of specific version that is relevant to {@code assetId}
      * @param assetId the asset id, you can find it in {@link AssetIndexInfo#getId()} {@link Version#getAssetIndex()}
-     * @param name    the asset object name, you can find it in keys of {@link AssetIndex#getObjects()}
-     * @return the file that given asset object refers to
+     * @param name the asset object name, you can find it in keys of {@link AssetIndex#getObjects()}
      * @throws java.io.IOException if I/O operation fails.
+     * @return the file that given asset object refers to
      */
     Optional<Path> getAssetObject(String version, String assetId, String name) throws IOException;
 
@@ -225,7 +225,7 @@ public interface GameRepository extends VersionProvider {
      *
      * @param version the id of specific version that is relevant to {@code assetId}
      * @param assetId the asset id, you can find it in {@link AssetIndexInfo#getId()} {@link Version#getAssetIndex()}
-     * @param obj     the asset object, you can find it in {@link AssetIndex#getObjects()}
+     * @param obj the asset object, you can find it in {@link AssetIndex#getObjects()}
      * @return the file that given asset object refers to
      */
     Path getAssetObject(String version, String assetId, AssetObject obj);
@@ -250,8 +250,8 @@ public interface GameRepository extends VersionProvider {
     /**
      * Get logging object
      *
-     * @param version     the id of specific version that is relevant to {@code assetId}
-     * @param assetId     the asset id, you can find it in {@link AssetIndexInfo#getId()} {@link Version#getAssetIndex()}
+     * @param version the id of specific version that is relevant to {@code assetId}
+     * @param assetId the asset id, you can find it in {@link AssetIndexInfo#getId()} {@link Version#getAssetIndex()}
      * @param loggingInfo the logging info
      * @return the file that loggingInfo refers to
      */

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/game/GameRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/game/GameRepository.java
@@ -112,7 +112,7 @@ public interface GameRepository extends VersionProvider {
      * This method allows versions and libraries that are not loaded by this game repository.
      *
      * @param version the reference of game version
-     * @param lib the library, {@link Version#getLibraries()}
+     * @param lib     the library, {@link Version#getLibraries()}
      * @return the library file
      */
     Path getLibraryFile(Version version, Library lib);
@@ -125,11 +125,17 @@ public interface GameRepository extends VersionProvider {
      * If you do want to return a temporary directory, make {@link org.jackhuang.hmcl.launch.Launcher#makeLaunchScript}
      * always fail({@code UnsupportedOperationException}) and not to use it.
      *
-     * @param id version id
+     * @param id       version id
      * @param platform the platform of native libraries
      * @return the native directory
      */
     Path getNativeDirectory(String id, Platform platform);
+
+    /// Get the directory for placing mod files.
+    ///
+    /// @param id instance id
+    /// @return the mods directory
+    Path getModsDirectory(String id);
 
     /**
      * Get minecraft jar
@@ -177,9 +183,9 @@ public interface GameRepository extends VersionProvider {
      * Rename given version to new name.
      *
      * @param from The id of original version
-     * @param to The new id of the version
-     * @throws UnsupportedOperationException if this game repository does not support renaming a version
+     * @param to   The new id of the version
      * @return true if the operation is done successfully, false if version `from` not found, version json is malformed or I/O errors occurred.
+     * @throws UnsupportedOperationException if this game repository does not support renaming a version
      */
     boolean renameVersion(String from, String to);
 
@@ -208,9 +214,9 @@ public interface GameRepository extends VersionProvider {
      *
      * @param version the id of specific version that is relevant to {@code assetId}
      * @param assetId the asset id, you can find it in {@link AssetIndexInfo#getId()} {@link Version#getAssetIndex()}
-     * @param name the asset object name, you can find it in keys of {@link AssetIndex#getObjects()}
-     * @throws java.io.IOException if I/O operation fails.
+     * @param name    the asset object name, you can find it in keys of {@link AssetIndex#getObjects()}
      * @return the file that given asset object refers to
+     * @throws java.io.IOException if I/O operation fails.
      */
     Optional<Path> getAssetObject(String version, String assetId, String name) throws IOException;
 
@@ -219,7 +225,7 @@ public interface GameRepository extends VersionProvider {
      *
      * @param version the id of specific version that is relevant to {@code assetId}
      * @param assetId the asset id, you can find it in {@link AssetIndexInfo#getId()} {@link Version#getAssetIndex()}
-     * @param obj the asset object, you can find it in {@link AssetIndex#getObjects()}
+     * @param obj     the asset object, you can find it in {@link AssetIndex#getObjects()}
      * @return the file that given asset object refers to
      */
     Path getAssetObject(String version, String assetId, AssetObject obj);
@@ -244,8 +250,8 @@ public interface GameRepository extends VersionProvider {
     /**
      * Get logging object
      *
-     * @param version the id of specific version that is relevant to {@code assetId}
-     * @param assetId the asset id, you can find it in {@link AssetIndexInfo#getId()} {@link Version#getAssetIndex()}
+     * @param version     the id of specific version that is relevant to {@code assetId}
+     * @param assetId     the asset id, you can find it in {@link AssetIndexInfo#getId()} {@link Version#getAssetIndex()}
      * @param loggingInfo the logging info
      * @return the file that loggingInfo refers to
      */

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModManager.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModManager.java
@@ -70,12 +70,12 @@ public final class ModManager {
         return repository;
     }
 
-    public String getVersion() {
+    public String getInstanceId() {
         return id;
     }
 
     public Path getModsDirectory() {
-        return repository.getRunDirectory(id).resolve("mods");
+        return repository.getModsDirectory(id);
     }
 
     public LocalMod getLocalMod(String id, ModLoaderType modLoaderType) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModManager.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModManager.java
@@ -18,6 +18,7 @@
 package org.jackhuang.hmcl.mod;
 
 import com.google.gson.JsonParseException;
+import org.jackhuang.hmcl.download.LibraryAnalyzer;
 import org.jackhuang.hmcl.game.GameRepository;
 import org.jackhuang.hmcl.mod.modinfo.*;
 import org.jackhuang.hmcl.util.Pair;
@@ -30,34 +31,39 @@ import java.io.IOException;
 import java.nio.file.*;
 import java.util.*;
 
+import static org.jackhuang.hmcl.util.Pair.pair;
+import static org.jackhuang.hmcl.util.logging.Logger.LOG;
+
 public final class ModManager {
     @FunctionalInterface
     private interface ModMetadataReader {
         LocalModFile fromFile(ModManager modManager, Path modFile, FileSystem fs) throws IOException, JsonParseException;
     }
 
-    private static final Map<String, Pair<ModMetadataReader[], String>> READERS;
+    private static final Map<String, List<Pair<ModMetadataReader, Set<ModLoaderType>>>> READERS;
 
     static {
-        TreeMap<String, Pair<ModMetadataReader[], String>> readers = new TreeMap<>();
-        readers.put("zip", Pair.pair(new ModMetadataReader[]{
-                ForgeOldModMetadata::fromFile,
-                ForgeNewModMetadata::fromFile,
-                FabricModMetadata::fromFile,
-                QuiltModMetadata::fromFile,
-                PackMcMeta::fromFile,
-        }, ""));
-        readers.put("jar", readers.get("zip"));
-        readers.put("litemod", Pair.pair(new ModMetadataReader[]{
-                LiteModMetadata::fromFile
-        }, "LiteLoader Mod"));
-        READERS = Collections.unmodifiableMap(readers);
+        var map = new HashMap<String, List<Pair<ModMetadataReader, Set<ModLoaderType>>>>();
+        var zipReaders = List.<Pair<ModMetadataReader, Set<ModLoaderType>>>of(
+                pair(ForgeNewModMetadata::fromFile, EnumSet.of(ModLoaderType.FORGE, ModLoaderType.NEO_FORGED)),
+                pair(ForgeOldModMetadata::fromFile, EnumSet.of(ModLoaderType.FORGE)),
+                pair(FabricModMetadata::fromFile, EnumSet.of(ModLoaderType.FABRIC)),
+                pair(QuiltModMetadata::fromFile, EnumSet.of(ModLoaderType.QUILT)),
+                pair(PackMcMeta::fromFile, EnumSet.of(ModLoaderType.PACK))
+        );
+
+        map.put("zip", zipReaders);
+        map.put("jar", zipReaders);
+        map.put("litemod", List.of(pair(LiteModMetadata::fromFile, EnumSet.of(ModLoaderType.LITE_LOADER))));
+
+        READERS = map;
     }
 
     private final GameRepository repository;
     private final String id;
     private final TreeSet<LocalModFile> localModFiles = new TreeSet<>();
     private final HashMap<LocalMod, LocalMod> localMods = new HashMap<>();
+    private LibraryAnalyzer analyzer;
 
     private boolean loaded = false;
 
@@ -83,44 +89,82 @@ public final class ModManager {
     }
 
     private void addModInfo(Path file) {
-        try {
-            LocalModFile localModFile = getModInfo(file);
-            if (!localModFile.isOld()) {
-                localModFiles.add(localModFile);
-            }
-        } catch (IllegalArgumentException ignore) {
-        }
-    }
-
-    public LocalModFile getModInfo(Path modFile) {
-        String fileName = StringUtils.removeSuffix(FileUtils.getName(modFile), DISABLED_EXTENSION, OLD_EXTENSION);
+        String fileName = StringUtils.removeSuffix(FileUtils.getName(file), DISABLED_EXTENSION, OLD_EXTENSION);
         String extension = fileName.substring(fileName.lastIndexOf(".") + 1);
-        Pair<ModMetadataReader[], String> currentReader = READERS.get(extension);
-        if (currentReader == null) {
-            throw new IllegalArgumentException("File " + modFile + " is not a mod file.");
+
+        List<Pair<ModMetadataReader, Set<ModLoaderType>>> readersMap = READERS.get(extension);
+        if (readersMap == null) {
+            // Is not a mod file.
+            return;
         }
 
-        try (FileSystem fs = CompressingUtils.createReadOnlyZipFileSystem(modFile)) {
-            for (ModMetadataReader reader : currentReader.getKey()) {
+        Set<ModLoaderType> modLoaderTypes = analyzer.getModLoaders();
+
+        var supportedReaders = new ArrayList<ModMetadataReader>();
+        var unsupportedReaders = new ArrayList<ModMetadataReader>();
+
+        for (Pair<ModMetadataReader, Set<ModLoaderType>> reader : readersMap) {
+            boolean supported = false;
+            for (ModLoaderType type : reader.getValue()) {
+                if (modLoaderTypes.contains(type)) {
+                    supported = true;
+                    break;
+                }
+            }
+
+            if (supported) {
+                supportedReaders.add(reader.getKey());
+            } else {
+                unsupportedReaders.add(reader.getKey());
+            }
+        }
+
+        LocalModFile modInfo = null;
+
+        try (FileSystem fs = CompressingUtils.createReadOnlyZipFileSystem(file)) {
+            for (ModMetadataReader reader : supportedReaders) {
                 try {
-                    return reader.fromFile(this, modFile, fs);
+                    modInfo = reader.fromFile(this, file, fs);
+                    break;
                 } catch (Exception ignore) {
                 }
             }
-        } catch (Exception ignored) {
+
+            if (modInfo == null) {
+                for (ModMetadataReader reader : unsupportedReaders) {
+                    try {
+                        modInfo = reader.fromFile(this, file, fs);
+                        break;
+                    } catch (Exception ignore) {
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.warning("Failed to open mod file " + file, e);
         }
 
-        return new LocalModFile(this,
-                getLocalMod(FileUtils.getNameWithoutExtension(modFile), ModLoaderType.UNKNOWN),
-                modFile,
-                FileUtils.getNameWithoutExtension(modFile),
-                new LocalModFile.Description(currentReader.getValue())
-        );
+        if (modInfo == null) {
+            String fileNameWithoutExtension = FileUtils.getNameWithoutExtension(file);
+
+            modInfo = new LocalModFile(this,
+                    getLocalMod(fileNameWithoutExtension, ModLoaderType.UNKNOWN),
+                    file,
+                    fileNameWithoutExtension,
+                    new LocalModFile.Description("litemod".equals(extension) ? "LiteLoader Mod" : "")
+            );
+        }
+
+        if (!modInfo.isOld()) {
+            localModFiles.add(modInfo);
+        }
     }
 
     public void refreshMods() throws IOException {
         localModFiles.clear();
         localMods.clear();
+
+        analyzer = LibraryAnalyzer.analyze(getRepository().getResolvedPreservingPatchesVersion(id), null);
+
         if (Files.isDirectory(getModsDirectory())) {
             try (DirectoryStream<Path> modsDirectoryStream = Files.newDirectoryStream(getModsDirectory())) {
                 for (Path subitem : modsDirectoryStream) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseCompletionTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseCompletionTask.java
@@ -138,7 +138,7 @@ public final class CurseCompletionTask extends Task<Void> {
                         .collect(Collectors.toList()));
         JsonUtils.writeToJsonFile(root.resolve("manifest.json"), newManifest);
 
-        Path versionRoot = repository.getVersionRoot(modManager.getVersion());
+        Path versionRoot = repository.getVersionRoot(modManager.getInstanceId());
         Path resourcePacksRoot = versionRoot.resolve("resourcepacks");
         Path shaderPacksRoot = versionRoot.resolve("shaderpacks");
         finished.set(0);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackCompletionTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackCompletionTask.java
@@ -273,7 +273,7 @@ public class McbbsModpackCompletionTask extends CompletableFutureTask<Void> {
     @Nullable
     private Path getFilePath(McbbsModpackManifest.File file) {
         if (file instanceof McbbsModpackManifest.AddonFile) {
-            return modManager.getRepository().getRunDirectory(modManager.getVersion()).resolve(((McbbsModpackManifest.AddonFile) file).getPath());
+            return modManager.getRepository().getRunDirectory(modManager.getInstanceId()).resolve(((McbbsModpackManifest.AddonFile) file).getPath());
         } else if (file instanceof McbbsModpackManifest.CurseFile) {
             String fileName = ((McbbsModpackManifest.CurseFile) file).getFileName();
             if (fileName == null) return null;


### PR DESCRIPTION
现在 HMCL 会先分析实例已安装的模组加载器，从而解决将同时支持 NeoForge 和 Fabric 的模组总是判定为 NeoForge 模组的问题。