### PR TITLE
在陶瓦联机界面的启动游戏按钮中显示实例名称

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/terracotta/TerracottaPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/terracotta/TerracottaPage.java
@@ -29,6 +29,7 @@ import org.jackhuang.hmcl.game.LauncherHelper;
 import org.jackhuang.hmcl.setting.Profile;
 import org.jackhuang.hmcl.setting.Profiles;
 import org.jackhuang.hmcl.terracotta.TerracottaMetadata;
+import org.jackhuang.hmcl.ui.Controllers;
 import org.jackhuang.hmcl.ui.FXUtils;
 import org.jackhuang.hmcl.ui.SVG;
 import org.jackhuang.hmcl.ui.animation.ContainerAnimations;
@@ -38,7 +39,9 @@ import org.jackhuang.hmcl.ui.construct.PageAware;
 import org.jackhuang.hmcl.ui.construct.TabHeader;
 import org.jackhuang.hmcl.ui.decorator.DecoratorAnimatedPage;
 import org.jackhuang.hmcl.ui.decorator.DecoratorPage;
+import org.jackhuang.hmcl.ui.main.MainPage;
 import org.jackhuang.hmcl.ui.versions.Versions;
+import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.StringUtils;
 
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
@@ -79,6 +82,12 @@ public class TerracottaPage extends DecoratorAnimatedPage implements DecoratorPa
                     instanceChangeListenerHolder = FXUtils.onWeakChangeAndOperate(Profiles.selectedVersionProperty(),
                             instanceName -> item.setSubtitle(StringUtils.isNotBlank(instanceName) ? instanceName : i18n("version.empty"))
                     );
+
+                    MainPage mainPage = Controllers.getRootPage().getMainPage();
+                    FXUtils.onScroll(item, mainPage.getVersions(), list -> {
+                        String currentId = mainPage.getCurrentGame();
+                        return Lang.indexWhere(list, instance -> instance.getId().equals(currentId));
+                    }, it -> mainPage.getProfile().setSelectedVersion(it.getId()));
                 })
                 .addNavigationDrawerItem(i18n("terracotta.feedback.title"), SVG.FEEDBACK, () -> FXUtils.openLink(TerracottaMetadata.FEEDBACK_LINK))
                 .addNavigationDrawerItem(i18n("terracotta.easytier"), SVG.HOST, () -> FXUtils.openLink("https://easytier.cn/"))


### PR DESCRIPTION
<img width="1636" height="1016" alt="image" src="https://github.com/user-attachments/assets/24e47359-5381-432f-bfa2-512a488eab27" />

此外，这里也顺便支持了用滚轮切换实例。