### PR TITLE
Fix: #4958 模组检查更新

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModCheckUpdatesTask.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModCheckUpdatesTask.java
@@ -19,34 +19,45 @@ package org.jackhuang.hmcl.ui.versions;
 
 import org.jackhuang.hmcl.mod.LocalModFile;
 import org.jackhuang.hmcl.mod.RemoteMod;
+import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.task.Task;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import static org.jackhuang.hmcl.util.logging.Logger.LOG;
 
 public class ModCheckUpdatesTask extends Task<List<LocalModFile.ModUpdate>> {
-    private final String gameVersion;
-    private final Collection<LocalModFile> mods;
-    private final Collection<Collection<Task<LocalModFile.ModUpdate>>> dependents;
+    private final List<Task<LocalModFile.ModUpdate>> dependents;
 
     public ModCheckUpdatesTask(String gameVersion, Collection<LocalModFile> mods) {
-        this.gameVersion = gameVersion;
-        this.mods = mods;
+        dependents = mods.stream().map(mod ->
+                Task.supplyAsync(Schedulers.io(), () -> {
+                    LocalModFile.ModUpdate candidate = null;
+                    for (RemoteMod.Type type : RemoteMod.Type.values()) {
+                        LocalModFile.ModUpdate update = null;
+                        try {
+                            update = mod.checkUpdates(gameVersion, type.getRemoteModRepository());
+                        } catch (IOException e) {
+                            LOG.warning(String.format("Cannot check update for mod %s.", mod.getFileName()), e);
+                        }
+                        if (update == null) {
+                            continue;
+                        }
 
-        dependents = mods.stream()
-                .map(mod ->
-                        Arrays.stream(RemoteMod.Type.values())
-                                .map(type ->
-                                        Task.supplyAsync(() -> mod.checkUpdates(gameVersion, type.getRemoteModRepository()))
-                                                .setSignificance(TaskSignificance.MAJOR)
-                                                .setName(String.format("%s (%s)", mod.getFileName(), type.name())).withCounter("update.checking")
-                                )
-                                .collect(Collectors.toList())
-                )
-                .collect(Collectors.toList());
+                        if (candidate == null || candidate.getCandidate().getDatePublished().isBefore(update.getCandidate().getDatePublished())) {
+                            candidate = update;
+                        }
+                    }
+
+                    return candidate;
+                }).setName(mod.getFileName()).setSignificance(TaskSignificance.MAJOR).withCounter("update.checking")
+        ).toList();
 
         setStage("update.checking");
-        getProperties().put("total", dependents.size() * RemoteMod.Type.values().length);
+        getProperties().put("total", dependents.size());
     }
 
     @Override
@@ -61,7 +72,7 @@ public class ModCheckUpdatesTask extends Task<List<LocalModFile.ModUpdate>> {
 
     @Override
     public Collection<? extends Task<?>> getDependents() {
-        return dependents.stream().flatMap(Collection::stream).collect(Collectors.toList());
+        return dependents;
     }
 
     @Override
@@ -72,14 +83,7 @@ public class ModCheckUpdatesTask extends Task<List<LocalModFile.ModUpdate>> {
     @Override
     public void execute() throws Exception {
         setResult(dependents.stream()
-                .map(tasks -> tasks.stream()
-                        .filter(task -> task.getResult() != null)
-                        .map(Task::getResult)
-                        .filter(modUpdate -> !modUpdate.getCandidates().isEmpty())
-                        .max(Comparator.comparing((LocalModFile.ModUpdate modUpdate) -> modUpdate.getCandidates().get(0).getDatePublished()))
-                        .orElse(null)
-                )
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList()));
+                .map(Task::getResult)
+                .filter(Objects::nonNull).toList());
     }
 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModUpdatesPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModUpdatesPage.java
@@ -134,7 +134,7 @@ public class ModUpdatesPage extends BorderPane implements DecoratorPage {
                 modManager,
                 objects.stream()
                         .filter(o -> o.enabled.get())
-                        .map(object -> pair(object.data.getLocalMod(), object.data.getCandidates().get(0)))
+                        .map(object -> pair(object.data.getLocalMod(), object.data.getCandidate()))
                         .collect(Collectors.toList()));
         Controllers.taskDialog(
                 task.whenComplete(Schedulers.javafx(), exception -> {
@@ -203,7 +203,7 @@ public class ModUpdatesPage extends BorderPane implements DecoratorPage {
             enabled.set(!data.getLocalMod().getModManager().isDisabled(data.getLocalMod().getFile()));
             fileName.set(data.getLocalMod().getFileName());
             currentVersion.set(data.getCurrentVersion().getVersion());
-            targetVersion.set(data.getCandidates().get(0).getVersion());
+            targetVersion.set(data.getCandidate().getVersion());
             switch (data.getCurrentVersion().getSelf().getType()) {
                 case CURSEFORGE:
                     source.set(i18n("mods.curseforge"));

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/LocalModFile.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/LocalModFile.java
@@ -23,8 +23,11 @@ import org.jackhuang.hmcl.util.io.FileUtils;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 import static org.jackhuang.hmcl.util.logging.Logger.LOG;
 
@@ -182,9 +185,9 @@ public final class LocalModFile implements Comparable<LocalModFile> {
                 .filter(version -> version.getLoaders().contains(getModLoaderType()))
                 .filter(version -> version.getDatePublished().compareTo(currentVersion.get().getDatePublished()) > 0)
                 .sorted(Comparator.comparing(RemoteMod.Version::getDatePublished).reversed())
-                .collect(Collectors.toList());
+                .toList();
         if (remoteVersions.isEmpty()) return null;
-        return new ModUpdate(this, currentVersion.get(), remoteVersions);
+        return new ModUpdate(this, currentVersion.get(), remoteVersions.get(0));
     }
 
     @Override
@@ -205,12 +208,12 @@ public final class LocalModFile implements Comparable<LocalModFile> {
     public static class ModUpdate {
         private final LocalModFile localModFile;
         private final RemoteMod.Version currentVersion;
-        private final List<RemoteMod.Version> candidates;
+        private final RemoteMod.Version candidate;
 
-        public ModUpdate(LocalModFile localModFile, RemoteMod.Version currentVersion, List<RemoteMod.Version> candidates) {
+        public ModUpdate(LocalModFile localModFile, RemoteMod.Version currentVersion, RemoteMod.Version candidate) {
             this.localModFile = localModFile;
             this.currentVersion = currentVersion;
-            this.candidates = candidates;
+            this.candidate = candidate;
         }
 
         public LocalModFile getLocalMod() {
@@ -221,8 +224,8 @@ public final class LocalModFile implements Comparable<LocalModFile> {
             return currentVersion;
         }
 
-        public List<RemoteMod.Version> getCandidates() {
-            return candidates;
+        public RemoteMod.Version getCandidate() {
+            return candidate;
         }
     }
 


### PR DESCRIPTION
原来的码太狗屎了，竟然会保留全部模组的全部历史版本待查，怪不得这么容易 OOM

该 PR 必须在 #5026 后合并，否则会 DOS 服务器