### PR TITLE
修复 1.5.2 等版本 LegacyFabric 无法安装的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/legacyfabric/LegacyFabricInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/legacyfabric/LegacyFabricInstallTask.java
@@ -21,7 +21,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.jackhuang.hmcl.download.DefaultDependencyManager;
 import org.jackhuang.hmcl.download.LibraryAnalyzer;
-import org.jackhuang.hmcl.download.UnsupportedInstallationException;
 import org.jackhuang.hmcl.download.fabric.FabricInstallTask;
 import org.jackhuang.hmcl.game.Arguments;
 import org.jackhuang.hmcl.game.Artifact;
@@ -31,9 +30,10 @@ import org.jackhuang.hmcl.task.GetTask;
 import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.util.gson.JsonUtils;
 
-import java.util.*;
-
-import static org.jackhuang.hmcl.download.UnsupportedInstallationException.FABRIC_NOT_COMPATIBLE_WITH_FORGE;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 public final class LegacyFabricInstallTask extends Task<Version> {
 
@@ -55,12 +55,6 @@ public final class LegacyFabricInstallTask extends Task<Version> {
     @Override
     public boolean doPreExecute() {
         return true;
-    }
-
-    @Override
-    public void preExecute() throws Exception {
-        if (!Objects.equals("net.minecraft.client.main.Main", version.resolve(dependencyManager.getGameRepository()).getMainClass()))
-            throw new UnsupportedInstallationException(FABRIC_NOT_COMPATIBLE_WITH_FORGE);
     }
 
     @Override


### PR DESCRIPTION
这个版本 LegacyFabric 也是使用的 LaunchWrapper，现在的实现会在安装的时候直接提示不兼容
<img width="1227" height="762" alt="image" src="https://github.com/user-attachments/assets/786b412e-40bb-49ae-afb2-fe4d7891813c" />
