### PR TITLE
修复无法获取部分远古版本版本号的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/game/GameVersion.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/game/GameVersion.java
@@ -46,7 +46,7 @@ final class GameVersion {
     private GameVersion() {
     }
 
-    // For Minecraft 1.0 rc or versions earlier than Alpha 1.6,
+    // For Minecraft 1.0 rc versions and versions earlier than Alpha 1.0.6,
     // it is difficult to obtain the game version from the JAR.
     // For these versions, we get the version number based on their SHA-1 hash.
     private static final Map<String, String> KNOWN_VERSIONS = Map.<String, String>ofEntries(


### PR DESCRIPTION
1. 修复将 `1.0.0-rc1`、`1.0.0-rc2-1`、`1.0.0-rc2-2` 的版本号识别为 `RC1` 的问题。
2. 修复将 `1.0.0-rc2-3` 的版本号识别为 `RC2` 的问题。
3. 修复无法获取版本低于 Alpha 1.0.6 的游戏版本号的问题。