### PR TITLE
[release/3.8] 修复从 BMCLAPI 下载部分旧文件时校验失败的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/task/FileDownloadTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/task/FileDownloadTask.java
@@ -193,7 +193,7 @@ public class FileDownloadTask extends FetchTask<Void> {
         if (integrityCheck != null) {
             algorithm = integrityCheck.getAlgorithm();
             checksum = integrityCheck.getChecksum();
-        } else if (bmclapiHash != null) {
+        } else if (bmclapiHash != null && DigestUtils.isSha1Digest(bmclapiHash)) {
             algorithm = "SHA-1";
             checksum = bmclapiHash;
         } else {


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/pull/4949