### PR TITLE
[release/3.11] fix: 安装整合包时任务弹窗可能空白

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/ModpackSelectionPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/ModpackSelectionPage.java
@@ -139,7 +139,7 @@ public final class ModpackSelectionPage extends VBox implements WizardPage {
                         } else {
                             handler.reject(e.getMessage());
                         }
-                    }).executor(true), i18n("message.downloading"), TaskCancellationAction.NORMAL);
+                    }), i18n("message.downloading"), TaskCancellationAction.NORMAL);
                 } else {
                     // otherwise we still consider the file as modpack zip file
                     // since casually the url may not ends with ".zip"
@@ -156,7 +156,7 @@ public final class ModpackSelectionPage extends VBox implements WizardPage {
                                         } else {
                                             handler.reject(e.getMessage());
                                         }
-                                    }).executor(true),
+                                    }),
                             i18n("message.downloading"),
                             TaskCancellationAction.NORMAL
                     );

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/Versions.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/Versions.java
@@ -103,7 +103,7 @@ public final class Versions {
                                         i18n("install.failed.downloading.detail", file.getFile().getUrl()) + "\n" + StringUtils.getStackTrace(e),
                                         i18n("download.failed.no_code"), MessageDialogPane.MessageType.ERROR);
                             }
-                        }).executor(true),
+                        }),
                 i18n("message.downloading"),
                 TaskCancellationAction.NORMAL
         );


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/pull/5550