### PR TITLE
[release/3.10] 将世界管理界面“生成启动脚本”按钮折叠到二级菜单

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/WorldManagePage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/WorldManagePage.java
@@ -112,13 +112,11 @@ public final class WorldManagePage extends DecoratorAnimatedPage implements Deco
 
         if (world.getGameVersion() != null && world.getGameVersion().isAtLeast("1.20", "23w14a")) {
             toolbar.addNavigationDrawerItem(i18n("version.launch"), SVG.ROCKET_LAUNCH, this::launch, advancedListItem -> advancedListItem.setDisable(isReadOnly()));
-            toolbar.addNavigationDrawerItem(i18n("version.launch_script"), SVG.SCRIPT, this::generateLaunchScript, null);
         }
 
         if (ChunkBaseApp.isSupported(world)) {
             PopupMenu chunkBasePopupMenu = new PopupMenu();
             JFXPopup chunkBasePopup = new JFXPopup(chunkBasePopupMenu);
-
 
             chunkBasePopupMenu.getContent().addAll(
                     new IconedMenuItem(SVG.EXPLORE, i18n("world.chunkbase.seed_map"), () -> ChunkBaseApp.openSeedMap(world), chunkBasePopup),
@@ -143,6 +141,14 @@ public final class WorldManagePage extends DecoratorAnimatedPage implements Deco
         {
             PopupMenu managePopupMenu = new PopupMenu();
             JFXPopup managePopup = new JFXPopup(managePopupMenu);
+
+            if (world.getGameVersion() != null && world.getGameVersion().isAtLeast("1.20", "23w14a")) {
+                managePopupMenu.getContent().addAll(
+                        new IconedMenuItem(SVG.ROCKET_LAUNCH, i18n("version.launch"), this::launch, managePopup),
+                        new IconedMenuItem(SVG.SCRIPT, i18n("version.launch_script"), this::generateLaunchScript, managePopup),
+                        new MenuSeparator()
+                );
+            }
 
             managePopupMenu.getContent().addAll(
                     new IconedMenuItem(SVG.OUTPUT, i18n("world.export"), () -> WorldManageUIUtils.export(world, sessionLockChannel), managePopup),


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/pull/5198