### PR TITLE
修复 macOS 下剩余内存读取问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/macos/MacOSHardwareDetector.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/macos/MacOSHardwareDetector.java
@@ -167,7 +167,6 @@ public final class MacOSHardwareDetector extends HardwareDetector {
             long pagesFree;
             long pagesInactive;
             long pagesSpeculative;
-            long pagesPurgeable;
 
             if (statistics != null) {
                 Matcher matcher = PAGE_SIZE_PATTERN.matcher(statistics);
@@ -201,14 +200,7 @@ public final class MacOSHardwareDetector extends HardwareDetector {
                 break vmStat;
             }
 
-            String pagesPurgeableStr = stats.get("Pages purgeable");
-            if (pagesPurgeableStr != null && pagesPurgeableStr.endsWith(".")) {
-                pagesPurgeable = Long.parseUnsignedLong(pagesPurgeableStr, 0, pagesPurgeableStr.length() - 1, 10);
-            } else {
-                break vmStat;
-            }
-
-            long available = (pagesFree + pagesSpeculative + pagesInactive + pagesPurgeable) * pageSize;
+            long available = (pagesFree + pagesSpeculative + pagesInactive) * pageSize;
             if (available > 0) {
                 return available;
             }


### PR DESCRIPTION
Fix #3980

实现逻辑：通过 `vm_stat` 命令获取空闲内存，内存读取较原有逻辑误差显著降低

受限于手头设备原因，**这可能需要额外的测试来证明代码可用性**

### Before

<img width="600" alt="Before" src="https://github.com/user-attachments/assets/f3b31e2c-ec22-48c4-ac76-5912f87dd112" />

### After

<img width="600" alt="After" src="https://github.com/user-attachments/assets/808ceb6e-7589-439d-92d4-da7c9c8fd01e" />

误差原因：这是同时计算了 `vm_stat` 输出的 `Pages inactive` 和 `Pages free`，可能逻辑与检测工具之间存在差异

***

附: `vm_stat` 示例输出：
~~~
Mach Virtual Memory Statistics: (page size of 16384 bytes)
Pages free:                                3857.
Pages active:                            446206.
Pages inactive:                          443760.
Pages speculative:                         1075.
Pages throttled:                              0.
Pages wired down:                        181483.
Pages purgeable:                          17340.
"Translation faults":                8667427138.
Pages copy-on-write:                  156847509.
Pages zero filled:                   4902315421.
Pages reactivated:                    586001636.
Pages purged:                         174538344.
File-backed pages:                       294894.
Anonymous pages:                         596147.
Pages stored in compressor:             1943619.
Pages occupied by compressor:            442179.
Decompressions:                       591661242.
Compressions:                         654599489.
Pageins:                              134108004.
Pageouts:                              31713991.
Swapins:                                1582661.
Swapouts:                               2698721.
~~~