### PR TITLE
fix: 游戏进程是 Java 11 以下时无法导出游戏运行栈

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/game/GameDumpGenerator.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/game/GameDumpGenerator.java
@@ -129,7 +129,14 @@ public final class GameDumpGenerator {
     }
 
     private static void writeDumpBodyTo(VirtualMachine vm, Writer writer) throws IOException {
-        int vmVersion = JavaInfo.parseVersion(vm.getSystemProperties().get("java.version").toString());
+        int vmVersion = -1;
+
+        try {
+            if (vm.getSystemProperties().get("java.version") instanceof String javaVersion)
+                vmVersion = JavaInfo.parseVersion(javaVersion);
+        } catch (Throwable e) {
+            LOG.warning("Failed to get VM system properties", e);
+        }
 
         if (vmVersion >= 11)
             execute(vm, "Thread.print -e -l", writer);


### PR DESCRIPTION
`-e` 参数于 Java 11 加入，启动器附加 `-e -l` 参数导致 Java 11 以下导出运行栈时报错。