### PR TITLE
fix: 修复新建账号界面从微软账号切换到其他方式后下面按钮排版奇怪的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/CreateAccountPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/CreateAccountPane.java
@@ -275,7 +275,7 @@ public class CreateAccountPane extends JFXDialogLayout implements DialogAware {
             lblErrorMessage.setText("");
             lblErrorMessage.setVisible(true);
             actions.setVisible(true);
-            actions.setVisible(true);
+            actions.setManaged(true);
         }
 
         if (factory == Accounts.FACTORY_MICROSOFT) {


### PR DESCRIPTION
<img width="1227" height="762" alt="image" src="https://github.com/user-attachments/assets/28acefd4-fa91-4571-af97-c8120972f8ee" />
