### PR TITLE
Fix #4939: 深色模式超链接的已访问样式配色问题

### DIFF
--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -41,6 +41,10 @@
     -fx-text-fill: -monet-on-surface-variant;
 }
 
+.hyperlink {
+    -fx-text-fill: -monet-primary;
+}
+
 .hint {
     -fx-background-radius: 5;
     -fx-border-width: 1;
@@ -92,10 +96,6 @@
 .hint.warning .hyperlink {
     -fx-fill: -fx-hyperlink-fill;
     -fx-text-fill: -fx-hyperlink-fill;
-}
-
-.hyperlink:visited {
-    -fx-text-fill: -monet-on-surface;
 }
 
 .skin-pane .jfx-text-field {


### PR DESCRIPTION
<img width="216" height="187" alt="image" src="https://github.com/user-attachments/assets/3b13656f-33a3-49c6-9981-8299efa7a32b" />

~~另外，我还对现有的重复声明进行了清理~~