### PR TITLE
[release/3.9] Fix #5121 : NeoForge alpha 版本未正确归类的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/neoforge/NeoForgeRemoteVersion.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/neoforge/NeoForgeRemoteVersion.java
@@ -19,7 +19,7 @@ public class NeoForgeRemoteVersion extends RemoteVersion {
     }
 
     private static Type getType(String version) {
-        return version.contains("beta") ? Type.SNAPSHOT : Type.RELEASE;
+        return version.contains("beta") || version.contains("alpha") ? Type.SNAPSHOT : Type.RELEASE;
     }
 
     public static String normalize(String version) {


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/pull/5125