### PR TITLE
优化打包日志逻辑

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/LogExporter.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/LogExporter.java
@@ -29,8 +29,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileTime;
+import java.nio.file.PathMatcher;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -42,7 +41,9 @@ public final class LogExporter {
     private LogExporter() {
     }
 
-    public static CompletableFuture<Void> exportLogs(Path zipFile, DefaultGameRepository gameRepository, String versionId, String logs, String launchScript, long processStartTime) {
+    public static CompletableFuture<Void> exportLogs(
+            Path zipFile, DefaultGameRepository gameRepository, String versionId, String logs, String launchScript,
+            PathMatcher logMatcher) {
         Path runDirectory = gameRepository.getRunDirectory(versionId);
         Path baseDirectory = gameRepository.getBaseDirectory();
         List<String> versions = new ArrayList<>();
@@ -64,10 +65,10 @@ public final class LogExporter {
 
         return CompletableFuture.runAsync(() -> {
             try (Zipper zipper = new Zipper(zipFile)) {
-                processLogs(runDirectory.resolve("liteconfig"), "*.log", "liteconfig", zipper, processStartTime);
-                processLogs(runDirectory.resolve("logs"), "*.log", "logs", zipper, processStartTime);
-                processLogs(runDirectory, "*.log", "runDirectory", zipper, processStartTime);
-                processLogs(runDirectory.resolve("crash-reports"), "*.txt", "crash-reports", zipper, processStartTime);
+                processLogs(runDirectory.resolve("liteconfig"), "*.log", "liteconfig", zipper, logMatcher);
+                processLogs(runDirectory.resolve("logs"), "*.log", "logs", zipper, logMatcher);
+                processLogs(runDirectory, "*.log", "runDirectory", zipper, logMatcher);
+                processLogs(runDirectory.resolve("crash-reports"), "*.txt", "crash-reports", zipper, logMatcher);
 
                 zipper.putTextFile(LOG.getLogs(), "hmcl.log");
                 zipper.putTextFile(logs, "minecraft.log");
@@ -85,12 +86,11 @@ public final class LogExporter {
         });
     }
 
-    private static void processLogs(Path directory, String fileExtension, String logDirectory, Zipper zipper, long processStartTime) {
+    private static void processLogs(Path directory, String fileExtension, String logDirectory, Zipper zipper, PathMatcher logMatcher) {
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(directory, fileExtension)) {
             for (Path file : stream) {
                 if (Files.isRegularFile(file)) {
-                    FileTime time = Files.readAttributes(file, BasicFileAttributes.class).lastModifiedTime();
-                    if (time.toMillis() >= processStartTime) {
+                    if (logMatcher == null || logMatcher.matches(file)) {
                         try (BufferedReader reader = IOUtils.newBufferedReaderMaybeNativeEncoding(file)) {
                             zipper.putLines(reader.lines().map(Logger::filterForbiddenToken), file.getFileName().toString());
                         } catch (IOException e) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/GameCrashWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/GameCrashWindow.java
@@ -50,9 +50,11 @@ import org.jackhuang.hmcl.util.logging.Logger;
 import org.jackhuang.hmcl.util.platform.*;
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -270,8 +272,30 @@ public class GameCrashWindow extends Stage {
 
         CompletableFuture.supplyAsync(() ->
                         logs.stream().map(Log::getLog).collect(Collectors.joining("\n")))
-                .thenComposeAsync(logs ->
-                        LogExporter.exportLogs(logFile, repository, launchOptions.getVersionName(), logs, new CommandBuilder().addAll(managedProcess.getCommands()).toString(),managedProcess.getProcess().toHandle().info().startInstant().map(Instant::toEpochMilli).orElse(0L)))
+                .thenComposeAsync(logs -> {
+                    long processStartTime = managedProcess.getProcess().info()
+                            .startInstant()
+                            .map(Instant::toEpochMilli).orElseGet(() -> {
+                                try {
+                                    return ManagementFactory.getRuntimeMXBean().getStartTime();
+                                } catch (Throwable e) {
+                                    LOG.warning("Failed to get process start time", e);
+                                    return 0L;
+                                }
+                            });
+
+                    return LogExporter.exportLogs(logFile, repository, launchOptions.getVersionName(), logs,
+                            new CommandBuilder().addAll(managedProcess.getCommands()).toString(),
+                            path -> {
+                                try {
+                                    FileTime lastModifiedTime = Files.getLastModifiedTime(path);
+                                    return lastModifiedTime.toMillis() >= processStartTime;
+                                } catch (Throwable e) {
+                                    LOG.warning("Failed to read file attributes", e);
+                                    return false;
+                                }
+                            });
+                })
                 .handleAsync((result, exception) -> {
                     Alert alert;
 


### PR DESCRIPTION
#4587 是因为当事人启动器连着开了好几天没关，然后打包崩溃日志的时候排除的是早于启动器启动之前的文件，而不是早于游戏启动的文件，导致启动器启动到游戏崩溃之间的 crash-report 全部被打包

本 pr 将此处的逻辑修改为了排除早于游戏启动的文件