### PR TITLE
[Bugfix] Fix #5421: 修复部分滚动页面滚动时圆角消失的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
@@ -281,6 +281,7 @@ public class DownloadPage extends Control implements DecoratorPage {
                 FXUtils.smoothScrolling(scrollPane);
                 scrollPane.setFitToWidth(true);
                 scrollPane.setFitToHeight(true);
+                FXUtils.setOverflowHidden(scrollPane, 8);
                 StackPane.setAlignment(scrollPane, Pos.TOP_CENTER);
                 spinnerPane.setContent(scrollPane);
 


### PR DESCRIPTION
Fixes #5421

修改：
- 下载模组详情界面依赖列表
- 下载模组版本列表（阴影也一块被裁了，反正早晚要下掉）