### PR TITLE
修复日志级别选择地下长一截的问题

### DIFF
--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -1268,6 +1268,7 @@
 
 .log-toggle {
     -fx-border: 1px;
+    -fx-background-insets: 0;
     -fx-border-color: -fixed-log-toggle-unselected;
     -fx-text-fill: -fixed-log-toggle-unselected;
 }


### PR DESCRIPTION
<img width="543" height="77" alt="image" src="https://github.com/user-attachments/assets/4213dacd-9e7e-412f-954c-3b5b4e63f571" />
<img width="567" height="99" alt="image" src="https://github.com/user-attachments/assets/cc2391c0-81ea-44d1-ac54-446305b566be" />
