### PR TITLE
修复下载光影时对话框的标题文字错误

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/DownloadPage.java
@@ -25,7 +25,6 @@ import org.jackhuang.hmcl.download.*;
 import org.jackhuang.hmcl.download.game.GameRemoteVersion;
 import org.jackhuang.hmcl.mod.RemoteMod;
 import org.jackhuang.hmcl.mod.curse.CurseForgeRemoteModRepository;
-import org.jackhuang.hmcl.mod.modrinth.ModrinthRemoteModRepository;
 import org.jackhuang.hmcl.setting.DownloadProviders;
 import org.jackhuang.hmcl.setting.Profile;
 import org.jackhuang.hmcl.setting.Profiles;
@@ -96,7 +95,7 @@ public class DownloadPage extends DecoratorAnimatedPage implements DecoratorPage
         }));
         modTab.setNodeSupplier(loadVersionFor(() -> HMCLLocalizedDownloadListPage.ofMod((profile, version, file) -> download(profile, version, file, "mods"), true)));
         resourcePackTab.setNodeSupplier(loadVersionFor(() -> HMCLLocalizedDownloadListPage.ofResourcePack((profile, version, file) -> download(profile, version, file, "resourcepacks"), true)));
-        shaderTab.setNodeSupplier(loadVersionFor(() -> new DownloadListPage(ModrinthRemoteModRepository.SHADER_PACKS, (profile, version, file) -> download(profile, version, file, "shaderpacks"), true)));
+        shaderTab.setNodeSupplier(loadVersionFor(() -> HMCLLocalizedDownloadListPage.ofShaderPack((profile, version, file) -> download(profile, version, file, "shaderpacks"), true)));
         worldTab.setNodeSupplier(loadVersionFor(() -> new DownloadListPage(CurseForgeRemoteModRepository.WORLDS)));
         tab = new TabHeader(transitionPane, newGameTab, modpackTab, modTab, resourcePackTab, shaderTab, worldTab);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
