### PR TITLE
fix: SpinnerPane 裁切元素

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/SpinnerPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/SpinnerPane.java
@@ -222,7 +222,6 @@ public class SpinnerPane extends Control {
             } else {
                 if (contentPane == null) {
                     contentPane = new StackPane();
-                    contentPane.setClip(null);
                 }
 
                 Node content = control.getContent();


### PR DESCRIPTION
例如：账号右侧图标
<img width="330" height="88" alt="image" src="https://github.com/user-attachments/assets/1b3a90bf-5e9a-45c6-9b60-a388813d76cd" />
<img width="318" height="109" alt="image" src="https://github.com/user-attachments/assets/db3c07b0-609d-438d-a6b1-b7ed6c677aae" />
