### PR TITLE
fix: 无法导入部分 Modrinth 整合包

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthManifest.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthManifest.java
@@ -34,8 +34,7 @@ public class ModrinthManifest implements ModpackManifest, Validation {
     private final int formatVersion;
     private final String versionId;
     private final String name;
-    @Nullable
-    private final String summary;
+    private final @Nullable String summary;
     private final List<File> files;
     private final Map<String, String> dependencies;
 


### PR DESCRIPTION
<img width="1111" height="194" alt="558e4400cecf112a5ca4edd6aecc9064" src="https://github.com/user-attachments/assets/ddf4ec8e-ba96-444e-a233-fb31fcc66cea" />


https://support.modrinth.com/en/articles/8802351-modrinth-modpack-format-mrpack


`env` 是一个可选字段，部分启动器导出时不会携带，且 `getEnv`  的调用处做了判空，但 `equals` 方法没有做判空。

HMCL 自身导出的整合包始终存在 `env` 字段，但其他启动器例如 PCL2 导出可能不存在 `env` 字段