### PR TITLE
优化更新日志展示功能

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/UpgradeDialog.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/UpgradeDialog.java
@@ -72,11 +72,11 @@ public final class UpgradeDialog extends JFXDialogLayout {
         maxHeightProperty().bind(Controllers.getScene().heightProperty().multiply(0.7));
 
         setHeading(new Label(i18n("update.changelog")));
+        setBody(new ProgressIndicator());
 
         String url = CHANGELOG_URL + remoteVersion.getChannel().channelName + ".html";
         boolean isPreview = remoteVersion.isPreview();
 
-        setBody(new ProgressIndicator());
         Task.supplyAsync(Schedulers.io(), () -> {
             VersionNumber targetVersion = VersionNumber.asVersion(remoteVersion.getVersion());
             VersionNumber currentVersion = VersionNumber.asVersion(Metadata.VERSION);


### PR DESCRIPTION
1. 如果检测到是降级更新，则不展示更新日志；
2. 如果检测到最新更新日志和最新版本不匹配，则不显示更新日志；
3. 展示当前版本与 `nowchange`/`nowpreview` 之间的所有更新日志，而不只展示一个版本的日志。