### PR TITLE
fix: #5682 安装整合包界面文件名重复的提示显示不全

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/ModpackPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/ModpackPage.java
@@ -46,7 +46,7 @@ public abstract class ModpackPage extends SpinnerPane implements WizardPage {
 
                 txtModpackName = new JFXTextField();
                 txtModpackName.setPrefWidth(300);
-                // FIXME: Validator are not shown properly
+                FXUtils.setLimitHeight(archiveNamePane, 75);
                 // BorderPane.setMargin(txtModpackName, new Insets(0, 0, 8, 32));
                 BorderPane.setAlignment(txtModpackName, Pos.CENTER_RIGHT);
                 archiveNamePane.setRight(txtModpackName);


### PR DESCRIPTION
<img width="1258" height="762" alt="image" src="https://github.com/user-attachments/assets/731013c0-79b3-4453-a690-7679d5ca691c" />