### PR TITLE
修复惯性滚动可能导致弹出菜单错位的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/ScrollUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/ScrollUtils.java
@@ -52,8 +52,8 @@ final class ScrollUtils {
         }
     }
 
-    private ScrollUtils() {
-    }
+    private static final double DEFAULT_SPEED = 1.0;
+    private static final double DEFAULT_TRACK_PAD_ADJUSTMENT = 7.0;
 
     /**
      * Determines if the given ScrollEvent comes from a trackpad.
@@ -68,16 +68,10 @@ final class ScrollUtils {
      * @see ScrollEvent#getDeltaY()
      */
     public static boolean isTrackPad(ScrollEvent event, ScrollDirection scrollDirection) {
-        switch (scrollDirection) {
-            case UP:
-            case DOWN:
-                return Math.abs(event.getDeltaY()) < 10;
-            case LEFT:
-            case RIGHT:
-                return Math.abs(event.getDeltaX()) < 10;
-            default:
-                return false;
-        }
+        return switch (scrollDirection) {
+            case UP, DOWN -> Math.abs(event.getDeltaY()) < 10;
+            case LEFT, RIGHT -> Math.abs(event.getDeltaX()) < 10;
+        };
     }
 
     /**
@@ -117,7 +111,7 @@ final class ScrollUtils {
      * default speed value of 1.
      */
     public static void addSmoothScrolling(ScrollPane scrollPane) {
-        addSmoothScrolling(scrollPane, 1);
+        addSmoothScrolling(scrollPane, DEFAULT_SPEED);
     }
 
     /**
@@ -126,7 +120,7 @@ final class ScrollUtils {
      * with a default trackPadAdjustment of 7.
      */
     public static void addSmoothScrolling(ScrollPane scrollPane, double speed) {
-        addSmoothScrolling(scrollPane, speed, 7);
+        addSmoothScrolling(scrollPane, speed, DEFAULT_TRACK_PAD_ADJUSTMENT);
     }
 
     /**
@@ -143,12 +137,12 @@ final class ScrollUtils {
 
     /// @author Glavo
     public static void addSmoothScrolling(VirtualFlow<?> virtualFlow) {
-        addSmoothScrolling(virtualFlow, 1);
+        addSmoothScrolling(virtualFlow, DEFAULT_SPEED);
     }
 
     /// @author Glavo
     public static void addSmoothScrolling(VirtualFlow<?> virtualFlow, double speed) {
-        addSmoothScrolling(virtualFlow, speed, 7);
+        addSmoothScrolling(virtualFlow, speed, DEFAULT_TRACK_PAD_ADJUSTMENT);
     }
 
     /// @author Glavo
@@ -180,16 +174,16 @@ final class ScrollUtils {
             }
         };
         if (scrollPane.getContent().getParent() != null) {
-            scrollPane.getContent().getParent().addEventHandler(MouseEvent.MOUSE_PRESSED, mouseHandler);
+            scrollPane.getContent().getParent().addEventFilter(MouseEvent.MOUSE_PRESSED, mouseHandler);
             scrollPane.getContent().getParent().addEventHandler(ScrollEvent.ANY, scrollHandler);
         }
         scrollPane.getContent().parentProperty().addListener((observable, oldValue, newValue) -> {
             if (oldValue != null) {
-                oldValue.removeEventHandler(MouseEvent.MOUSE_PRESSED, mouseHandler);
+                oldValue.removeEventFilter(MouseEvent.MOUSE_PRESSED, mouseHandler);
                 oldValue.removeEventHandler(ScrollEvent.ANY, scrollHandler);
             }
             if (newValue != null) {
-                newValue.addEventHandler(MouseEvent.MOUSE_PRESSED, mouseHandler);
+                newValue.addEventFilter(MouseEvent.MOUSE_PRESSED, mouseHandler);
                 newValue.addEventHandler(ScrollEvent.ANY, scrollHandler);
             }
         });
@@ -250,7 +244,7 @@ final class ScrollUtils {
                 event.consume();
             }
         };
-        virtualFlow.addEventHandler(MouseEvent.MOUSE_PRESSED, mouseHandler);
+        virtualFlow.addEventFilter(MouseEvent.MOUSE_PRESSED, mouseHandler);
         virtualFlow.addEventFilter(ScrollEvent.ANY, scrollHandler);
 
         timeline.getKeyFrames().add(new KeyFrame(DURATION, event -> {
@@ -277,5 +271,8 @@ final class ScrollUtils {
             }
         }));
         timeline.setCycleCount(Animation.INDEFINITE);
+    }
+
+    private ScrollUtils() {
     }
 }


### PR DESCRIPTION
1. 清理 `ScrollUtils`
2. 修复惯性滚动可能导致 `JFXComboBox` 弹出菜单错位的问题