### PR TITLE
feat: 优化InputDialogPane体验

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/InputDialogPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/InputDialogPane.java
@@ -30,7 +30,7 @@ import java.util.concurrent.CompletableFuture;
 import static org.jackhuang.hmcl.ui.FXUtils.onEscPressed;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
-public class InputDialogPane extends JFXDialogLayout {
+public class InputDialogPane extends JFXDialogLayout implements DialogAware {
     private final CompletableFuture<String> future = new CompletableFuture<>();
 
     private final JFXTextField textField;
@@ -72,6 +72,11 @@ public class InputDialogPane extends JFXDialogLayout {
 
         textField.setOnAction(event -> acceptButton.fire());
         onEscPressed(this, cancelButton::fire);
+    }
+
+    @Override
+    public void onDialogShown() {
+        textField.requestFocus();
     }
 
     public CompletableFuture<String> getCompletableFuture() {


### PR DESCRIPTION
之前打开输入框不会自动聚焦到输入框，现在会了
之前输入文本后需要鼠标移动点击确认，现在输入文本后直接按Enter就可以了，更方便。