### PR TITLE
移除 `large-spinner-pane` 样式

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/ToolbarListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/ToolbarListPageSkin.java
@@ -46,7 +46,6 @@ public abstract class ToolbarListPageSkin<E, P extends ListPageBase<E>> extends 
         spinnerPane.loadingProperty().bind(skinnable.loadingProperty());
         spinnerPane.failedReasonProperty().bind(skinnable.failedReasonProperty());
         spinnerPane.onFailedActionProperty().bind(skinnable.onFailedActionProperty());
-        spinnerPane.getStyleClass().add("large-spinner-pane");
 
         ComponentList root = new ComponentList();
         root.getStyleClass().add("no-padding");

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/ModpackPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/ModpackPage.java
@@ -33,8 +33,6 @@ public abstract class ModpackPage extends SpinnerPane implements WizardPage {
     protected ModpackPage(WizardController controller) {
         this.controller = controller;
 
-        this.getStyleClass().add("large-spinner-pane");
-
         VBox borderPane = new VBox();
         borderPane.setAlignment(Pos.CENTER);
         FXUtils.setLimitWidth(borderPane, 500);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DatapackListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DatapackListPageSkin.java
@@ -183,7 +183,6 @@ final class DatapackListPageSkin extends SkinBase<DatapackListPage> {
         {
             SpinnerPane center = new SpinnerPane();
             ComponentList.setVgrow(center, Priority.ALWAYS);
-            center.getStyleClass().add("large-spinner-pane");
             center.loadingProperty().bind(skinnable.loadingProperty());
 
             listView.setCellFactory(x -> new DatapackInfoListCell(listView, getSkinnable().readOnly));

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
@@ -199,7 +199,6 @@ final class ModListPageSkin extends SkinBase<ModListPage> {
         {
             SpinnerPane center = new SpinnerPane();
             ComponentList.setVgrow(center, Priority.ALWAYS);
-            center.getStyleClass().add("large-spinner-pane");
             center.loadingProperty().bind(skinnable.loadingProperty());
 
             listView.setCellFactory(x -> new ModInfoListCell(listView));

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ResourcepackListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ResourcepackListPage.java
@@ -156,7 +156,6 @@ public final class ResourcepackListPage extends ListPageBase<ResourcepackListPag
 
             SpinnerPane center = new SpinnerPane();
             ComponentList.setVgrow(center, Priority.ALWAYS);
-            center.getStyleClass().add("large-spinner-pane");
             center.loadingProperty().bind(control.loadingProperty());
 
             listView.setCellFactory(x -> new ResourcepackListCell(listView, control));

--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -1403,14 +1403,6 @@
     -fx-stroke-width: 3.0;
 }
 
-.large-spinner-pane .jfx-spinner {
-    -jfx-radius: 20;
-}
-
-.large-spinner-pane .jfx-spinner {
-    -fx-stroke-width: 5.0;
-}
-
 .second-spinner {
     -jfx-radius: 30;
 }


### PR DESCRIPTION
![PixPin_2026-02-03_21-34-26](https://github.com/user-attachments/assets/f807b935-3d0a-4d40-83f4-55dd3c99e6e4)
![PixPin_2026-02-03_21-36-24](https://github.com/user-attachments/assets/8798024f-189c-4311-bd07-6f73188855b9)
正常大小的 Spinner 看着比大 Spinner 顺眼很多，并且 Material Design 里看起来也没有这种样式的 Spinner，且 HMCL 看起来就这几个地方在用 `large-spinner-pane`，其他地方（比如下载页面、世界备份管理页面）都是用的正常大小 Spinner