### PR TITLE
优化日志窗口无日志行背景

### DIFF
--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -1348,6 +1348,10 @@
     -fx-background-color: -fixed-log-info;
 }
 
+.log-window-list-cell {
+    -fx-background-color: -fixed-log-info;
+}
+
 .log-window-list-cell:debug {
     -fx-text-fill: -fixed-log-text-fill;
     -fx-background-color: -fixed-log-debug;


### PR DESCRIPTION
<img width="1204" height="767" alt="image" src="https://github.com/user-attachments/assets/b279a559-57e4-4ae4-84e3-6d2936d261a0" />
<img width="1204" height="767" alt="image" src="https://github.com/user-attachments/assets/247ff37d-d348-4c43-8cbd-1c06e6e1495f" />
