### PR TITLE
修复 CurseForge 源无法搜索到内容的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseForgeRemoteModRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseForgeRemoteModRepository.java
@@ -35,14 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.Semaphore;
 import java.util.stream.Stream;
 
@@ -125,16 +118,20 @@ public final class CurseForgeRemoteModRepository implements RemoteModRepository 
             if (category != null && category.getSelf() instanceof CurseAddon.Category) {
                 categoryId = ((CurseAddon.Category) category.getSelf()).getId();
             }
-            Response<List<CurseAddon>> response = withApiKey(HttpRequest.GET(downloadProvider.injectURL(NetworkUtils.withQuery(PREFIX + "/v1/mods/search", mapOf(
-                    pair("gameId", "432"),
-                    pair("classId", Integer.toString(section)),
-                    pair("categoryId", Integer.toString(categoryId)),
-                    pair("gameVersion", gameVersion),
-                    pair("searchFilter", searchFilter),
-                    pair("sortField", Integer.toString(toModsSearchSortField(sortType))),
-                    pair("sortOrder", toSortOrder(sortOrder)),
-                    pair("index", Integer.toString(pageOffset * pageSize)),
-                    pair("pageSize", Integer.toString(pageSize)))))))
+
+            var query = new LinkedHashMap<String, String>();
+            query.put("gameId", "432");
+            query.put("classId", Integer.toString(section));
+            if (categoryId != 0)
+                query.put("categoryId", Integer.toString(categoryId));
+            query.put("gameVersion", gameVersion);
+            query.put("searchFilter", searchFilter);
+            query.put("sortField", Integer.toString(toModsSearchSortField(sortType)));
+            query.put("sortOrder", toSortOrder(sortOrder));
+            query.put("index", Integer.toString(pageOffset * pageSize));
+            query.put("pageSize", Integer.toString(pageSize));
+
+            Response<List<CurseAddon>> response = withApiKey(HttpRequest.GET(downloadProvider.injectURL(NetworkUtils.withQuery(PREFIX + "/v1/mods/search", query))))
                     .getJson(Response.typeOf(listTypeOf(CurseAddon.class)));
             if (searchFilter.isEmpty()) {
                 return new SearchResult(response.getData().stream().map(CurseAddon::toMod), calculateTotalPages(response, pageSize));


### PR DESCRIPTION
CurseForge 做了一次破坏性更改，在 query 中包含 `categoryId=0` 的时候无法搜索到内容。