### PR TITLE
使用 Translator 转换 category 的大小写

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
@@ -47,12 +47,11 @@ import org.jackhuang.hmcl.ui.construct.AdvancedListItem;
 import org.jackhuang.hmcl.ui.construct.ClassTitle;
 import org.jackhuang.hmcl.ui.decorator.DecoratorAnimatedPage;
 import org.jackhuang.hmcl.ui.decorator.DecoratorPage;
+import org.jackhuang.hmcl.util.i18n.I18n;
 import org.jackhuang.hmcl.util.i18n.LocaleUtils;
 import org.jackhuang.hmcl.util.io.NetworkUtils;
 import org.jackhuang.hmcl.util.javafx.BindingMapping;
 import org.jackhuang.hmcl.util.javafx.MappedObservableList;
-
-import java.util.Locale;
 
 import static org.jackhuang.hmcl.setting.ConfigHolder.globalConfig;
 import static org.jackhuang.hmcl.ui.versions.VersionPage.wrap;
@@ -178,7 +177,7 @@ public final class AccountListPage extends DecoratorAnimatedPage implements Deco
                     });
                     Bindings.bindContent(boxAuthServers.getChildren(), authServerItems);
 
-                    ClassTitle title = new ClassTitle(i18n("account.create").toUpperCase(Locale.ROOT));
+                    ClassTitle title = new ClassTitle(I18n.toCategoryCase(i18n("account.create")));
                     if (RESTRICTED.get()) {
                         VBox wrapper = new VBox(offlineItem, boxAuthServers);
                         wrapper.setPadding(Insets.EMPTY);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/CreateAccountPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/CreateAccountPane.java
@@ -62,12 +62,12 @@ import org.jackhuang.hmcl.ui.construct.*;
 import org.jackhuang.hmcl.upgrade.IntegrityChecker;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.gson.UUIDTypeAdapter;
+import org.jackhuang.hmcl.util.i18n.I18n;
 import org.jackhuang.hmcl.util.javafx.BindingMapping;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -643,7 +643,7 @@ public class CreateAccountPane extends JFXDialogLayout implements DialogAware {
             StackPane.setAlignment(cancel, Pos.BOTTOM_RIGHT);
             cancel.setOnAction(e -> latch.countDown());
 
-            listBox.startCategory(i18n("account.choose").toUpperCase(Locale.ROOT));
+            listBox.startCategory(I18n.toCategoryCase(i18n("account.choose")));
 
             setCenter(listBox);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/DownloadPage.java
@@ -53,11 +53,11 @@ import org.jackhuang.hmcl.ui.wizard.WizardController;
 import org.jackhuang.hmcl.ui.wizard.WizardProvider;
 import org.jackhuang.hmcl.util.SettingsMap;
 import org.jackhuang.hmcl.util.TaskCancellationAction;
+import org.jackhuang.hmcl.util.i18n.I18n;
 import org.jackhuang.hmcl.util.io.FileUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
-import java.util.Locale;
 import java.util.concurrent.CancellationException;
 import java.util.function.Supplier;
 
@@ -110,10 +110,10 @@ public class DownloadPage extends DecoratorAnimatedPage implements DecoratorPage
         });
 
         AdvancedListBox sideBar = new AdvancedListBox()
-                .startCategory(i18n("download.game").toUpperCase(Locale.ROOT))
+                .startCategory(I18n.toCategoryCase(i18n("download.game")))
                 .addNavigationDrawerTab(tab, newGameTab, i18n("game"), SVG.STADIA_CONTROLLER)
                 .addNavigationDrawerTab(tab, modpackTab, i18n("modpack"), SVG.PACKAGE2)
-                .startCategory(i18n("download.content").toUpperCase(Locale.ROOT))
+                .startCategory(I18n.toCategoryCase(i18n("download.content")))
                 .addNavigationDrawerTab(tab, modTab, i18n("mods"), SVG.EXTENSION)
                 .addNavigationDrawerTab(tab, resourcePackTab, i18n("resourcepack"), SVG.TEXTURE)
                 .addNavigationDrawerTab(tab, shaderTab, i18n("download.shader"), SVG.WB_SUNNY)

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/LauncherSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/LauncherSettingsPage.java
@@ -29,8 +29,7 @@ import org.jackhuang.hmcl.ui.construct.*;
 import org.jackhuang.hmcl.ui.decorator.DecoratorAnimatedPage;
 import org.jackhuang.hmcl.ui.decorator.DecoratorPage;
 import org.jackhuang.hmcl.ui.versions.VersionSettingsPage;
-
-import java.util.Locale;
+import org.jackhuang.hmcl.util.i18n.I18n;
 
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
@@ -68,11 +67,11 @@ public class LauncherSettingsPage extends DecoratorAnimatedPage implements Decor
         AdvancedListBox sideBar = new AdvancedListBox()
                 .addNavigationDrawerTab(tab, gameTab, i18n("settings.type.global.manage"), SVG.STADIA_CONTROLLER)
                 .addNavigationDrawerTab(tab, javaManagementTab, i18n("java.management"), SVG.LOCAL_CAFE)
