### PR TITLE
fix:补充贡献开发文档

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -8,7 +8,7 @@
 
 ### Requirements
 
-To build the HMCL launcher, you need to install JDK 17 (or higher). You can download it here: [Download Liberica JDK](https://bell-sw.com/pages/downloads/#jdk-25-lts).
+To build the HMCL launcher, you need to install JDK 17 (or higher,install Full JDK). You can download it here: [Download Liberica JDK](https://bell-sw.com/pages/downloads/#jdk-25-lts).
 
 After installing the JDK, make sure the `JAVA_HOME` environment variable points to the required JDK directory.
 You can check the JDK version that `JAVA_HOME` points to like this:

--- a/docs/Contributing_zh.md
+++ b/docs/Contributing_zh.md
@@ -8,7 +8,7 @@
 
 ### 环境需求
 
-构建 HMCL 启动器需要安装 JDK 17 (或更高版本)。你可以从此处下载它: [Download Liberica JDK](https://bell-sw.com/pages/downloads/#jdk-25-lts)。
+构建 HMCL 启动器需要安装 JDK 17 (或更高版本)。你可以从此处下载它(注意安装Full JDK): [Download Liberica JDK](https://bell-sw.com/pages/downloads/#jdk-25-lts)。
 
 在安装 JDK 后，请确保 `JAVA_HOME` 环境变量指向符合需求的 JDK 目录。
 你可以这样查看 `JAVA_HOME` 指向的 JDK 版本:


### PR DESCRIPTION
下载JDK的时候下载Full JDK避免踩坑，Lite JDK、Standard JDK 在Windows中都启动不起来