### PR TITLE
fix(i18n): update i18n for open dir button on instance `mods` tab

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
@@ -150,7 +150,7 @@ final class ModListPageSkin extends SkinBase<ModListPage> {
             toolbarNormal.getChildren().setAll(
                     createToolbarButton2(i18n("button.refresh"), SVG.REFRESH, skinnable::refresh),
                     createToolbarButton2(i18n("mods.add"), SVG.ADD, skinnable::add),
-                    createToolbarButton2(i18n("folder.mod"), SVG.FOLDER_OPEN, skinnable::openModFolder),
+                    createToolbarButton2(i18n("button.reveal_dir"), SVG.FOLDER_OPEN, skinnable::openModFolder),
                     createToolbarButton2(i18n("mods.check_updates"), SVG.UPDATE, skinnable::checkUpdates),
                     createToolbarButton2(i18n("download"), SVG.DOWNLOAD, skinnable::download),
                     createToolbarButton2(i18n("search"), SVG.SEARCH, () -> changeToolbar(searchBar))

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -186,6 +186,7 @@ button.export=Export
 button.no=No
 button.ok=OK
 button.ok.countdown=OK (%d)
+button.reveal_dir=Reveal
 button.refresh=Refresh
 button.remove=Remove
 button.remove.confirm=Are you sure you want to permanently remove it? This action cannot be undone!

--- a/HMCL/src/main/resources/assets/lang/I18N_es.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_es.properties
@@ -187,6 +187,7 @@ button.export=Exportar
 button.no=No
 button.ok=Aceptar
 button.ok.countdown=Aceptar (%d)
+button.reveal_dir=Carpeta
 button.refresh=Refrescar
 button.remove=Eliminar
 button.remove.confirm=¿Estás seguro de que deseas eliminarlo de forma permanente? ¡Esta acción no se puede deshacer!

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -189,6 +189,7 @@ button.export=匯出
 button.no=否
 button.ok=確定
 button.ok.countdown=確定 (%d)
+button.reveal_dir=開啟目錄
 button.refresh=重新整理
 button.remove=刪除
 button.remove.confirm=你確認要刪除嗎？該操作無法復原！

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -197,6 +197,7 @@ button.export=导出
 button.no=否
 button.ok=确定
 button.ok.countdown=确定 (%d)
+button.reveal_dir=打开文件夹
 button.refresh=刷新
 button.remove=删除
 button.remove.confirm=你确定要删除吗？此操作无法撤销！


### PR DESCRIPTION
For most Chinese users, everything looks fine, but in English the text displayed does not mean open directory, but shows `Mods`, which is confusing. This PR corrects the relevant i18n key and text.

Fair warning: l10n has only been updated for English, Chinese and Spanish.

---

在简繁中文内，「模组管理」页面上方的「模组文件夹/模組目錄」按钮看起来挺好。但从英语用户的视角看，这个按钮显示「Mods」这个意义不明的词，比较吊诡。如果没有旁边的文件夹图标，那么大部分人可能一眼看不出这个按钮的作用。

此 PR 更新了相关的 i18n key 和对应文本。现在看起来应该明朗多了。

---

Before:
<img width="818" height="508" alt="image-1" src="https://github.com/user-attachments/assets/236c0135-7687-467a-916b-c2cf7c7b7d75" />

<img width="818" height="508" alt="image-2" src="https://github.com/user-attachments/assets/50cb75d6-bb43-4ded-a148-1dcccdac5a86" />

After:

<img width="818" height="508" alt="image-3" src="https://github.com/user-attachments/assets/04cf4ca4-7916-4f0f-a8a1-218dcb8bdd08" />

<img width="818" height="508" alt="image-4" src="https://github.com/user-attachments/assets/aed92426-202f-48c6-bc47-a4679e1bc866" />