### PR TITLE
[release/3.10] RemoteImageLoader 在图标尚未加载时应当将图像更新为占位符

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/RemoteImageLoader.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/RemoteImageLoader.java
@@ -66,6 +66,8 @@ public abstract class RemoteImageLoader {
             cache.remove(uri);
         }
 
+        writableValue.setValue(getPlaceholder());
+
         {
             List<WeakReference<WritableValue<Image>>> list = pendingRequests.get(uri);
             if (list != null) {


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/pull/5239