### PR TITLE
取消 Windows 7 高版本的不兼容提示

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/NativePatcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/NativePatcher.java
@@ -197,10 +197,10 @@ public final class NativePatcher {
 
     public static SupportStatus checkSupportedStatus(GameVersionNumber gameVersion, Platform platform,
                                                      OSVersion systemVersion) {
-        if (!systemVersion.isAtLeast(OSVersion.WINDOWS_7) && gameVersion.isAtLeast("1.20.5", "24w14a"))
-            return SupportStatus.UNSUPPORTED;
-
         if (platform.equals(Platform.WINDOWS_X86_64)) {
+            if (!systemVersion.isAtLeast(OSVersion.WINDOWS_7) && gameVersion.isAtLeast("1.20.5", "24w14a"))
+                return SupportStatus.UNSUPPORTED;
+
             return SupportStatus.OFFICIAL_SUPPORTED;
         }
 


### PR DESCRIPTION
Windows 7 下官方启动器也是可以直接启动 26.1 的，并且没有警告

根据崩溃分析群那边的说法目前也没有遇到过 Windows 7 系统 + 高版本产生的兼容性问题