### PR TITLE
feat: remove folder button from the mod management header

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
@@ -150,7 +150,6 @@ final class ModListPageSkin extends SkinBase<ModListPage> {
             toolbarNormal.getChildren().setAll(
                     createToolbarButton2(i18n("button.refresh"), SVG.REFRESH, skinnable::refresh),
                     createToolbarButton2(i18n("mods.add"), SVG.ADD, skinnable::add),
-                    createToolbarButton2(i18n("folder.mod"), SVG.FOLDER_OPEN, skinnable::openModFolder),
                     createToolbarButton2(i18n("mods.check_updates"), SVG.UPDATE, skinnable::checkUpdates),
                     createToolbarButton2(i18n("download"), SVG.DOWNLOAD, skinnable::download),
                     createToolbarButton2(i18n("search"), SVG.SEARCH, () -> changeToolbar(searchBar))


### PR DESCRIPTION
Other pages within the instance management section do not have similar buttons at the top. The relevant functionality is already provided by action buttons on the bottom left and next to the entries on the right.

Remove this button to simplify and unify the UI.

---

在「实例管理」中的一系列页面中，其他页面上方均无此类按钮。且相关功能已在页面左下方和右侧条目旁的 action 按钮中提供。移除此按钮可以精简和统一 UI。

以下为英语的 UI。移除前，上方按钮文本过长会被遮挡。移除后可以按预期显示。
但其他语言可能还是比较长，需要后续优化。

<img width="818" height="508" alt="Image" src="https://github.com/user-attachments/assets/8523de3b-3433-467f-b8a0-efd4087b7d0d" />
