### PR TITLE
fix: 修复 Windows 下全局设置本地库路径路径分隔符显示错误的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/AdvancedVersionSettingPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/AdvancedVersionSettingPage.java
@@ -17,6 +17,7 @@ import org.jackhuang.hmcl.setting.VersionSetting;
 import org.jackhuang.hmcl.ui.FXUtils;
 import org.jackhuang.hmcl.ui.construct.*;
 import org.jackhuang.hmcl.ui.decorator.DecoratorPage;
+import org.jackhuang.hmcl.util.io.FileUtils;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 import org.jackhuang.hmcl.util.platform.Platform;
 import org.jetbrains.annotations.Nullable;
@@ -251,12 +252,9 @@ public final class AdvancedVersionSettingPage extends StackPane implements Decor
             if (versionSetting.getNativesDirType() == NativesDirectoryType.VERSION_FOLDER) {
                 String nativesDirName = "natives-" + Platform.SYSTEM_PLATFORM;
                 if (versionId == null) {
-                    String separator = FileSystems.getDefault().getSeparator();
-                    return String.format("%s%s%s%s%s",
-                            profile.getRepository().getBaseDirectory().resolve("versions").toAbsolutePath().normalize(),
-                            separator,
+                    return String.join(FileSystems.getDefault().getSeparator(),
+                            FileUtils.getAbsolutePath(profile.getRepository().getBaseDirectory().resolve("versions")),
                             i18n("settings.advanced.natives_directory.default.version_id"),
-                            separator,
                             nativesDirName
                     );
                 } else {


### PR DESCRIPTION
<img width="1167" height="91" alt="image" src="https://github.com/user-attachments/assets/7e5e1610-d3bf-40e9-971c-2a8b3118fe22" />

应为 `\`