### PR TITLE
从注册表中读取 Windows 版本信息

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/OperatingSystem.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/OperatingSystem.java
@@ -170,7 +170,7 @@ public enum OperatingSystem {
                     }
                 }
 
-                if (minorVersion >= 10) {
+                if (majorVersion >= 10) {
                     Object ubr = reg.queryValue(WinReg.HKEY.HKEY_LOCAL_MACHINE,
                             "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", "UBR");
 


### PR DESCRIPTION
如果用户为 `java.exe` 配置了兼容性选项，`GetVersionExW` 获取到的系统版本号将是兼容性设置中的系统版本，而不是真实的系统版本号。从注册表中读取系统版本应当能绕过此问题。