### PR TITLE
Fix #4670: 修复不在场景中的按钮尝试取消自身焦点时触发 NPE 的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
@@ -36,6 +36,7 @@ import javafx.geometry.Pos;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Cursor;
 import javafx.scene.Node;
+import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
@@ -1385,6 +1386,16 @@ public final class FXUtils {
             updater.accept(list.get((index + list.size()) % list.size()));
             event.consume();
         });
+    }
+
+    public static void clearFocus(Node node) {
+        Scene scene = node.getScene();
+        if (scene != null) {
+            Parent root = scene.getRoot();
+            if (root != null) {
+                root.requestFocus();
+            }
+        }
     }
 
     public static void copyOnDoubleClick(Labeled label) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/ToolbarListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/ToolbarListPageSkin.java
@@ -102,7 +102,7 @@ public abstract class ToolbarListPageSkin<T extends ListPageBase<? extends Node>
         ret.setText(text);
         ret.setOnAction(e -> {
             onClick.run();
-            ret.getScene().getRoot().requestFocus();
+            FXUtils.clearFocus(ret);
         });
         return ret;
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
@@ -181,7 +181,7 @@ public final class VersionsPage extends Control implements WizardPage, Refreshab
                     JFXButton wikiButton = newToggleButton4(SVG.GLOBE_BOOK);
                     wikiButton.setOnAction(event -> {
                         onOpenWiki();
-                        wikiButton.getScene().getRoot().requestFocus();
+                        FXUtils.clearFocus(wikiButton);
                     });
                     FXUtils.installFastTooltip(wikiButton, i18n("wiki.tooltip"));
                     actions.getChildren().add(wikiButton);


### PR DESCRIPTION
我没能复现这个问题。@wxs3a  @TheWhiteDog9487 可以试试 GitHub Action 中的构建，看看修复了这个问题吗。