### PR TITLE
[codex] 安装新实例时支持选择是否开启版本隔离

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
@@ -23,10 +23,13 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Node;
 import javafx.scene.control.*;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
 import org.jackhuang.hmcl.download.DownloadProvider;
 import org.jackhuang.hmcl.download.LibraryAnalyzer;
 import org.jackhuang.hmcl.ui.Controllers;
@@ -97,6 +100,10 @@ public abstract class AbstractInstallersPage extends Control implements WizardPa
 
     protected abstract void reload();
 
+    protected Node createBottomPaneLeadingNode() {
+        return null;
+    }
+
     @Override
     public void onNavigate(SettingsMap settings) {
         reload();
@@ -155,8 +162,20 @@ public abstract class AbstractInstallersPage extends Control implements WizardPa
                 installButton.setPrefWidth(100);
                 installButton.setPrefHeight(40);
                 installButton.setOnAction(e -> control.onInstall());
-                BorderPane.setAlignment(installButton, Pos.CENTER_RIGHT);
-                root.setBottom(installButton);
+
+                HBox bottomPane = new HBox(8);
+                bottomPane.setAlignment(Pos.CENTER_LEFT);
+
+                Node leadingNode = control.createBottomPaneLeadingNode();
+                if (leadingNode != null) {
+                    bottomPane.getChildren().add(leadingNode);
+                }
+
+                Region spacer = new Region();
+                HBox.setHgrow(spacer, Priority.ALWAYS);
+                bottomPane.getChildren().add(spacer);
+                bottomPane.getChildren().add(installButton);
+                root.setBottom(bottomPane);
             }
 
             getChildren().setAll(root);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java
@@ -17,9 +17,12 @@
  */
 package org.jackhuang.hmcl.ui.download;
 
+import com.jfoenix.controls.JFXCheckBox;
+import javafx.scene.Node;
 import org.jackhuang.hmcl.download.DownloadProvider;
 import org.jackhuang.hmcl.download.LibraryAnalyzer;
 import org.jackhuang.hmcl.download.RemoteVersion;
+import org.jackhuang.hmcl.game.GameDirectoryType;
 import org.jackhuang.hmcl.game.HMCLGameRepository;
 import org.jackhuang.hmcl.ui.Controllers;
 import org.jackhuang.hmcl.ui.InstallerItem;
@@ -34,8 +37,10 @@ import static javafx.beans.binding.Bindings.createBooleanBinding;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
 public class InstallersPage extends AbstractInstallersPage {
+    public static final String ENABLE_VERSION_ISOLATION = "enableVersionIsolation";
 
     private boolean isNameModifiedByUser = false;
+    private final JFXCheckBox chkEnableVersionIsolation = new JFXCheckBox(i18n("install.new_game.version_isolation"));
 
     public InstallersPage(WizardController controller, HMCLGameRepository repository, String gameVersion, DownloadProvider downloadProvider) {
         super(controller, gameVersion, downloadProvider);
@@ -47,6 +52,7 @@ public class InstallersPage extends AbstractInstallersPage {
         installable.bind(createBooleanBinding(txtName::validate, txtName.textProperty()));
 
         txtName.textProperty().addListener((obs, oldText, newText) -> isNameModifiedByUser = true);
+        chkEnableVersionIsolation.setSelected(repository.getProfile().getGlobal().getGameDirType() == GameDirectoryType.VERSION_FOLDER);
     }
 
     @Override
@@ -70,6 +76,11 @@ public class InstallersPage extends AbstractInstallersPage {
         if (!isNameModifiedByUser) {
             setTxtNameWithLoaders();
         }
+    }
+
+    @Override
+    protected Node createBottomPaneLeadingNode() {
+        return chkEnableVersionIsolation;
     }
 
     @Override
@@ -100,6 +111,7 @@ public class InstallersPage extends AbstractInstallersPage {
                     MessageDialogPane.MessageType.QUESTION)
                     .yesOrNo(() -> {
                         controller.getSettings().put("name", name);
+                        controller.getSettings().put(ENABLE_VERSION_ISOLATION, chkEnableVersionIsolation.isSelected());
                         controller.onFinish();
                     }, () -> {
                         // The user selects Cancel and does nothing.
@@ -107,6 +119,7 @@ public class InstallersPage extends AbstractInstallersPage {
                     .build());
         } else {
             controller.getSettings().put("name", name);
+            controller.getSettings().put(ENABLE_VERSION_ISOLATION, chkEnableVersionIsolation.isSelected());
             controller.onFinish();
         }
     }

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -753,6 +753,7 @@ install.new_game.already_exists=This instance name already exists. Please use an
 install.new_game.current_game_version=Current Instance Version
 install.new_game.installation=Instance Installation
 install.new_game.malformed=Invalid name.
+install.new_game.version_isolation=Enable Version Isolation (Independent Instance)
 install.select=Choose operation
 install.success=Successfully installed.
 

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -557,6 +557,7 @@ install.new_game.already_exists=此實例已經存在，請重新命名
 install.new_game.current_game_version=目前遊戲實例
 install.new_game.installation=安裝新實例
 install.new_game.malformed=名稱無效
+install.new_game.version_isolation=啟用版本隔離（各實例獨立）
 install.select=請選取安裝方式
 install.success=安裝成功
 

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -562,6 +562,7 @@ install.new_game.already_exists=此实例已经存在，请换一个名字
 install.new_game.current_game_version=当前游戏实例
 install.new_game.installation=安装新游戏
 install.new_game.malformed=名字不合法
+install.new_game.version_isolation=启用版本隔离（各实例独立）
 install.select=请选择安装方式
 install.success=安装成功
 


### PR DESCRIPTION
## 背景与用户影响
在“安装新游戏实例”流程中，Fabric API / Quilt API / Legacy Fabric API 会以 `mods` 形式下载到当前运行目录。若用户安装后再开启“版本隔离（各实例独立）”，这些 API 会留在公共目录，导致新实例缺失对应 API，进而出现启动失败或依赖缺失的情况。

## 根因
安装向导在创建实例时没有提供“版本隔离”选择，也没有在安装阶段提前为“将要创建的实例”指定独立运行目录，导致 API 安装路径依赖当时的全局工作目录设置。

## 变更说明
本 PR 在新实例安装向导中新增“启用版本隔离（各实例独立）”开关，并将该选择贯穿到安装执行流程：

1. 在安装页增加勾选项，并放置在底部操作栏左侧，与“安装”按钮同一行。
2. 安装前将目标实例临时标记为 `VERSION_FOLDER`，保证 Fabric API / Quilt API 写入实例目录。
3. 安装完成后为该实例落盘 `VersionSetting.gameDirType=VERSION_FOLDER`（通过实例级设置生效）。
4. 安装流程结束后清理临时目录类型标记，避免影响后续流程。
5. 增加多语言文案：`install.new_game.version_isolation`（EN/简中/繁中）。

## 主要改动文件
- `HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java`
- `HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java`
- `HMCL/src/main/java/org/jackhuang/hmcl/ui/download/DownloadPage.java`
- `HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VanillaInstallWizardProvider.java`
- `HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java`
- `HMCL/src/main/resources/assets/lang/I18N.properties`
- `HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties`
- `HMCL/src/main/resources/assets/lang/I18N_zh.properties`

## 验证
- 本地编译通过：
  - `./gradlew.bat :HMCL:compileJava`

## 兼容性
- 不勾选该项时，行为与现有逻辑一致。
- 勾选该项时，仅影响当前新建实例的安装路径与实例级版本隔离设置，不影响其他实例。
