### PR TITLE
Fix #5293 账户列表 > 添加认证服务器，非 CJK 语言下输入地址后下一步的对话框，超级宽……

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AddAuthlibInjectorServerPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AddAuthlibInjectorServerPane.java
@@ -118,7 +118,6 @@ public final class AddAuthlibInjectorServerPane extends TransitionPane implement
                 lblServerWarning.setStyle("-fx-text-fill: red;");
                 GridPane.setColumnIndex(lblServerWarning, 0);
                 GridPane.setRowIndex(lblServerWarning, 2);
-                lblServerWarning.setWrapText(true);
                 lblServerWarning.managedProperty().bind(lblServerWarning.visibleProperty());
                 GridPane.setColumnSpan(lblServerWarning, 2);
 


### PR DESCRIPTION
<img width="1227" height="762" alt="image" src="https://github.com/user-attachments/assets/d0898096-302c-476a-a3ba-53668b9c7fa8" />
原因是因为 http 警告未显示却仍参与排版， CJK 语言下警告内容比较短所以不明显