### PR TITLE
优化不透明度滑块显示效果

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
@@ -173,6 +173,7 @@ public class PersonalizationPage extends StackPane {
                 slider.setMinorTickCount(1);
                 slider.setBlockIncrement(5);
                 slider.setSnapToTicks(true);
+                slider.setPadding(new Insets(9, 0, 0, 0));
                 HBox.setHgrow(slider, Priority.ALWAYS);
 
                 if (config().getBackgroundImageType() == EnumBackgroundImage.TRANSLUCENT) {


### PR DESCRIPTION
# 优化不透明度滑块显示效果

## 描述

原本滑块组件中的滑轨未能垂直居中，导致视觉效果不佳。现通过为组件添加顶部内边距，尽量将滑轨调整至垂直居中的位置，从而使整体布局更加和谐。

_before_

<img width="818" height="508" alt="image" src="https://github.com/user-attachments/assets/905d04a3-dfd1-493d-b9c2-a32f1920172f" />


_after_

<img width="818" height="508" alt="image" src="https://github.com/user-attachments/assets/ac560984-9bf2-4bfe-ace9-4ae00a184ec1" />

