### PR TITLE
fix(SystemUtils) : 移除 `redirectInput(ProcessBuilder.Redirect.DISCARD)`

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/SystemUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/SystemUtils.java
@@ -82,7 +82,6 @@ public final class SystemUtils {
 
     public static <T> T run(List<String> command, ExceptionalFunction<InputStream, T, ?> convert) throws Exception {
         Process process = new ProcessBuilder(command)
-                .redirectInput(ProcessBuilder.Redirect.DISCARD)
                 .redirectError(ProcessBuilder.Redirect.DISCARD)
                 .start();
         try {


### PR DESCRIPTION
在我的设备上，这行代码会导致每次启动都出现

```
java.io.IOException: java.lang.IllegalArgumentException: Redirect invalid for reading: WRITE
	at org.jackhuang.hmcl.java.JavaInfoUtils.fromExecutable(JavaInfoUtils.java:102)
	at org.jackhuang.hmcl.java.JavaManager.tryAddJavaExecutable(JavaManager.java:520)
	at org.jackhuang.hmcl.java.JavaManager.searchPotentialJavaExecutables(JavaManager.java:423)
	at org.jackhuang.hmcl.java.JavaManager.initialize(JavaManager.java:329)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: java.lang.IllegalArgumentException: Redirect invalid for reading: WRITE
	at java.base/java.lang.ProcessBuilder.redirectInput(ProcessBuilder.java:751)
	at org.jackhuang.hmcl.util.platform.SystemUtils.run(SystemUtils.java:85)
	at org.jackhuang.hmcl.util.platform.SystemUtils.run(SystemUtils.java:79)
	at org.jackhuang.hmcl.java.JavaInfoUtils.fromExecutable(JavaInfoUtils.java:76)
	... 4 more
```

原因是 `ProcessBuilder.Redirect.DISCARD` 仅适用于输出流，而 `redirectInput` 需要的是输入流

并且这里也没有重定向输入流的需求