### PR TITLE
Fix UI scaling not working on GNOME Wayland

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/EntryPoint.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/EntryPoint.java
@@ -100,7 +100,6 @@ public final class EntryPoint {
             LOG.info("Detected Wayland session");
             // On Wayland, ensure JavaFX can properly detect the scale factor
             // by setting jdk.gtk.version to 3 which has better Wayland support
-            System.getProperties().putIfAbsent("jdk.gtk.version", "3");
 
             // Try to detect GNOME scale factor from monitors.xml if no manual scale is set
             String uiScaleEnv = System.getProperty("hmcl.uiScale", System.getenv("HMCL_UI_SCALE"));


### PR DESCRIPTION
JavaFX applications running through XWayland cannot automatically detect the Wayland compositor's scale factor, causing the UI to appear too small on HiDPI displays.

This commit:
- Detects Wayland session via XDG_SESSION_TYPE and WAYLAND_DISPLAY
- Enables prism.allowhidpi for HiDPI support
- Sets jdk.gtk.version=3 for better Wayland compatibility
- Auto-detects GNOME scale factor from ~/.config/monitors.xml
- Adds prism.uiscale as fallback for some JavaFX versions
Users can still manually override the scale using HMCL_UI_SCALE env var.
```
HMCL_UI_SCALE=2 ./HMCL
HMCL_UI_SCALE=175% ./HMCL
HMCL_UI_SCALE=192dpi ./HMCL
```
compare: 
<img width="2879" height="1799" alt="图片" src="https://github.com/user-attachments/assets/9a40ba2d-a2f8-48aa-bbfb-937cc63dd0aa" />
<img width="2879" height="1799" alt="图片" src="https://github.com/user-attachments/assets/46b63105-e7bc-41fe-8c9d-609a1aba96a7" />
setting:
<img width="2879" height="1799" alt="图片" src="https://github.com/user-attachments/assets/84adbcdc-5cc7-4e9c-9bb1-7fc6aa12ed1c" />

