### PR TITLE
扫描子目录时忽略 `.connector` 文件夹

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModManager.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModManager.java
@@ -182,7 +182,7 @@ public final class ModManager {
         if (Files.isDirectory(getModsDirectory())) {
             try (DirectoryStream<Path> modsDirectoryStream = Files.newDirectoryStream(getModsDirectory())) {
                 for (Path subitem : modsDirectoryStream) {
-                    if (supportSubfolders && Files.isDirectory(subitem)) {
+                    if (supportSubfolders && Files.isDirectory(subitem) && !".connector".equalsIgnoreCase(subitem.getFileName().toString())) {
                         try (DirectoryStream<Path> subitemDirectoryStream = Files.newDirectoryStream(subitem)) {
                             for (Path subsubitem : subitemDirectoryStream) {
                                 addModInfo(subsubitem);


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/issues/5285
测试发现 kilt 没有类似的行为