### PR TITLE
修复下载页面模组简介只会显示一行的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
@@ -44,6 +44,9 @@ public class TwoLineListItem extends VBox {
     private final ObservableList<Label> tags = FXCollections.observableArrayList();
     private final StringProperty subtitle = new SimpleStringProperty(this, "subtitle");
 
+    private final Label lblSubtitle;
+    private final Label lblTitle;
+
     private final AggregatedObservableList<Node> firstLineChildren;
 
     public TwoLineListItem(String titleString, String subtitleString) {
@@ -59,7 +62,7 @@ public class TwoLineListItem extends VBox {
         HBox firstLine = new HBox();
         firstLine.getStyleClass().add("first-line");
 
-        Label lblTitle = new Label();
+        lblTitle = new Label();
         lblTitle.getStyleClass().add("title");
         lblTitle.textProperty().bind(title);
 
@@ -68,7 +71,7 @@ public class TwoLineListItem extends VBox {
         firstLineChildren.appendList(tags);
         Bindings.bindContent(firstLine.getChildren(), firstLineChildren.getAggregatedList());
 
-        Label lblSubtitle = new Label();
+        lblSubtitle = new Label();
         lblSubtitle.getStyleClass().add("subtitle");
         lblSubtitle.textProperty().bind(subtitle);
 
@@ -107,6 +110,14 @@ public class TwoLineListItem extends VBox {
 
     public void setSubtitle(String subtitle) {
         this.subtitle.set(subtitle);
+    }
+
+    public Label getSubtitleLabel() {
+        return lblSubtitle;
+    }
+
+    public Label getTitleLabel() {
+        return lblTitle;
     }
 
     public void addTag(String tag) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
@@ -230,6 +230,7 @@ public class DownloadPage extends Control implements DecoratorPage {
                 ModTranslations.Mod mod = getSkinnable().translations.getModByCurseForgeId(getSkinnable().addon.getSlug());
                 content.setTitle(mod != null && I18n.isUseChinese() ? mod.getDisplayName() : getSkinnable().addon.getTitle());
                 content.setSubtitle(getSkinnable().addon.getDescription());
+                content.getSubtitleLabel().setWrapText(true);
                 getSkinnable().addon.getCategories().stream()
                         .map(category -> getSkinnable().page.getLocalizedCategory(category))
                         .forEach(content::addTag);


### PR DESCRIPTION
<img width="1227" height="762" alt="image" src="https://github.com/user-attachments/assets/562a6b3f-ff77-4e27-b587-b7f878da562b" />