@@ -447,22 +447,13 @@ public class DownloadPage extends Control implements DecoratorPage {
         public ModVersion(RemoteMod.Version version, DownloadPage selfPage) {
             RemoteModRepository.Type type = selfPage.repository.getType();
 
-            String title;
-            switch (type) {
-                case WORLD:
-                    title = "world.download.title";
-                    break;
-                case MODPACK:
-                    title = "modpack.download.title";
-                    break;
-                case RESOURCE_PACK:
-                    title = "resourcepack.download.title";
-                    break;
-                case MOD:
-                default:
-                    title = "mods.download.title";
-                    break;
-            }
+            String title = switch (type) {
+                case WORLD -> "world.download.title";
+                case MODPACK -> "modpack.download.title";
+                case RESOURCE_PACK -> "resourcepack.download.title";
+                case SHADER_PACK -> "shaderpack.download.title";
+                default -> "mods.download.title";
+            };
             this.setHeading(new HBox(new Label(i18n(title, version.getName()))));
 
             VBox box = new VBox(8);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/HMCLLocalizedDownloadListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/HMCLLocalizedDownloadListPage.java
@@ -25,8 +25,8 @@ import org.jackhuang.hmcl.util.i18n.I18n;
 
 import java.util.MissingResourceException;
 
-import static org.jackhuang.hmcl.util.logging.Logger.LOG;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
+import static org.jackhuang.hmcl.util.logging.Logger.LOG;
 
 public final class HMCLLocalizedDownloadListPage extends DownloadListPage {
     public static DownloadListPage ofMod(DownloadPage.DownloadCallback callback, boolean versionSelection) {
@@ -47,6 +47,10 @@ public final class HMCLLocalizedDownloadListPage extends DownloadListPage {
 
     public static DownloadListPage ofResourcePack(DownloadPage.DownloadCallback callback, boolean versionSelection) {
         return new HMCLLocalizedDownloadListPage(callback, versionSelection, RemoteModRepository.Type.RESOURCE_PACK, CurseForgeRemoteModRepository.RESOURCE_PACKS, ModrinthRemoteModRepository.RESOURCE_PACKS);
+    }
+
+    public static DownloadListPage ofShaderPack(DownloadPage.DownloadCallback callback, boolean versionSelection) {
+        return new HMCLLocalizedDownloadListPage(callback, versionSelection, RemoteModRepository.Type.SHADER_PACK, null, ModrinthRemoteModRepository.SHADER_PACKS);
     }
 
     private HMCLLocalizedDownloadListPage(DownloadPage.DownloadCallback callback, boolean versionSelection, RemoteModRepository.Type type, CurseForgeRemoteModRepository curseForge, ModrinthRemoteModRepository modrinth) {

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -1423,6 +1423,8 @@ settings.type.special.enable=Enable Instance-specific Settings
 settings.type.special.edit=Edit Current Instance Settings
 settings.type.special.edit.hint=Current instance "%s" has enabled the "Instance-specific Settings". All options on this page will NOT affect that instance. Click here to edit its own settings.
 
+shaderpack.download.title=Download Shader - %1s
+
 sponsor=Donors
 sponsor.bmclapi=Downloads for the Chinese Mainland are provided by BMCLAPI. Click here for more information.
 sponsor.hmcl=Hello Minecraft! Launcher is a FOSS Minecraft launcher that allows users to manage multiple Minecraft instances easily. Click here for more information.

--- a/HMCL/src/main/resources/assets/lang/I18N_lzh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_lzh.properties
@@ -1201,6 +1201,8 @@ settings.type.special.enable=啟例殊戲設 (不殃余者)
 settings.type.special.edit=纂例殊戲設
 settings.type.special.edit.hint=是戲例「%s」既啟「例殊戲設」，是故本頁諸置設弗行於斯。擊此鏈赴斯版之「戲設」頁。
 
+shaderpack.download.title=引光影 - %1s
+
 sponsor=資勉
 sponsor.bmclapi=本朝迅傳之功在 BMCLAPI 焉。BMCLAPI 久行善業，垂衆以慷慨解囊助作者兼濟天下也。[願聞其詳]
 sponsor.hmcl=Hello Minecraft! Launcher，乃一免費，自由，開源之礦藝啟者。[願聞其詳]

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -1211,6 +1211,8 @@ settings.type.special.enable=啟用實例特定遊戲設定 (不影響其他實�
 settings.type.special.edit=編輯實例特定遊戲設定
 settings.type.special.edit.hint=目前實例「%s」啟用了「實例特定遊戲設定」，本頁面選項不對目前實例生效。點擊連結以修改目前實例設定。
 
+shaderpack.download.title=光影下載 - %1s
+
 sponsor=贊助
 sponsor.bmclapi=中國大陸下載源由 BMCLAPI 提供高速下載服務。點選此處查閱詳細訊息。
 sponsor.hmcl=Hello Minecraft! Launcher 是一個免費、自由、開源的 Minecraft 啟動器，允許玩家方便快捷地安裝、管理、執行遊戲。點選此處查閱詳細訊息。

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -1221,6 +1221,8 @@ settings.type.special.enable=启用实例特定游戏设置 (不影响其他游�
 settings.type.special.edit=编辑实例特定游戏设置
 settings.type.special.edit.hint=当前游戏实例“%s”启用了“实例特定游戏设置”，因此本页面选项不对该实例生效。点击链接前往该实例的“游戏设置”页。
 
+shaderpack.download.title=光影下载 - %1s
+
 sponsor=赞助
 sponsor.bmclapi=国内下载源由 BMCLAPI 提供高速下载服务。BMCLAPI 为公益服务，赞助 BMCLAPI 可以帮助作者更好地提供稳定高速的下载服务。[点击此处查阅详细信息]
 sponsor.hmcl=Hello Minecraft! Launcher 是一个免费、自由、开放源代码的 Minecraft 启动器。[点击此处查阅详细信息]

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/RemoteModRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/RemoteModRepository.java
@@ -32,6 +32,7 @@ public interface RemoteModRepository {
         MOD,
         MODPACK,
         RESOURCE_PACK,
+        SHADER_PACK,
         WORLD,
         CUSTOMIZATION
     }


### PR DESCRIPTION
在下载世界、模组、资源包时，都会使用对应的类别，但是 `SHADER_PACK ` 忘记 case 了，导致默认是模组下载

<details>
<summary>效果图片</summary>
<img width="1023" height="635" alt="屏幕截图 2025-12-21 085035" src="https://github.com/user-attachments/assets/58f4ce9b-4cce-441e-b34e-873a2b15437e" />
<img width="1022" height="635" alt="屏幕截图 2025-12-21 085246" src="https://github.com/user-attachments/assets/efe30230-02ca-4ec0-8580-2bef81f4fb0d" />

</details>