### PR TITLE
优化陶瓦联机的复制邀请码功能

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
@@ -1411,12 +1411,16 @@ public final class FXUtils {
     }
 
     public static void copyText(String text) {
+        copyText(text, i18n("message.copied"));
+    }
+
+    public static void copyText(String text, @Nullable String toastMessage) {
         ClipboardContent content = new ClipboardContent();
         content.putString(text);
         Clipboard.getSystemClipboard().setContent(content);
 
-        if (!Controllers.isStopped()) {
-            Controllers.showToast(i18n("message.copied"));
+        if (toastMessage != null && !Controllers.isStopped()) {
+            Controllers.showToast(toastMessage);
         }
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/terracotta/TerracottaControllerPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/terracotta/TerracottaControllerPage.java
@@ -339,7 +339,7 @@ public class TerracottaControllerPage extends StackPane {
                     return;
                 } else {
                     String cs = hostOK.getCode();
-                    FXUtils.copyText(cs);
+                    copyCode(cs);
 
                     statusProperty.set(i18n("terracotta.status.host_ok"));
                     progressProperty.set(1);
@@ -359,13 +359,13 @@ public class TerracottaControllerPage extends StackPane {
                         code.getChildren().setAll(desc, label);
                     }
                     code.setCursor(Cursor.HAND);
-                    FXUtils.onClicked(code, () -> FXUtils.copyText(cs));
+                    FXUtils.onClicked(code, () -> copyCode(cs));
 
                     LineButton copy = LineButton.of();
                     copy.setLeftIcon(SVG.CONTENT_COPY);
                     copy.setTitle(i18n("terracotta.status.host_ok.code.copy"));
                     copy.setSubtitle(i18n("terracotta.status.host_ok.code.desc"));
-                    FXUtils.onClicked(copy, () -> FXUtils.copyText(cs));
+                    FXUtils.onClicked(copy, () -> copyCode(cs));
 
                     LineButton back = LineButton.of();
                     back.setLeftIcon(SVG.ARROW_BACK);
@@ -585,6 +585,10 @@ public class TerracottaControllerPage extends StackPane {
             locals.getContent().add(container);
         }
         return locals;
+    }
+
+    private void copyCode(String code) {
+        FXUtils.copyText(code, i18n("terracotta.status.host_ok.code.copy.toast"));
     }
 
     private static final class LineButton extends RipplerContainer {

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -1460,6 +1460,7 @@ terracotta.status.host_starting.back=This will stop creating the room.
 terracotta.status.host_ok=Room created
 terracotta.status.host_ok.code=Invitation code (Copied)
 terracotta.status.host_ok.code.copy=Copy invitation code
+terracotta.status.host_ok.code.copy.toast=Invitation code has been copied to clipboard
 terracotta.status.host_ok.code.desc=Please remind your friends to select Guest mode in HMCL - Multiplayer or PCL CE and enter this invitation code.
 terracotta.status.host_ok.back=This will also close the room, other guests will leave and cannot rejoin.
 terracotta.status.guest_starting=Joining room

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -1248,6 +1248,7 @@ terracotta.status.host_starting.back=這將會取消建立房間。
 terracotta.status.host_ok=已建立房間
 terracotta.status.host_ok.code=邀請碼 (已自動複製到剪貼簿)
 terracotta.status.host_ok.code.copy=複製邀請碼
+terracotta.status.host_ok.code.copy.toast=已將邀請碼複製到剪貼簿
 terracotta.status.host_ok.code.desc=請提醒您的朋友在 HMCL 或 PCL CE 多人遊戲功能中選擇房客模式，並輸入該邀請碼。
 terracotta.status.host_ok.back=這將同時徹底關閉房間，其他房客將退出並不再能重新加入該房間。
 terracotta.status.guest_starting=正在加入房間

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -1258,6 +1258,7 @@ terracotta.status.host_starting.back=这将会取消创建房间。
 terracotta.status.host_ok=已启动房间
 terracotta.status.host_ok.code=邀请码 (已自动复制到剪贴板)
 terracotta.status.host_ok.code.copy=复制邀请码
+terracotta.status.host_ok.code.copy.toast=已将邀请码复制到剪贴板
 terracotta.status.host_ok.code.desc=请提醒您的朋友在 HMCL 或 PCL CE 多人联机功能中选择房客模式，并输入该邀请码。
 terracotta.status.host_ok.back=这将同时彻底关闭房间，其他房客将退出并不再能重新加入该房间。
 terracotta.status.guest_starting=正在加入房间


### PR DESCRIPTION
我觉得原先使用 TextField 有些意义不明，单击复制+有一个明显的复制按钮我觉得已经足够了，这也和 HMCL 其他位置的复制逻辑接近（双击标签复制信息）。在复制后启动器也会通过 `showToast` 提示已经复制相关内容，我觉得这个提醒是足够充分的。

另外初次的静默复制很重要吗？HMCL 在微软登录时也会自动复制内容，但那里也是直接用 `FXUtils.copyText` 实现的。我觉得不是很有必要为了不显示提示而再实现一次复制到剪切板的逻辑。