### PR TITLE
fix(ServerModpackCompletionTask): 修复已禁用模组仍被下载的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackCompletionTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackCompletionTask.java
@@ -142,10 +142,14 @@ public class ServerModpackCompletionTask extends Task<Void> {
             }
 
             boolean download;
-            if (!files.containsKey(file.getPath()) ||
-                    modsDirectory.equals(actualPath.getParent())
-                            && Files.notExists(actualPath.resolveSibling(fileName + ModManager.DISABLED_EXTENSION))
-                            && Files.notExists(actualPath.resolveSibling(fileName + ModManager.OLD_EXTENSION))) {
+
+            boolean isModDisabled = modsDirectory.equals(actualPath.getParent()) &&
+                    (Files.exists(actualPath.resolveSibling(fileName + ModManager.DISABLED_EXTENSION)) ||
+                            Files.exists(actualPath.resolveSibling(fileName + ModManager.OLD_EXTENSION)));
+
+            if (isModDisabled) {
+                download = false;
+            } else if (!files.containsKey(file.getPath())) {
                 // If old modpack does not have this entry, download it
                 download = true;
             } else if (!Files.exists(actualPath)) {


### PR DESCRIPTION
## 问题
修复服务端自动更新整合包时，用户主动禁用的模组（`.disabled` / `.old`）会被错误地判定为"丢失"并重新下载的问题（#3955）。

## 根本原因
之前的逻辑在判断是否需要下载时，会优先检查目标文件是否存在（`!Files.exists(actualPath)`）。对于已禁用的模组，其原始文件名（如 `Mod.jar`）确实不存在（已被重命名为 `Mod.jar.disabled`），导致逻辑误判为文件丢失，从而触发下载。

此前的修复尝试（如处理运算符优先级）未能解决核心的逻辑顺序问题。

## 修复逻辑
重构了 `ServerModpackCompletionTask.java` 中的判断逻辑：
1. **优先检查禁用状态**：在检查文件是否存在之前，先判断该文件是否已被重命名为 `.disabled` 或 `.old`。
2. **逻辑短路**：如果发现对应的禁用文件存在，直接标记 `download = false`，跳过后续所有检查。
3. **保留原有逻辑**：仅在确认未被禁用的情况下，才继续执行标准的文件存在性检查和 hash 校验。

这一修改确保了用户禁用的模组不会在更新时“复活”。

Fixes #3955