### PR TITLE
fix: 修复模组列表点击搜索按钮无法正确聚焦到搜索栏的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
@@ -19,6 +19,7 @@ package org.jackhuang.hmcl.ui.versions;
 
 import com.jfoenix.controls.*;
 import javafx.animation.PauseTransition;
+import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
@@ -241,7 +242,7 @@ final class ModListPageSkin extends SkinBase<ModListPage> {
         if (newToolbar != oldToolbar) {
             toolbarPane.setContent(newToolbar, ContainerAnimations.FADE);
             if (newToolbar == searchBar) {
-                searchField.requestFocus();
+                Platform.runLater(searchField::requestFocus);
             }
         }
     }


### PR DESCRIPTION
模组列表界面点击搜索按钮是有聚焦在搜索栏的设计的，但是之前的不生效，现在正常生效了

之前：

https://github.com/user-attachments/assets/de77f2a8-10ed-41a5-9f98-3bfe90ae181e

之后：

https://github.com/user-attachments/assets/aa399c96-8731-4f81-bf0c-840339856009

