### PR TITLE
Fix #5295 下载 > 光影，下载源为「CurseForge」时，无法展示内容，且 HMCL 内部崩溃

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/HMCLLocalizedDownloadListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/HMCLLocalizedDownloadListPage.java
@@ -59,7 +59,10 @@ public final class HMCLLocalizedDownloadListPage extends DownloadListPage {
         repository = new Repository(type, curseForge, modrinth);
 
         supportChinese.set(true);
-        downloadSources.get().setAll("mods.modrinth", "mods.curseforge");
+
+        if (modrinth != null) downloadSources.add("mods.modrinth");
+        if (curseForge != null) downloadSources.add("mods.curseforge");
+
         if (modrinth != null) {
             downloadSource.set("mods.modrinth");
         } else if (curseForge != null) {


### PR DESCRIPTION
本身这里就是没有 Curseforge 下载的，#5034 改炸了一些地方导致这里意外显示出来了