### PR TITLE
feat:添加窗口拖动限制

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorSkin.java
@@ -57,8 +57,6 @@ import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
 import java.util.Objects;
 
-import static org.jackhuang.hmcl.util.logging.Logger.LOG;
-
 public class DecoratorSkin extends SkinBase<Decorator> {
     private final StackPane root, parent;
     private final StackPane titleContainer;
@@ -482,8 +480,6 @@ public class DecoratorSkin extends SkinBase<Decorator> {
                     primaryStage.setY(Math.max(Math.min(stageInitY + dy, currentMouseVisualBounds.getMaxY() - titleContainer.getHeight()), currentMouseVisualBounds.getMinY() - titleContainer.getHeight()));
 
                 }
-                LOG.trace("Mouse position:[" + mouseEvent.getScreenX() + "," + mouseEvent.getScreenY() + "]");
-
                 mouseEvent.consume();
             }
         }


### PR DESCRIPTION
现在HMCL标题栏不会被拖动到任务栏位置而隐藏到任务栏下方导致无法被拖动
仅在单显示器/多显示器但所有显示器的DPI缩放一致时启用这个功能

https://github.com/user-attachments/assets/3fe8abef-030f-41ee-82b7-3bed1214ca52