### PR TITLE
fix: 修复安装游戏时选择版本后返回已选择的版本会被清除的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
@@ -60,7 +60,6 @@ import org.jackhuang.hmcl.ui.wizard.Navigation;
 import org.jackhuang.hmcl.ui.wizard.Refreshable;
 import org.jackhuang.hmcl.ui.wizard.WizardPage;
 import org.jackhuang.hmcl.util.NativePatcher;
-import org.jackhuang.hmcl.util.SettingsMap;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.i18n.I18n;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
@@ -129,11 +128,6 @@ public final class VersionsPage extends Control implements WizardPage, Refreshab
     @Override
     public String getTitle() {
         return title;
-    }
-
-    @Override
-    public void cleanup(SettingsMap settings) {
-        settings.remove(libraryId);
     }
 
     private void onRefresh() {


### PR DESCRIPTION
复现：打开版本安装页面 -> 选择一个 Forge 版本 -> 再次打开 Forge 选择页面，点击左上角返回 -> 已选择的 Forge 版本被清除