### PR TITLE
重构 FutureCallback

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/LauncherHelper.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/LauncherHelper.java
@@ -328,7 +328,7 @@ public final class LauncherHelper {
                                             (result, handler) -> {
                                                 if (CommandBuilder.setExecutionPolicy()) {
                                                     LOG.info("Set the ExecutionPolicy for the scope 'CurrentUser' to 'RemoteSigned'");
-                                                    handler.accept();
+                                                    handler.resolve();
                                                 } else {
                                                     LOG.warning("Failed to set ExecutionPolicy");
                                                     handler.reject(i18n("launch.failed.execution_policy.failed_to_set"));

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/InputDialogPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/InputDialogPane.java
@@ -74,7 +74,7 @@ public class InputDialogPane extends JFXDialogLayout implements DialogAware {
 
             onResult.call(textField.getText(), new FutureCallback.ResultHandler() {
                 @Override
-                public void accept() {
+                public void resolve() {
                     acceptPane.hideSpinner();
                     future.complete(textField.getText());
                     fireEvent(new DialogCloseEvent());

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/PromptDialogPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/PromptDialogPane.java
@@ -119,7 +119,7 @@ public class PromptDialogPane extends DialogPane {
 
         builder.callback.call(builder.questions, new FutureCallback.ResultHandler() {
             @Override
-            public void accept() {
+            public void resolve() {
                 future.complete(builder.questions);
                 runInFX(() -> onSuccess());
             }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/DownloadPage.java
@@ -152,7 +152,7 @@ public class DownloadPage extends DecoratorAnimatedPage implements DecoratorPage
                     Controllers.showToast(i18n("install.success"));
                 }
             }), i18n("message.downloading"), TaskCancellationAction.NORMAL);
-            handler.accept();
+            handler.resolve();
         }, file.getFile().getFilename(), new Validator(i18n("install.new_game.malformed"), FileUtils::isNameValid));
 
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/ModpackSelectionPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/ModpackSelectionPage.java
@@ -133,7 +133,7 @@ public final class ModpackSelectionPage extends VBox implements WizardPage {
                         if (manifest == null) {
                             handler.reject(i18n("modpack.type.server.malformed"));
                         } else if (e == null) {
-                            handler.accept();
+                            handler.resolve();
                             controller.getSettings().put(MODPACK_SERVER_MANIFEST, manifest);
                             controller.onNext();
                         } else {
@@ -144,13 +144,13 @@ public final class ModpackSelectionPage extends VBox implements WizardPage {
                     // otherwise we still consider the file as modpack zip file
                     // since casually the url may not ends with ".zip"
                     Path modpack = Files.createTempFile("modpack", ".zip");
-                    handler.accept();
+                    handler.resolve();
 
                     Controllers.taskDialog(
                             new FileDownloadTask(url, modpack)
                                     .whenComplete(Schedulers.javafx(), e -> {
                                         if (e == null) {
-                                            handler.accept();
+                                            handler.resolve();
                                             controller.getSettings().put(MODPACK_FILE, modpack);
                                             controller.onNext();
                                         } else {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/terracotta/TerracottaControllerPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/terracotta/TerracottaControllerPage.java
@@ -252,12 +252,12 @@ public class TerracottaControllerPage extends StackPane {
                                 if (e != null) {
                                     handler.reject(i18n("terracotta.status.waiting.guest.prompt.invalid"));
                                 } else {
-                                    handler.accept();
+                                    handler.resolve();
                                     UI_STATE.set(s);
                                 }
                             }).setSignificance(Task.TaskSignificance.MINOR).start();
                         } else {
-                            handler.accept();
+                            handler.resolve();
                         }
                     });
                 });

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/SchematicsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/SchematicsPage.java
@@ -179,7 +179,7 @@ public final class SchematicsPage extends ListPageBase<SchematicsPage.Item> impl
 
                     try {
                         Files.createDirectories(targetDir);
-                        handler.accept();
+                        handler.resolve();
                         refresh();
                     } catch (IOException e) {
                         LOG.warning("Failed to create directory: " + targetDir, e);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/Versions.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/Versions.java
@@ -131,11 +131,11 @@ public final class Versions {
     public static CompletableFuture<String> renameVersion(Profile profile, String version) {
         return Controllers.prompt(i18n("version.manage.rename.message"), (newName, handler) -> {
             if (newName.equals(version)) {
-                handler.accept();
+                handler.resolve();
                 return;
             }
             if (profile.getRepository().renameVersion(version, newName)) {
-                handler.accept();
+                handler.resolve();
                 profile.getRepository().refreshVersionsAsync()
                         .thenRunAsync(Schedulers.javafx(), () -> {
                             if (profile.getRepository().hasVersion(newName)) {
@@ -166,7 +166,7 @@ public final class Versions {
                             .thenComposeAsync(profile.getRepository().refreshVersionsAsync())
                             .whenComplete(Schedulers.javafx(), (result, exception) -> {
                                 if (exception == null) {
-                                    handler.accept();
+                                    handler.resolve();
                                 } else {
                                     handler.reject(StringUtils.getStackTrace(exception));
                                     if (!profile.getRepository().versionIdConflicts(newVersionName)) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/WorldListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/WorldListPage.java
@@ -159,7 +159,7 @@ public final class WorldListPage extends ListPageBase<World> implements VersionP
                     Controllers.prompt(i18n("world.name.enter"), (name, handler) -> {
                         Task.runAsync(() -> world.install(savesDir, name))
                                 .whenComplete(Schedulers.javafx(), () -> {
-                                    handler.accept();
+                                    handler.resolve();
                                     refresh();
                                 }, e -> {
                                     if (e instanceof FileAlreadyExistsException)

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/WorldManageUIUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/WorldManageUIUtils.java
@@ -118,7 +118,7 @@ public final class WorldManageUIUtils {
                                     }
                             ).whenComplete(Schedulers.javafx(), (throwable) -> {
                                 if (throwable == null) {
-                                    handler.accept();
+                                    handler.resolve();
                                 } else {
                                     handler.reject(i18n("world.duplicate.failed"));
                                     LOG.warning("Failed to duplicate world " + world.getFile(), throwable);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/FutureCallback.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/FutureCallback.java
@@ -31,7 +31,7 @@ public interface FutureCallback<T> {
     interface ResultHandler {
 
         /// Accept the result.
-        void accept();
+        void resolve();
 
         /// Reject the result with given reason.
         void reject(String reason);


### PR DESCRIPTION
原本 `FutureCallback` 使用两个函数参数来接受/拒绝结果。但由于 `Consumer` 的方法名为 `accept`，所以需要通过 `reject.accept(...)` 这样的写法来拒绝结果，与 `resolve.run()` 也不对称，看起来很抽象，会给开发者在阅读代码时造成困难。

本 PR 引入了一个新的 `ResultHandler` 接口来处理结果，使用更加适合 `FutureCallback` 的方法名 `accept`/`reject` 来处理结果，使代码更容易阅读。