### PR TITLE
在macOS下禁用最小化动画

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/Decorator.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/Decorator.java
@@ -42,6 +42,7 @@ import javafx.util.Duration;
 import org.jackhuang.hmcl.ui.FXUtils;
 import org.jackhuang.hmcl.ui.animation.AnimationUtils;
 import org.jackhuang.hmcl.ui.wizard.Navigation;
+import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
 public class Decorator extends Control {
     private final ListProperty<Node> drawer = new SimpleListProperty<>(FXCollections.observableArrayList());
@@ -273,7 +274,7 @@ public class Decorator extends Control {
     }
 
     public void minimize() {
-        if (AnimationUtils.playWindowAnimation()) {
+        if (AnimationUtils.playWindowAnimation() && OperatingSystem.CURRENT_OS != OperatingSystem.MACOS) {
             playRestoreMinimizeAnimation = true;
             Timeline timeline = new Timeline(
                     new KeyFrame(Duration.millis(0),


### PR DESCRIPTION
在macOS下禁用最小化动画，使用macOS默认动画效果

### Before
https://github.com/user-attachments/assets/11e4c89a-87ea-4cbb-9647-45d9ca8eba10
### After
https://github.com/user-attachments/assets/18cb3a37-b29e-4268-aaeb-4efd20aa6476

## 注：
由于启用动画后，macOS依旧会对透明的窗口进行最小化动画绘制，导致从按下最小化到在程序坞中显示有明显的延迟现象，禁用此动画效果也变相解决了这个问题

另外这还可以解决开启台前调度后窗口无法复原的恶性BUG