### PR TITLE
fix: 导出 Modrinth 整合包时，不要求填写作者

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ModpackInfoPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ModpackInfoPage.java
@@ -221,9 +221,14 @@ public final class ModpackInfoPage extends Control implements WizardPage {
 
                     list.getContent().addAll(
                             createTextFieldLinePane(i18n("modpack.name"), skinnable.name, new RequiredValidator()),
-                            createTextFieldLinePane(i18n("archive.author"), skinnable.author, new RequiredValidator()),
                             createTextFieldLinePane(i18n("archive.version"), skinnable.version, new RequiredValidator())
                     );
+
+                    if (skinnable.options.isRequireAuthor()) {
+                        list.getContent().add(
+                                createTextFieldLinePane(i18n("archive.author"), skinnable.author, new RequiredValidator())
+                        );
+                    }
 
                     if (skinnable.options.isRequireFileApi()) {
                         list.getContent().add(createTextFieldLinePane(

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModpackExportInfo.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModpackExportInfo.java
@@ -210,6 +210,7 @@ public class ModpackExportInfo {
     }
 
     public static class Options {
+        private boolean requireAuthor;
         private boolean requireUrl;
         private boolean requireForceUpdate;
         private boolean requireFileApi;
@@ -223,6 +224,10 @@ public class ModpackExportInfo {
         private boolean requireSkipCurseForgeRemoteFiles;
 
         public Options() {
+        }
+
+        public boolean isRequireAuthor() {
+            return requireAuthor;
         }
 
         public boolean isRequireUrl() {
@@ -267,6 +272,11 @@ public class ModpackExportInfo {
 
         public boolean isRequireSkipCurseForgeRemoteFiles() {
             return requireSkipCurseForgeRemoteFiles;
+        }
+
+        public Options requireAuthor() {
+            requireAuthor = true;
+            return this;
         }
 
         public Options requireUrl() {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackExportTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackExportTask.java
@@ -143,6 +143,7 @@ public class McbbsModpackExportTask extends Task<Void> {
             .requireAuthlibInjectorServer()
             .requireJavaArguments()
             .requireLaunchArguments()
-            .requireOrigins();
+            .requireOrigins()
+            .requireAuthor();
 
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/multimc/MultiMCModpackExportTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/multimc/MultiMCModpackExportTask.java
@@ -103,5 +103,7 @@ public class MultiMCModpackExportTask extends Task<Void> {
         }
     }
 
-    public static final ModpackExportInfo.Options OPTION = new ModpackExportInfo.Options().requireMinMemory();
+    public static final ModpackExportInfo.Options OPTION = new ModpackExportInfo.Options()
+            .requireAuthor()
+            .requireMinMemory();
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackExportTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackExportTask.java
@@ -107,5 +107,6 @@ public class ServerModpackExportTask extends Task<Void> {
     }
 
     public static final ModpackExportInfo.Options OPTION = new ModpackExportInfo.Options()
+            .requireAuthor()
             .requireFileApi(false);
 }


### PR DESCRIPTION
参考 Modrinth 官方整合包格式文档，并未找到有要求填写“作者”，我翻阅了 HMCL 导出整合包的实现，也并未看到其真正使用到了玩家填写的作者名：

https://github.com/HMCL-dev/HMCL/blob/e9d7d0a33ce0516a738e12b709feb897356313dd/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthModpackExportTask.java#L171-L179

因此，不应当在填写整合包信息页面内，要求玩家为 Modrinth 整合包填写“作者”

当然，我为了最小代码修改，调换了下 UI 顺序，如果考虑到玩家的操作习惯，需要将“作者”栏排在“整合包名称”栏之后，可能需要修改为：
``` java

list.getContent().add(
        createTextFieldLinePane(i18n("modpack.name"), skinnable.name, new RequiredValidator())
);
if (skinnable.options.isRequireAuthor()) {
    list.getContent().add(
            createTextFieldLinePane(i18n("archive.author"), skinnable.author, new RequiredValidator())
    );
}
list.getContent().add(
        createTextFieldLinePane(i18n("archive.version"), skinnable.version, new RequiredValidator())
);

```

如有需要，可以进行修改 XD

相关参考：[Modrinth Modpack Format (.mrpack)](https://support.modrinth.com/en/articles/8802351-modrinth-modpack-format-mrpack)