### PR TITLE
修复自动更新时未继承窗口位置尺寸的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateHandler.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateHandler.java
@@ -125,6 +125,7 @@ public final class UpdateHandler {
                         }
 
                         requestUpdate(downloaded, getCurrentLocation());
+                        Controllers.onApplicationStop();
                         EntryPoint.exit(0);
                     } catch (IOException e) {
                         LOG.warning("Failed to update to " + version, e);


### PR DESCRIPTION
目前 移动启动器窗口后更新启动器，窗口位置会被还原