### PR TITLE
优化检查更新工作流

### DIFF
--- a/.github/workflows/check-update.yml
+++ b/.github/workflows/check-update.yml
@@ -67,13 +67,13 @@ jobs:
       - name: Create release
         if: ${{ env.continue == 'true' }}
         run: |
-          gh release create "${HMCL_TAG_NAME}" \
-            "HMCL-${HMCL_VERSION}.exe" \
-            "HMCL-${HMCL_VERSION}.jar" \
-            "HMCL-${HMCL_VERSION}.sh" \
-            --title "${HMCL_TAG_NAME}" \
+          gh release create "${{ env.HMCL_TAG_NAME }}" \
+            "HMCL-${{ env.HMCL_VERSION }}.exe" \
+            "HMCL-${{ env.HMCL_VERSION }}.jar" \
+            "HMCL-${{ env.HMCL_VERSION }}.sh" \
+            --target "${{ env.HMCL_COMMIT_SHA }}" \
+            --title "${{ env.HMCL_TAG_NAME }}" \
             --notes-file RELEASE_NOTE \
-            --target "${HMCL_COMMIT_SHA}" \
             --prerelease
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# 优化检查更新工作流

## 描述

1. 将 `actions/checkout` 升级到 `v6`
2. 使用 `fetch-tags: true` 替代 `Fetch tags`
3. 移除 `Download artifacts` 中无意义的环境变量 `GH_DOWNLOAD_BASE_URL`
4. 使用 `${{ github.repository }}` 替换在环境变量 `GH_DOWNLOAD_BASE_URL` 中硬编码的仓库名部分
5. 使用 `gh cli` 替代 `softprops/action-gh-release@v2`

## 参考

https://github.com/actions/checkout?tab=readme-ov-file#usage
https://cli.github.com/manual/gh_release_create
