### PR TITLE
限制 ./gradlew run 运行时的默认内存占用

### DIFF
--- a/HMCL/build.gradle.kts
+++ b/HMCL/build.gradle.kts
@@ -335,7 +335,7 @@ tasks.register<JavaExec>("run") {
     classpath = files(jarPath)
     workingDir = rootProject.rootDir
 
-    val vmOptions = parseToolOptions(System.getenv("HMCL_JAVA_OPTS"))
+    val vmOptions = parseToolOptions(System.getenv("HMCL_JAVA_OPTS") ?: "-Xmx1g")
     if (vmOptions.none { it.startsWith("-Dhmcl.offline.auth.restricted=") })
         vmOptions += "-Dhmcl.offline.auth.restricted=false"
 


### PR DESCRIPTION
在通过 `./gradlew run` 运行时将默认 JVM 参数设置为 `-Xmx1G`，与 Windows 平台上的内存限制保持一致，避免在资源充足的设备上开发时意外造成资源泄漏等问题。