### PR TITLE
Revert #4453: 恢复对 JavaFX 14 的兼容性

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/StyleSheets.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/StyleSheets.java
@@ -123,7 +123,7 @@ public final class StyleSheets {
 
         builder.append('}');
 
-        return toStyleSheetUri(builder.toString(), fontFamily);
+        return toStyleSheetUri(builder.toString(), defaultCss);
     }
 
     private static String rgba(Color color, double opacity) {


### PR DESCRIPTION
我们在 FreeBSD 平台依然会下载 OpenJFX 14，并且 FreeBSD 的 pkg  源中依然存在 openjfx 14 包。

为了优化 FreeBSD 用户的体验，我们应当恢复对 JavaFX 14 的兼容性。