### PR TITLE
Fix #4934 返回页面时可能卡进空白页面

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/animation/TransitionPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/animation/TransitionPane.java
@@ -119,4 +119,3 @@ public class TransitionPane extends StackPane {
         }
     }
 }
-


### PR DESCRIPTION
在我和 Glavo 群的一位群友的设备上之前基本随便点击几下就会卡出空白页面，应用这个修复之后测了几分钟都没卡出来
<details>
<summary>Gemini 3 解释</summary>
这是一个非常典型的 JavaFX 动画与状态并发导致的 Race Condition（竞态条件）问题。

### 问题诊断

问题出现在 `TransitionPane.java` 中，特别是在快速连续导航的场景下（例如 A -> B -> A）。

1.  **初始状态**：当前显示页面 A (`currentNode` = A)。
2.  **动作 1（导航到 B）**：调用 `setContent(B)`。
    *   `currentNode` 更新为 B。
    *   `previousNode` 被捕获为 A。
    *   `Platform.runLater` 启动动画 A -> B。
3.  **动作 2（快速返回 A）**：在动画 A -> B 尚未结束时，用户立即点击返回或触发导航回 A。调用 `setContent(A)`。
    *   `currentNode` 更新为 A。
    *   `previousNode` 被捕获为 B。
    *   子节点列表被设置为 `[B, A]` (将 A 重新加回场景)。
4.  **Bug 触发**：动作 1 的动画（A -> B）结束。
    *   它的 `onFinished` 回调被触发。
    *   回调中执行 `getChildren().remove(previousNode)`，此时该闭包中的 `previousNode` 是 **A**。
    *   **关键点**：尽管此时 `currentNode` 已经是 A 了，但旧的动画回调强制移除了 A。
    *   结果：场景中只剩下 B（且 B 可能正在执行淡出动画或随后被动作 2 的回调移除），最终导致 `TransitionPane` 为空，屏幕白屏。

### 修复方案

在 `TransitionPane` 的动画结束回调 (`onFinished`) 中，在移除 `previousNode` 之前，必须检查它是否意外地变回了当前的 `currentNode`。如果它现在是当前应当显示的节点，就不应该将其移除。
</details>