### PR TITLE
修复主页公告阴影被裁切的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/MainPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/MainPage.java
@@ -154,11 +154,13 @@ public final class MainPage extends StackPane implements DecoratorPage {
             announcementCard.getStyleClass().addAll("card", "announcement");
 
             VBox announcementBox = new VBox(16);
+            announcementBox.setPadding(new Insets(15));
             announcementBox.getChildren().add(announcementCard);
 
             announcementPane = new TransitionPane();
             announcementPane.setContent(announcementBox, ContainerAnimations.NONE);
 
+            StackPane.setMargin(announcementPane, new Insets(-15));
             getChildren().add(announcementPane);
         }
 


### PR DESCRIPTION
<img width="128" height="159" alt="image" src="https://github.com/user-attachments/assets/d6e8de51-ef02-4805-87ce-ec4bc00e3c93" />
<img width="169" height="132" alt="image" src="https://github.com/user-attachments/assets/50d0b4b0-317c-4120-a5a9-d91271673636" />
