### PR TITLE
fix: correct the MB to MiB in the game crash window

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/GameCrashWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/GameCrashWindow.java
@@ -93,7 +93,7 @@ public class GameCrashWindow extends Stage {
         this.logs = logs;
         this.analyzer = LibraryAnalyzer.analyze(version, repository.getGameVersion(version).orElse(null));
 
-        memory = Optional.ofNullable(launchOptions.getMaxMemory()).map(i -> i + " MB").orElse("-");
+        memory = Optional.ofNullable(launchOptions.getMaxMemory()).map(i -> i + " " + i18n("settings.memory.unit.mib")).orElse("-");
 
         total_memory = MEGABYTES.formatBytes(SystemInfo.getTotalMemorySize());
 


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/pull/3903 将 `MB` 等信息单位修订为 `MiB` 等。但游戏崩溃窗口有一个硬编码的 `MB` 没改。

CC @Glavo 