### PR TITLE
[release/3.7] 修复 Windows 下全局游戏设置中本地库路径路径分隔符显示错误的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/AdvancedVersionSettingPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/AdvancedVersionSettingPage.java
@@ -11,16 +11,18 @@ import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.*;
 import org.jackhuang.hmcl.game.NativesDirectoryType;
-import org.jackhuang.hmcl.setting.Profile;
 import org.jackhuang.hmcl.game.Renderer;
+import org.jackhuang.hmcl.setting.Profile;
 import org.jackhuang.hmcl.setting.VersionSetting;
 import org.jackhuang.hmcl.ui.FXUtils;
 import org.jackhuang.hmcl.ui.construct.*;
 import org.jackhuang.hmcl.ui.decorator.DecoratorPage;
+import org.jackhuang.hmcl.util.io.FileUtils;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 import org.jackhuang.hmcl.util.platform.Platform;
 import org.jetbrains.annotations.Nullable;
 
+import java.nio.file.FileSystems;
 import java.util.Arrays;
 import java.util.Locale;
 
@@ -250,8 +252,8 @@ public final class AdvancedVersionSettingPage extends StackPane implements Decor
             if (versionSetting.getNativesDirType() == NativesDirectoryType.VERSION_FOLDER) {
                 String nativesDirName = "natives-" + Platform.SYSTEM_PLATFORM;
                 if (versionId == null) {
-                    return String.format("%s/%s/%s",
-                            profile.getRepository().getBaseDirectory().resolve("versions").toAbsolutePath().normalize(),
+                    return String.join(FileSystems.getDefault().getSeparator(),
+                            FileUtils.getAbsolutePath(profile.getRepository().getBaseDirectory().resolve("versions")),
                             i18n("settings.advanced.natives_directory.default.version_id"),
                             nativesDirName
                     );


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/pull/4808