### PR TITLE
首页切换实例菜单仅在菜单高度大于最大高度时显示垂直滚动条

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/MainPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/MainPage.java
@@ -298,7 +298,7 @@ public final class MainPage extends StackPane implements DecoratorPage {
 
         menu.setMaxHeight(365);
         menu.setMaxWidth(545);
-        menu.setAlwaysShowingVBar(true);
+        menu.setAlwaysShowingVBar(false);
         FXUtils.onClicked(menu, popup::hide);
         versionNodes = MappedObservableList.create(versions, version -> {
             Node node = PopupMenu.wrapPopupMenuItem(new GameItem(profile, version.getId()));


### PR DESCRIPTION
# 首页切换实例菜单仅在菜单高度大于最大高度时显示垂直滚动条

_菜单高度大于最大高度时_

<img width="818" height="508" alt="image" src="https://github.com/user-attachments/assets/a8c4341e-85d8-4e4f-877e-97ba7a2b29cd" />

_菜单高度小于最大高度时_

<img width="818" height="508" alt="image" src="https://github.com/user-attachments/assets/19641393-a820-4605-ab58-b9eb1aae54b7" />

