### PR TITLE
在全局游戏设置中对全部实例的启动器可见性进行设置

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionSettingsPage.java
@@ -373,10 +373,36 @@ public final class VersionSettingsPage extends StackPane implements DecoratorPag
                 launcherVisibilityPane.setLeft(label);
                 BorderPane.setAlignment(label, Pos.CENTER_LEFT);
 
+                BorderPane launcherVisibilityOperationsPane = new BorderPane();
+                launcherVisibilityPane.setRight(launcherVisibilityOperationsPane);
+                BorderPane.setAlignment(launcherVisibilityOperationsPane, Pos.CENTER_RIGHT);
+
                 cboLauncherVisibility = new JFXComboBox<>();
-                launcherVisibilityPane.setRight(cboLauncherVisibility);
-                BorderPane.setAlignment(cboLauncherVisibility, Pos.CENTER_RIGHT);
                 FXUtils.setLimitWidth(cboLauncherVisibility, 300);
+                launcherVisibilityOperationsPane.setLeft(cboLauncherVisibility);
+                BorderPane.setAlignment(cboLauncherVisibility, Pos.CENTER_LEFT);
+
+                if (globalSetting) {
+                    JFXButton syncButton = FXUtils.newBorderButton(i18n("settings.advanced.launcher_visible_sync"));
+                    VBox btnBox = new VBox(syncButton);
+                    btnBox.setPadding(new Insets(0, 0, 0, 8));
+                    launcherVisibilityOperationsPane.setRight(btnBox);
+                    BorderPane.setAlignment(btnBox, Pos.CENTER_RIGHT);
+
+                    syncButton.setOnAction(e -> {
+                        Profiles.getProfiles().forEach(profile -> {
+                            try {
+                                profile.getRepository().getVersions().forEach(v -> {
+                                    profile.getVersionSetting(v.getId())
+                                            .launcherVisibilityProperty()
+                                            .setValue(cboLauncherVisibility.getSelectionModel()
+                                                    .getSelectedItem());
+                                });
+                            } catch (NullPointerException npe) {
+                            }
+                        });
+                    });
+                }
             }
 
             BorderPane dimensionPane = new BorderPane();

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -1285,6 +1285,7 @@ settings.advanced.launcher_visibility.hide=Hide the launcher after the game laun
 settings.advanced.launcher_visibility.hide_and_reopen=Hide the launcher and show it when the game closes
 settings.advanced.launcher_visibility.keep=Keep the launcher visible
 settings.advanced.launcher_visible=Launcher Visibility
+settings.advanced.launcher_visible_sync=Synchronize this setting to all instances
 settings.advanced.minecraft_arguments=Launch Arguments
 settings.advanced.minecraft_arguments.prompt=Default
 settings.advanced.natives_directory=Native Library Path

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -1088,6 +1088,7 @@ settings.advanced.launcher_visibility.hide=游戏启动后隐藏启动器
 settings.advanced.launcher_visibility.hide_and_reopen=隐藏启动器并在游戏结束后重新打开
 settings.advanced.launcher_visibility.keep=保持启动器可见
 settings.advanced.launcher_visible=启动器可见性
+settings.advanced.launcher_visible_sync=同步此设置到全部实例
 settings.advanced.minecraft_arguments=游戏参数
 settings.advanced.minecraft_arguments.prompt=默认
 settings.advanced.natives_directory=本地库路径 (LWJGL)


### PR DESCRIPTION
HMCL目前的版本配置逻辑使打开版本隔离会让启动器可见性变为"游戏启动后隐藏启动器"，但是没有让它显形的办法，所以HMCL需要在开新游戏客户端时重开。而手动为每个版本设置启动器可见性过于麻烦，因此增加这个功能

https://github.com/user-attachments/assets/b09879ce-ffa2-41ff-ad2b-85291312f749

