### PR TITLE
fix: JFXRippler 可能无法覆盖整个控件

### DIFF
--- a/HMCL/src/main/java/com/jfoenix/controls/JFXRippler.java
+++ b/HMCL/src/main/java/com/jfoenix/controls/JFXRippler.java
@@ -519,7 +519,7 @@ public class JFXRippler extends StackPane {
                         new KeyValue(opacityProperty(),
                                 1,
                                 RIPPLE_INTERPOLATOR)
-                ), new KeyFrame(Duration.millis(900), inKeyValues));
+                ), new KeyFrame(Duration.millis(600), inKeyValues));
 
                 setScaleX(0);
                 setScaleY(0);


### PR DESCRIPTION
例：版本下载页面
<img width="1227" height="762" alt="image" src="https://github.com/user-attachments/assets/616215b0-68cb-4f90-90f3-cef412cf2522" />
