### PR TITLE
fix: 修复安装卡片部分区域点击无法触发水波纹效果的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
@@ -343,6 +343,7 @@ public class InstallerItem extends Control {
             BorderPane.setAlignment(statusLabel, Pos.CENTER_LEFT);
 
             HBox buttonsContainer = new HBox();
+            buttonsContainer.setPickOnBounds(false);
             buttonsContainer.setSpacing(8);
             buttonsContainer.setAlignment(Pos.CENTER);
             pane.getChildren().add(buttonsContainer);


### PR DESCRIPTION
<img width="1227" height="762" alt="image" src="https://github.com/user-attachments/assets/ae8575cd-9f76-4242-bbab-3a2c18d059e1" />
红色区域点击无法触发水波纹