### PR TITLE
fix: `message.question` 未本地化

### DIFF
--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -691,7 +691,7 @@ message.info=提示
 message.success=完成
 message.unknown=未知
 message.warning=警告
-message.question=提示
+message.question=確認
 
 modpack=模組包
 modpack.choose=選取要安裝的遊戲模組包檔案

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -696,7 +696,7 @@ message.info=提示
 message.success=完成
 message.unknown=未知
 message.warning=警告
-message.question=提示
+message.question=确认
 
 modpack=整合包
 modpack.choose=选择要安装的游戏整合包文件


### PR DESCRIPTION
<img width="1227" height="762" alt="image" src="https://github.com/user-attachments/assets/6a2dc416-8335-410f-aeb1-6982b43b2c82" />
这里译为 提示 是因为在之前版本中这里文案就是 提示
<img width="1227" height="762" alt="image" src="https://github.com/user-attachments/assets/be15be8a-2fc4-4c23-8baf-b8c33f3f4605" />
