### PR TITLE
fix: 解决数据包页面在加载超多数据包时卡顿的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DatapackListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DatapackListPage.java
@@ -51,7 +51,7 @@ public final class DatapackListPage extends ListPageBase<DatapackListPageSkin.Da
         datapack = new Datapack(worldDir.resolve("datapacks"));
         setItems(MappedObservableList.create(datapack.getPacks(), DatapackListPageSkin.DatapackInfoObject::new));
         FXUtils.applyDragListener(this, it -> Objects.equals("zip", FileUtils.getExtension(it)),
-                dataPacks -> dataPacks.forEach(this::installSingleDatapack), this::refresh);
+                mods -> mods.forEach(this::installSingleDatapack), this::refresh);
 
         refresh();
     }


### PR DESCRIPTION
将加载机制由同步改为异步，以解决在有超多数据包时加载页面的卡顿问题