### PR TITLE
默认添加preferIPv4参数

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
@@ -172,7 +172,7 @@ public class DefaultLauncher extends Launcher {
 
             Proxy.Type proxyType = options.getProxyType();
             if (proxyType == null) {
-                res.addDefault("-Djava.net.useSystemProxies", "true");
+                res.addDefault("-Djava.net.useSystemProxies=", "true");
             } else {
                 String proxyHost = options.getProxyHost();
                 int proxyPort = options.getProxyPort();


### PR DESCRIPTION
在网卡配置了ipv4的情况下，默认添加preferIPv4参数，应该可以修复部分forge局域网房间广播问题