### PR TITLE
优化检查更新日志的方式

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/UpgradeDialog.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/UpgradeDialog.java
@@ -28,18 +28,13 @@ import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.ui.construct.DialogCloseEvent;
 import org.jackhuang.hmcl.ui.construct.JFXHyperlink;
 import org.jackhuang.hmcl.upgrade.RemoteVersion;
+import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.versioning.VersionNumber;
-import org.jetbrains.annotations.Nullable;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
-import org.jsoup.nodes.TextNode;
 
-import java.io.IOException;
 import java.net.URL;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static org.jackhuang.hmcl.Metadata.CHANGELOG_URL;
 import static org.jackhuang.hmcl.ui.FXUtils.onEscPressed;
@@ -47,25 +42,6 @@ import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 import static org.jackhuang.hmcl.util.logging.Logger.LOG;
 
 public final class UpgradeDialog extends JFXDialogLayout {
-
-    private static final Pattern CHANGELOG_TITLE_PATTERN = Pattern.compile("HMCL (?<version>\\d(?:\\.\\d+)+)");
-
-    private static @Nullable VersionNumber extractVersionNumber(Node node) {
-        String text;
-        if (node instanceof Element element) {
-            text = element.text();
-        } else if (node instanceof TextNode textNode) {
-            text = textNode.text();
-        } else {
-            return null;
-        }
-
-        Matcher matcher = CHANGELOG_TITLE_PATTERN.matcher(text);
-        if (matcher.find())
-            return VersionNumber.asVersion(matcher.group("version"));
-        else
-            return null;
-    }
 
     public UpgradeDialog(RemoteVersion remoteVersion, Runnable updateRunnable) {
         maxWidthProperty().bind(Controllers.getScene().widthProperty().multiply(0.7));
@@ -75,36 +51,19 @@ public final class UpgradeDialog extends JFXDialogLayout {
         setBody(new ProgressIndicator());
 
         String url = CHANGELOG_URL + remoteVersion.getChannel().channelName + ".html";
-        boolean isPreview = remoteVersion.isPreview();
 
         Task.supplyAsync(Schedulers.io(), () -> {
             VersionNumber targetVersion = VersionNumber.asVersion(remoteVersion.getVersion());
             VersionNumber currentVersion = VersionNumber.asVersion(Metadata.VERSION);
-            if (targetVersion.compareTo(currentVersion) <= 0) {
+            if (targetVersion.compareTo(currentVersion) <= 0)
+                // Downgrade update, no need to display changelog
                 return null;
-            }
 
             Document document = Jsoup.parse(new URL(url), 30 * 1000);
-            String id = null;
-            Node node = null;
-            if (isPreview) {
-                id = "nowpreview";
-                node = document.selectFirst("#" + id);
-            }
-            if (node == null) {
-                id = "nowchange";
-                node = document.selectFirst("#" + id);
-            }
+            Node node = document.selectFirst("h1[data-version=\"%s\"]".formatted(targetVersion));
 
-            if (node == null || !"h1".equals(node.nodeName()))
-                throw new IOException("Cannot find current changelog in document");
-
-            VersionNumber changelogVersion = extractVersionNumber(node);
-            if (changelogVersion == null)
-                throw new IOException("Cannot find current changelog in document. The node: " + node);
-
-            if (!targetVersion.equals(changelogVersion)) {
-                LOG.warning("The changelog has not been updated yet. Expected: " + targetVersion + ", Actual: " + changelogVersion);
+            if (node == null || !"h1".equals(node.nodeName())) {
+                LOG.warning("Changelog not found");
                 return null;
             }
 
@@ -115,8 +74,8 @@ public final class UpgradeDialog extends JFXDialogLayout {
 
             do {
                 if ("h1".equals(node.nodeName())) {
-                    changelogVersion = extractVersionNumber(node);
-                    if (changelogVersion == null || changelogVersion.compareTo(currentVersion) <= 0) {
+                    String changelogVersion = node.attr("data-version");
+                    if (StringUtils.isBlank(changelogVersion) || currentVersion.compareTo(changelogVersion) >= 0) {
                         break;
                     }
                 }


### PR DESCRIPTION
现在我们只能提供一个 `nowchange` 和一个 `nowpreview` 标签，但如果我们想让稳定版 3.7.x 和 3.6.x 更新到不同目标的话，那么我们就无法为 3.6.x 指定最新更新日志。

本 PR 调整了 HMCL 检查更新日志的方式。现在 HMCL 不再依赖 `nowchange` 和 `nowpreview` 标签来检查更新日志，而是直接查询目标版本的日志条目。