### PR TITLE
修复标题栏按钮浮于弹窗上方的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorSkin.java
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/ >.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.jackhuang.hmcl.ui.decorator;
 


### PR DESCRIPTION
<img width="253" height="121" alt="image" src="https://github.com/user-attachments/assets/6a086ab4-f59d-44fd-a13f-1ffb3b57a4c2" />

<img width="349" height="166" alt="image" src="https://github.com/user-attachments/assets/4e2d56be-a4d0-42a2-bf97-45736396971b" />

#5122 指的是这个吗 CC @3gf8jv4dv 
