### PR TITLE
为不同类型的 Dialog 指定相应的默认标题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/MessageDialogPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/MessageDialogPane.java
@@ -87,7 +87,7 @@ public final class MessageDialogPane extends HBox {
         {
             StackPane titlePane = new StackPane();
             titlePane.getStyleClass().addAll("jfx-layout-heading", "title");
-            titlePane.getChildren().setAll(new Label(title != null ? title : i18n("message.info")));
+            titlePane.getChildren().setAll(new Label(title != null ? title : i18n(type.getDisplayName())));
 
             StackPane content = new StackPane();
             content.getStyleClass().add("jfx-layout-body");

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -875,6 +875,7 @@ message.info=Information
 message.success=Operation successfully completed
 message.unknown=Unknown
 message.warning=Warning
+message.question=Question
 
 modpack=Modpacks
 modpack.choose=Choose Modpack


### PR DESCRIPTION
# 为不同类型的 Dialog 指定相应的默认标题

> [!NOTE]
> 未提供 `message.question` 的多语言支持。

see #5074
