### PR TITLE
fix: 修复 Windows 平台下 `ModAdviser` 没有正常工作的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModAdviser.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModAdviser.java
@@ -19,6 +19,7 @@ package org.jackhuang.hmcl.mod;
 
 import org.jackhuang.hmcl.util.Lang;
 
+import java.nio.file.FileSystems;
 import java.util.List;
 
 /**
@@ -87,7 +88,7 @@ public interface ModAdviser {
     static boolean match(List<String> l, String fileName, boolean isDirectory) {
         for (String s : l)
             if (isDirectory) {
-                if (fileName.startsWith(s + "/"))
+                if (fileName.startsWith(s + "/") || fileName.startsWith(s + FileSystems.getDefault().getSeparator()))
                     return true;
             } else {
                 if (s.startsWith("regex:")) {


### PR DESCRIPTION
`match(List<String> l, String fileName, boolean isDirectory)` 方法调用处传进来的 `fileName` 都是使用的 `/` 分割而不是系统 `File.separator`，这就导致在 Windows 平台下这里的匹配总为 `false` 导致其他地方工作不正常（例如导出整合包时 `assets` 文件夹没有被正确隐藏）