### PR TITLE
修复清理游戏资源 / 库操作在 FXThread 运行的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionPage.java
@@ -195,7 +195,7 @@ public class VersionPage extends DecoratorAnimatedPage implements DecoratorPage 
             FileUtils.deleteDirectoryQuietly(libraries);
         }).whenComplete(Schedulers.javafx(), (exception) -> {
             if (exception != null) {
-                Controllers.dialog(i18n("message.failed") + StringUtils.getStackTrace(exception), i18n("message.error"), MessageDialogPane.MessageType.ERROR);
+                Controllers.dialog(i18n("message.failed") + "\n" + StringUtils.getStackTrace(exception), i18n("message.error"), MessageDialogPane.MessageType.ERROR);
             }
         }).start();
     }


### PR DESCRIPTION
改为和删除实例一样的逻辑