### PR TITLE
在资源包管理页面资源包标题去除 `§` 开头的格式文本

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/resourcepack/ResourcepackFolder.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/resourcepack/ResourcepackFolder.java
@@ -40,7 +40,7 @@ public final class ResourcepackFolder implements ResourcepackFile {
 
     @Override
     public String getName() {
-        return path.getFileName().toString();
+        return path.getFileName().toString().replaceAll("§[0-9a-fk-or]", "");
     }
 
     @Override

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/resourcepack/ResourcepackZipFile.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/resourcepack/ResourcepackZipFile.java
@@ -51,7 +51,7 @@ public final class ResourcepackZipFile implements ResourcepackFile {
 
     @Override
     public String getName() {
-        return name;
+        return name.replaceAll("§[0-9a-fk-or]", "");
     }
 
     @Override


### PR DESCRIPTION
**Before:** 
<img width="500" alt="image" src="https://github.com/user-attachments/assets/2785943a-ffd4-4720-9fc9-41c9a7d87f5c" />

**After:**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/73c8e8c3-c848-4c3f-afd6-1985bf41bcd7" />

这样调整后应该可以显著改善材质包名称的阅读体验
