### PR TITLE
在 HintPane 提示框中为图标和文本添加间距

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/HintPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/HintPane.java
@@ -68,6 +68,7 @@ public class HintPane extends VBox {
 
         HBox hbox = new HBox(svg.createIcon(16), new Text(type.getDisplayName()));
         hbox.setAlignment(Pos.CENTER_LEFT);
+        hbox.setSpacing(2);
         flow.getChildren().setAll(label);
         getChildren().setAll(hbox, flow);
         label.textProperty().bind(text);


### PR DESCRIPTION
| 添加间距版本 | 无间距版本 |
|-|-|
|<img width="818" height="508" alt="image" src="https://github.com/user-attachments/assets/5727879e-ea7b-4920-a483-6b72b5d971c7" />|<img width="818" height="508" alt="image" src="https://github.com/user-attachments/assets/8be44932-2345-4d7d-97aa-f865106dc725" />|
