### PR TITLE
[release/3.11] 修复微软登录报错的超链接显示

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/MicrosoftAccountLoginPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/MicrosoftAccountLoginPane.java
@@ -205,7 +205,7 @@ public class MicrosoftAccountLoginPane extends JFXDialogLayout implements Dialog
             cancelAllTasks();
 
             HintPane errHintPane = new HintPane(MessageDialogPane.MessageType.ERROR);
-            errHintPane.setText(failed.message());
+            errHintPane.setSegment(failed.message());
             rootContainer.getChildren().add(errHintPane);
         }
 


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/pull/5549