### PR TITLE
Forge Quilt 模组管理支持识别子文件夹

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModManager.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModManager.java
@@ -26,7 +26,6 @@ import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.io.CompressingUtils;
 import org.jackhuang.hmcl.util.io.FileUtils;
 import org.jackhuang.hmcl.util.tree.ZipFileTree;
-import org.jackhuang.hmcl.util.versioning.VersionNumber;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.io.IOException;
@@ -177,11 +176,13 @@ public final class ModManager {
 
         analyzer = LibraryAnalyzer.analyze(getRepository().getResolvedPreservingPatchesVersion(id), null);
 
+        boolean supportSubfolders = analyzer.has(LibraryAnalyzer.LibraryType.FORGE)
+                || analyzer.has(LibraryAnalyzer.LibraryType.QUILT);
+
         if (Files.isDirectory(getModsDirectory())) {
             try (DirectoryStream<Path> modsDirectoryStream = Files.newDirectoryStream(getModsDirectory())) {
                 for (Path subitem : modsDirectoryStream) {
-                    if (Files.isDirectory(subitem) && VersionNumber.isIntVersionNumber(FileUtils.getName(subitem))) {
-                        // If the folder name is game version, forge will search mod in this subdirectory
+                    if (supportSubfolders && Files.isDirectory(subitem)) {
                         try (DirectoryStream<Path> subitemDirectoryStream = Files.newDirectoryStream(subitem)) {
                             for (Path subsubitem : subitemDirectoryStream) {
                                 addModInfo(subsubitem);


### PR DESCRIPTION
Close #2178 #5164

经过实测，仅 Forge Quilt 支持识别子文件夹（Neoforge 和 Fabric 不支持）。原有代码额外判断 Forge 下是否为版本号才识别，但实测文件夹可为任意名称（同样见 #5164 截图）

另外，实际支持**多次嵌套**模组识别加载，目前 PR 只会识别一层，我打算把它作为特性保留