### PR TITLE
feat: 更新时继承所有 JVM 参数

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateHandler.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateHandler.java
@@ -185,7 +185,7 @@ public final class UpdateHandler {
                     commandline.add(inputArgument);
                 }
             }
-        } catch (Exception ignored) {
+        } catch (Throwable ignored) {
             // ManagementFactory not available
             for (Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {
                 if (entry.getKey() instanceof String key && key.startsWith("hmcl.")) {


### PR DESCRIPTION
#5612 #5049
目前只会继承 `hmcl.` 开头的系统属性，导致 `-Dglass.gtk.uiScale` `-Dprism.forceGPU=true` `-XX:+UseZGC` `-Xmx2G` 等都不会继承