### PR TITLE
chore: update copyright year and attribution

### DIFF
--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -1,6 +1,6 @@
 #
 # Hello Minecraft! Launcher
-# Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
+# Copyright (C) 2026 huangyuhui <huanghongxun2008@126.com> and contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,7 +21,7 @@
 
 about=About
 about.copyright=Copyright
-about.copyright.statement=Copyright © 2026 huangyuhui
+about.copyright.statement=Copyright © 2013-2026 huangyuhui and contributors.
 about.author=Author
 about.author.statement=bilibili @huanghongxun
 about.claim=EULA

--- a/HMCL/src/main/resources/assets/lang/I18N_ar.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_ar.properties
@@ -1,6 +1,6 @@
 #
 # Hello Minecraft! Launcher
-# Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
+# Copyright (C) 2026 huangyuhui <huanghongxun2008@126.com> and contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,7 +21,6 @@
 
 about=حول
 about.copyright=حقوق الطبع والنشر
-about.copyright.statement=حقوق النشر © 2026 huangyuhui
 about.author=المطور
 about.author.statement=bilibili @huanghongxun
 about.claim=اتفاقية الترخيص

--- a/HMCL/src/main/resources/assets/lang/I18N_es.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_es.properties
@@ -1,6 +1,6 @@
 #
 # Hello Minecraft! Launcher
-# Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
+# Copyright (C) 2026 huangyuhui <huanghongxun2008@126.com> and contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,7 +21,6 @@
 
 about=Acerca de
 about.copyright=Copyright
-about.copyright.statement=Copyright © 2026 huangyuhui.
 about.author=Autor
 about.author.statement=bilibili @huanghongxun
 about.claim=EULA

--- a/HMCL/src/main/resources/assets/lang/I18N_ja.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_ja.properties
@@ -1,6 +1,6 @@
 #
 # Hello Minecraft! Launcher
-# Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
+# Copyright (C) 2026 huangyuhui <huanghongxun2008@126.com> and contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,7 +20,6 @@
 
 about=について
 about.copyright=著作権
-about.copyright.statement=Copyright © 2026 huangyuhui
 about.author=著者
 about.author.statement=bilibili @huanghongxun
 about.claim=EULA

--- a/HMCL/src/main/resources/assets/lang/I18N_lzh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_lzh.properties
@@ -1,6 +1,6 @@
 #
 # Hello Minecraft! Launcher
-# Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
+# Copyright (C) 2026 huangyuhui <huanghongxun2008@126.com> and contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,7 +20,6 @@
 
 about=有涉
 about.copyright=持權
-about.copyright.statement=© 2026 huangyuhui 持權
 about.author=作者
 about.author.statement=嗶站 @huanghongxun
 about.claim=客契

--- a/HMCL/src/main/resources/assets/lang/I18N_ru.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_ru.properties
@@ -1,6 +1,6 @@
 #
 # Hello Minecraft! Launcher
-# Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
+# Copyright (C) 2026 huangyuhui <huanghongxun2008@126.com> and contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,7 +20,6 @@
 
 about=О лаунчере
 about.copyright=Авторские права
-about.copyright.statement=Авторские права © 2026 huangyuhui.
 about.author=Автор
 about.author.statement=bilibili @huanghongxun
 about.claim=EULA

--- a/HMCL/src/main/resources/assets/lang/I18N_uk.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_uk.properties
@@ -1,6 +1,6 @@
 #
 # Hello Minecraft! Launcher
-# Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
+# Copyright (C) 2026 huangyuhui <huanghongxun2008@126.com> and contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,7 +20,6 @@
 
 about=Про програму
 about.copyright=Авторське право
-about.copyright.statement=Авторське право © 2026 huangyuhui
 about.author=Автор
 about.author.statement=bilibili @huanghongxun
 about.claim=Ліцензійна угода з кінцевим користувачем (EULA)

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -1,6 +1,6 @@
 #
 # Hello Minecraft! Launcher
-# Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
+# Copyright (C) 2026 huangyuhui <huanghongxun2008@126.com> and contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,7 +20,7 @@
 
 about=關於
 about.copyright=著作權
-about.copyright.statement=著作權所有 © 2026 huangyuhui
+about.copyright.statement=著作權所有 © 2013-2026 huangyuhui 與貢獻者
 about.author=作者
 about.author.statement=bilibili @huanghongxun
 about.claim=使用者協議

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -1,6 +1,6 @@
 #
 # Hello Minecraft! Launcher
-# Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
+# Copyright (C) 2026 huangyuhui <huanghongxun2008@126.com> and contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,7 +20,7 @@
 
 about=关于
 about.copyright=版权
-about.copyright.statement=版权所有 © 2026 huangyuhui
+about.copyright.statement=版权所有 © 2013-2026 huangyuhui 及贡献者
 about.author=作者
 about.author.statement=bilibili @huanghongxun
 about.claim=用户协议


### PR DESCRIPTION
- bump copyright year from 2025 to 2026
- update about page range to 2013-2026
- "huangyuhui" > "huangyuhui and contributors" on about page

| Before | After |
|--------|--------|
| <img width="818" height="508" alt="image-1" src="https://github.com/user-attachments/assets/ac2eb9a1-3ab8-4e67-9bf8-520729ebcf76" /> |   <img width="818" height="508" alt="image-2" src="https://github.com/user-attachments/assets/a288e7f1-eebd-43a6-ab74-5d8f36de27e7" /> | 