### PR TITLE
调整导出游戏运行栈加载指示器大小

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/LogWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/LogWindow.java
@@ -411,6 +411,7 @@ public final class LogWindow extends Stage {
                 terminateButton.setOnAction(e -> getSkinnable().onTerminateGame());
 
                 SpinnerPane exportDumpPane = new SpinnerPane();
+                exportDumpPane.getStyleClass().add("small-spinner-pane");
                 JFXButton exportDumpButton = new JFXButton(i18n("logwindow.export_dump"));
                 if (SystemUtils.supportJVMAttachment()) {
                     exportDumpButton.setOnAction(e -> getSkinnable().onExportDump(exportDumpPane));


### PR DESCRIPTION
之前的大小边缘会被裁切
<img width="877" height="130" alt="image" src="https://github.com/user-attachments/assets/e077d495-2ba0-408e-9688-625875d1b9a7" />