### PR TITLE
imp: add padding for java selection list item

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/MultiFileItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/MultiFileItem.java
@@ -181,6 +181,7 @@ public final class MultiFileItem<T> extends VBox {
                 center.setWrapText(true);
                 center.getStyleClass().add("subtitle-label");
                 center.setStyle("-fx-font-size: 10;");
+                center.setPadding(new Insets(0, 0, 0, 15));
                 pane.setCenter(center);
             }
 


### PR DESCRIPTION
以前：
<img width="1058" height="633" alt="image" src="https://github.com/user-attachments/assets/e67dcad6-3641-49e4-9222-a7bb548ab851" />
之后：
<img width="1021" height="633" alt="image" src="https://github.com/user-attachments/assets/01b7ed47-fe24-4399-a591-3802688b1bd8" />