-                .startCategory(i18n("launcher").toUpperCase(Locale.ROOT))
+                .startCategory(I18n.toCategoryCase(i18n("launcher")))
                 .addNavigationDrawerTab(tab, settingsTab, i18n("settings.launcher.general"), SVG.TUNE)
                 .addNavigationDrawerTab(tab, personalizationTab, i18n("settings.launcher.appearance"), SVG.STYLE)
                 .addNavigationDrawerTab(tab, downloadTab, i18n("download"), SVG.DOWNLOAD)
-                .startCategory(i18n("help").toUpperCase(Locale.ROOT))
+                .startCategory(I18n.toCategoryCase(i18n("help")))
                 .addNavigationDrawerTab(tab, helpTab, i18n("help"), SVG.HELP)
                 .addNavigationDrawerTab(tab, feedbackTab, i18n("feedback"), SVG.FEEDBACK)
                 .addNavigationDrawerTab(tab, aboutTab, i18n("about"), SVG.INFO);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/RootPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/RootPage.java
@@ -48,6 +48,7 @@ import org.jackhuang.hmcl.upgrade.UpdateChecker;
 import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.TaskCancellationAction;
+import org.jackhuang.hmcl.util.i18n.I18n;
 import org.jackhuang.hmcl.util.io.CompressingUtils;
 import org.jackhuang.hmcl.util.versioning.VersionNumber;
 
@@ -56,7 +57,6 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Locale;
 import java.util.stream.Collectors;
 
 import static org.jackhuang.hmcl.ui.FXUtils.runInFX;
@@ -190,13 +190,13 @@ public class RootPage extends DecoratorAnimatedPage implements DecoratorPage {
 
             // the left sidebar
             AdvancedListBox sideBar = new AdvancedListBox()
-                    .startCategory(i18n("account").toUpperCase(Locale.ROOT))
+                    .startCategory(I18n.toCategoryCase(i18n("account")))
                     .add(accountListItem)
-                    .startCategory(i18n("version").toUpperCase(Locale.ROOT))
+                    .startCategory(I18n.toCategoryCase(i18n("version")))
                     .add(gameListItem)
                     .add(gameItem)
                     .add(downloadItem)
-                    .startCategory(i18n("settings.launcher.general").toUpperCase(Locale.ROOT))
+                    .startCategory(I18n.toCategoryCase(i18n("settings.launcher.general")))
                     .add(launcherSettingsItem)
                     .add(terracottaItem);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/I18n.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/I18n.java
@@ -67,6 +67,10 @@ public final class I18n {
         return locale.i18n(key);
     }
 
+    public static String toCategoryCase(String category) {
+        return getTranslator().toCategoryCase(category);
+    }
+
     public static String formatDateTime(TemporalAccessor time) {
         return getTranslator().formatDateTime(time);
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/translator/Translator.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/translator/Translator.java
@@ -43,6 +43,10 @@ public class Translator {
         return locale;
     }
 
+    public String toCategoryCase(String category) {
+        return category;
+    }
+
     public String getDisplayVersion(RemoteVersion remoteVersion) {
         return remoteVersion.getSelfVersion();
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/translator/Translator_en.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/translator/Translator_en.java
@@ -1,0 +1,34 @@
+/*
+ * Hello Minecraft! Launcher
+ * Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.jackhuang.hmcl.util.i18n.translator;
+
+import org.jackhuang.hmcl.util.i18n.SupportedLocale;
+
+import java.util.Locale;
+
+/// @author Glavo
+public class Translator_en extends Translator {
+    public Translator_en(SupportedLocale supportedLocale) {
+        super(supportedLocale);
+    }
+
+    @Override
+    public String toCategoryCase(String category) {
+        return category.toUpperCase(Locale.ENGLISH);
+    }
+}

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/translator/Translator_en_Qabs.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/translator/Translator_en_Qabs.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import static org.jackhuang.hmcl.util.logging.Logger.LOG;
 
 /// @author Glavo
-public class Translator_en_Qabs extends Translator {
+public class Translator_en_Qabs extends Translator_en {
     private static final DateTimeFormatter BASE_FORMATTER = DateTimeFormatter.ofPattern("MMM d, yyyy, h:mm:ss a")
             .withZone(ZoneId.systemDefault());
 


### PR DESCRIPTION
过去我们对这些地方都是一律 `toUpperCase(Locale.ROOT)`，但这并不一定符合所有语言的习惯。例如对于中文，我们不需要进行任何转换。

我们需要调查:

1. 对于英语，我们应该继续保持全大写，还是应当仅首字母大写？
2. 对于西班牙语/俄语/乌克兰语是否应该进行大小写转换？

cc @3gf8jv4dv 