### PR TITLE
feat: 允许重命名实例时使用原名

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/Versions.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/Versions.java
@@ -130,6 +130,10 @@ public final class Versions {
 
     public static CompletableFuture<String> renameVersion(Profile profile, String version) {
         return Controllers.prompt(i18n("version.manage.rename.message"), (newName, resolve, reject) -> {
+            if (newName.equals(version)) {
+                resolve.run();
+                return;
+            }
             if (profile.getRepository().renameVersion(version, newName)) {
                 resolve.run();
                 profile.getRepository().refreshVersionsAsync()
@@ -142,7 +146,7 @@ public final class Versions {
                 reject.accept(i18n("version.manage.rename.fail"));
             }
         }, version, new Validator(i18n("install.new_game.malformed"), HMCLGameRepository::isValidVersionId),
-            new Validator(i18n("install.new_game.already_exists"), newVersionName -> !profile.getRepository().versionIdConflicts(newVersionName)));
+            new Validator(i18n("install.new_game.already_exists"), newVersionName -> !profile.getRepository().versionIdConflicts(newVersionName) || newVersionName.equals(version)));
     }
 
     public static void exportVersion(Profile profile, String version) {


### PR DESCRIPTION
在之前的逻辑中，当用户点击“重命名实例”时，弹窗默认显示的名称是实例的原名。由于校验器会检查名称是否已存在，导致用户一打开弹窗就会看到“此实例已存在”的错误提示。

此外，用户通常认为“重名”是指与其他实例名称冲突，保持原名不应被视为错误。这不符合用户的使用习惯，且容易造成误导。
现在会进行判断，如果是原名则什么都不做。

| 之前  | <img width="1242" height="679" alt="image" src="https://github.com/user-attachments/assets/9390c903-1fcd-47e7-867d-0107f22b0319" /> |
| --- | ----------------------------------------------------------------------------------------------------------------------------------- |
| 现在  | <img width="1245" height="679" alt="image" src="https://github.com/user-attachments/assets/f8127745-3d94-4526-b4d5-cdc8d613c253" /> |