### PR TITLE
fix: 打开微软对话框有一个加载圈一闪而过

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/MicrosoftAccountLoginPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/MicrosoftAccountLoginPane.java
@@ -141,7 +141,7 @@ public class MicrosoftAccountLoginPane extends JFXDialogLayout implements Dialog
             hintPane.setText(i18n("account.methods.microsoft.hint"));
             rootContainer.getChildren().add(hintPane);
         } else if (currentStep instanceof Step.StartAuthorizationCodeLogin) {
-            loginButtonSpinner.setLoading(true);
+            loginButtonSpinner.setLoading(false);
             cancelAllTasks();
 
             rootContainer.getChildren().add(new JFXSpinner());


### PR DESCRIPTION
微软登录对话框默认是授权代码流，授权代码流生成 URL 不需要请求微软服务器，是本地生成的，所以打开对话框后加载圈闪一下就没了