### PR TITLE
[Enhancement] 切换标题栏透明不再更改背景图片布局

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorSkin.java
@@ -181,17 +181,12 @@ public class DecoratorSkin extends SkinBase<Decorator> {
 
         // Maybe, we can automatically identify whether the top part of the picture is light-coloured or dark when the title is transparent,
         // and decide whether the whole top bar should be rendered in white or black. TODO
+        wrapper.backgroundProperty().bind(skinnable.contentBackgroundProperty());
         FXUtils.onChangeAndOperate(skinnable.titleTransparentProperty(), titleTransparent -> {
             if (titleTransparent) {
-                wrapper.backgroundProperty().bind(skinnable.contentBackgroundProperty());
-                container.backgroundProperty().unbind();
-                container.setBackground(null);
                 titleContainer.getStyleClass().remove("background");
                 titleContainer.getStyleClass().add("gray-background");
             } else {
-                container.backgroundProperty().bind(skinnable.contentBackgroundProperty());
-                wrapper.backgroundProperty().unbind();
-                wrapper.setBackground(null);
                 titleContainer.getStyleClass().add("background");
                 titleContainer.getStyleClass().remove("gray-background");
             }


### PR DESCRIPTION
前：

https://github.com/user-attachments/assets/84d7c4b4-076f-4490-bb95-125e15d10fea

后：

https://github.com/user-attachments/assets/ecbc4c4d-50df-413b-a89b-142a0afbb4ed

