### PR TITLE
Bump authlib-injector to 1.2.7: fix compatibility with 26.1-snapshot-1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ twelvemonkeys = "3.12.0"
 jna = "5.18.1"
 pci-ids = "0.4.0"
 java-info = "1.0"
-authlib-injector = "1.2.6"
+authlib-injector = "1.2.7"
 monet-fx = "0.4.0"
 
 # testing


### PR DESCRIPTION
Fix #4989