### PR TITLE
同时检查 JarPath 是否包含 `!`

### DIFF
--- a/HMCLBoot/src/main/java/org/jackhuang/hmcl/Main.java
+++ b/HMCLBoot/src/main/java/org/jackhuang/hmcl/Main.java
@@ -131,7 +131,7 @@ public final class Main {
             return null;
 
         CodeSource codeSource = protectionDomain.getCodeSource();
-        if (codeSource == null)
+        if (codeSource == null || codeSource.getLocation() == null)
             return null;
 
         try {


### PR DESCRIPTION
突然发现不光运行路径，Jar路径也不能包括 `!`，否则也会报错
```
Exception in thread "main" java.lang.NullPointerException
        at java.base/java.io.Reader.<init>(Reader.java:286)
        at java.base/java.io.InputStreamReader.<init>(InputStreamReader.java:119)
        at org.jackhuang.hmcl.util.SelfDependencyPatcher$DependencyDescriptor.readDependencies(SelfDependencyPatcher.java:108)
        at org.jackhuang.hmcl.util.SelfDependencyPatcher.<init>(SelfDependencyPatcher.java:76)
        at org.jackhuang.hmcl.util.SelfDependencyPatcher.patch(SelfDependencyPatcher.java:176)
        at org.jackhuang.hmcl.EntryPoint.checkJavaFX(EntryPoint.java:207)
        at org.jackhuang.hmcl.EntryPoint.main(EntryPoint.java:58)
        at org.jackhuang.hmcl.Main.main(Main.java:107)
```
之前运行路径的检查也需要保留，否则 JavaFX 可能会无法加载 css 样式