### PR TITLE
修复自动安装界面，卡片上按钮无法点击

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
@@ -300,11 +300,15 @@ public class InstallerItem extends Control {
             }
             pane.getStyleClass().add("installer-item");
             RipplerContainer container = new RipplerContainer(pane);
-            container.setPosition(JFXRippler.RipplerPos.FRONT);
-            getChildren().setAll(container);
+            container.setPosition(JFXRippler.RipplerPos.BACK);
+            StackPane paneWrapper = new StackPane();
+            paneWrapper.getStyleClass().add("installer-item-wrapper");
+            paneWrapper.getChildren().setAll(container);
+            getChildren().setAll(paneWrapper);
 
             pane.pseudoClassStateChanged(LIST_ITEM, control.style == Style.LIST_ITEM);
             pane.pseudoClassStateChanged(CARD, control.style == Style.CARD);
+            paneWrapper.pseudoClassStateChanged(CARD, control.style == Style.CARD);
 
             if (control.iconType != null) {
                 ImageView view = new ImageView(control.iconType.getIcon());

--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -388,31 +388,33 @@
     -fx-cursor: hand;
 }
 
-.installer-item {
-    -fx-padding: 8px;
+.installer-item-wrapper {
+    -fx-background-color: -monet-surface;
+    -fx-background-radius: 4;
+    -fx-pref-width: 180px;
 }
 
-.installer-item:list-item {
+.installer-item-wrapper:card {
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.26), 10, 0.12, -1, 2);
+}
+
+.installer-item-wrapper .installer-item:list-item {
+    -fx-padding: 8px;
     -fx-border-color: -monet-outline-variant;
     -fx-border-width: 0 0 1 0;
     -fx-alignment: center-left;
 }
 
-.installer-item:list-item > .installer-item-name {
+.installer-item-wrapper .installer-item:list-item > .installer-item-name {
     -fx-pref-width: 80px;
 }
 
-.installer-item:list-item > .installer-item-status {
+.installer-item-wrapper .installer-item:list-item > .installer-item-status {
     -fx-max-width: infinity;
 }
 
-.installer-item:card {
-    -fx-background-color: -monet-surface;
-    -fx-background-radius: 4;
+.installer-item-wrapper .installer-item:card {
     -fx-alignment: center;
-    -fx-pref-width: 180px;
-
-    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.26), 10, 0.12, -1, 2);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
<img width="213" height="160" alt="image" src="https://github.com/user-attachments/assets/9b641b29-a983-4f35-a3a1-023b000943d2" />

修复这里的小按钮无法点击的bug，修复：https://github.com/HMCL-dev/HMCL/issues/5248

---

如果用了RipplerContainer，直接 setPosition 到 FRONT，由于 https://github.com/HMCL-dev/HMCL/commit/3e393982e09ce2b13539fc740af08c3d16b3688b 的对 RipplerContainer 改动，会直接挡住按钮，无法点击到按钮。
setPosition 到 BACK 的话，内部的节点似乎不能设置背景，如果设置背景就不会触发ripper动画。

---

https://github.com/user-attachments/assets/abd1e33e-79cb-402b-962a-4bdcb06be2a1

