### PR TITLE
[-] Remove username=email requirement for custom authlib servers

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/CreateAccountPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/CreateAccountPane.java
@@ -416,15 +416,7 @@ public class CreateAccountPane extends JFXDialogLayout implements DialogAware {
                 add(lblUsername, 0, rowIndex);
 
                 txtUsername = new JFXTextField();
-                txtUsername.setValidators(
-                        new RequiredValidator(),
-                        new Validator(i18n("input.email"), username -> {
-                            if (requiresEmailAsUsername()) {
-                                return username.contains("@");
-                            } else {
-                                return true;
-                            }
-                        }));
+                txtUsername.setValidators(new RequiredValidator());
                 setValidateWhileTextChanged(txtUsername, true);
                 txtUsername.setOnAction(e -> onAction.run());
                 add(txtUsername, 1, rowIndex);
@@ -518,16 +510,6 @@ public class CreateAccountPane extends JFXDialogLayout implements DialogAware {
                     return true;
                 }
             };
-        }
-
-        private boolean requiresEmailAsUsername() {
-            if ((factory instanceof AuthlibInjectorAccountFactory) && this.server != null) {
-                return !server.isNonEmailLogin();
-            }
-            if (factory instanceof BoundAuthlibInjectorAccountFactory bound) {
-                return !bound.getServer().isNonEmailLogin();
-            }
-            return false;
         }
 
         public Object getAdditionalData() {


### PR DESCRIPTION
Third party authlib servers might not require that usernames must be emails. 

Due to this check, I was unable to log in to my own authlib server.

**BEFORE**

<img width="1474" height="1368" alt="image" src="https://github.com/user-attachments/assets/af1736f6-1bdc-461b-a7ec-ee9241f0150c" />

**AFTER**

<img width="1853" height="1373" alt="image" src="https://github.com/user-attachments/assets/1c9ef0d9-49cd-477a-b781-f59add70d8f2" />