### PR TITLE
docs: 在贡献文档中添加专门针对 macOS 的 JDK 版本检查命令

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -28,10 +28,10 @@ OpenJDK 64-Bit Server VM (build 25+37-LTS, mixed mode, sharing)
 </details>
 
 <details>
-<summary>macOS</summary>
+<summary>Linux/FreeBSD</summary>
 
 ```
-> /usr/libexec/java_home --exec java -version
+> $JAVA_HOME/bin/java -version
 openjdk version "25" 2025-09-16 LTS
 OpenJDK Runtime Environment (build 25+37-LTS)
 OpenJDK 64-Bit Server VM (build 25+37-LTS, mixed mode, sharing)
@@ -40,10 +40,10 @@ OpenJDK 64-Bit Server VM (build 25+37-LTS, mixed mode, sharing)
 </details>
 
 <details>
-<summary>Linux/FreeBSD</summary>
+<summary>macOS</summary>
 
 ```
-> $JAVA_HOME/bin/java -version
+> /usr/libexec/java_home --exec java -version
 openjdk version "25" 2025-09-16 LTS
 OpenJDK Runtime Environment (build 25+37-LTS)
 OpenJDK 64-Bit Server VM (build 25+37-LTS, mixed mode, sharing)

--- a/docs/Contributing_zh.md
+++ b/docs/Contributing_zh.md
@@ -27,10 +27,10 @@ OpenJDK 64-Bit Server VM (build 25+37-LTS, mixed mode, sharing)
 </details>
 
 <details>
-<summary>macOS</summary>
+<summary>Linux/FreeBSD</summary>
 
 ```
-> /usr/libexec/java_home --exec java -version
+> $JAVA_HOME/bin/java -version
 openjdk version "25" 2025-09-16 LTS
 OpenJDK Runtime Environment (build 25+37-LTS)
 OpenJDK 64-Bit Server VM (build 25+37-LTS, mixed mode, sharing)
@@ -39,10 +39,10 @@ OpenJDK 64-Bit Server VM (build 25+37-LTS, mixed mode, sharing)
 </details>
 
 <details>
-<summary>Linux/FreeBSD</summary>
+<summary>macOS</summary>
 
 ```
-> $JAVA_HOME/bin/java -version
+> /usr/libexec/java_home --exec java -version
 openjdk version "25" 2025-09-16 LTS
 OpenJDK Runtime Environment (build 25+37-LTS)
 OpenJDK 64-Bit Server VM (build 25+37-LTS, mixed mode, sharing)


### PR DESCRIPTION
大部分的 OpenJDK 发行版都不会在 macOS 中添加 `JAVA_HOME` 的环境变量
苹果为此提供了 `/usr/libexec/java_home` 工具来管理安装的 Java，使用此工具以检查 JDK 在 macOS 上是更加通用的选择

~~~bash
/usr/libexec/java_home --exec java -version
~~~