### PR TITLE
修复 subtitle 颜色丢失的问题

### DIFF
--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -1009,6 +1009,10 @@
     -fx-text-fill: -monet-on-surface;
 }
 
+.options-list-item .label.subtitle {
+    -fx-text-fill: -monet-on-surface-variant;
+}
+
 .options-list-item.no-padding {
     -fx-padding: 0;
 }


### PR DESCRIPTION

<img width="818" height="508" alt="image" src="https://github.com/user-attachments/assets/a82a1000-2e0d-4b36-a94e-b36ed54b7ad6" />


fix #5017