### PR TITLE
ModListPage 刷新时不滚动到顶部

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
@@ -92,8 +92,6 @@ final class ModListPageSkin extends SkinBase<ModListPage> {
     // FXThread
     private boolean isSearching = false;
 
-    @SuppressWarnings({"FieldCanBeLocal", "unused"})
-
     ModListPageSkin(ModListPage skinnable) {
         super(skinnable);
 


### PR DESCRIPTION
现状是无论什么原因触发的 `loadMods`，加载完成后都会滚动到顶部。

假如模组列表发生了实质性变化，滚动到顶部让用户看到最新状态或许是可行的。但 `loadVersion` 的时候会触发 `loadMods`，这是 "保险起见重新加载"，但不假设"一定有变化"。这会导致模组列表没有变动，但是重新加载了模组列表，列表滚动到了顶部，这个滚动行为会导致 https://github.com/HMCL-dev/HMCL/issues/4821

列表刷新，但是保留滚动位置我感觉应该更好，似乎其他页面也没有这个滚动到顶部的逻辑。
