### PR TITLE
修复使用JFXComboBox的Tooltip颜色异常问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
@@ -431,6 +431,8 @@ public final class FXUtils {
         tooltip.setShowDelay(showDelay);
         tooltip.setShowDuration(showDuration);
         tooltip.setHideDelay(hideDelay);
+        // https://github.com/HMCL-dev/HMCL/pull/4933
+        tooltip.setStyle("-fx-text-fill: -monet-inverse-on-surface; -fx-background-color: -monet-inverse-surface;");
         Tooltip.install(node, tooltip);
     }
 


### PR DESCRIPTION
<img width="465" height="212" alt="屏幕截图 2025-12-06 213224" src="https://github.com/user-attachments/assets/84db2f2b-a040-4a4b-836c-8cecfc581031" />
<img width="1008" height="413" alt="屏幕截图 2025-12-06 213356" src="https://github.com/user-attachments/assets/5ea9c80a-2be0-4cc8-a096-adfd2ed47158" />
