### PR TITLE
优化 JFXToggleButton 配色

### DIFF
--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -1169,8 +1169,8 @@
     -fx-background-radius: 3px;
     -fx-background-insets: 0px;
 
-    -jfx-toggle-color: -monet-primary;
-    -jfx-toggle-line-color: -monet-primary-container;
+    -jfx-toggle-color: -monet-primary-container;
+    -jfx-toggle-line-color: -monet-primary-fixed-dim;
     -jfx-untoggle-color: -monet-outline;
     -jfx-untoggle-line-color: -monet-surface-container-highest;
     -jfx-size: 10;


### PR DESCRIPTION
<img width="453" height="156" alt="image" src="https://github.com/user-attachments/assets/83715006-de27-42d2-86d8-96207c835e99" />

依次为 本PR - 主线 - 颜色更新前

主线的长条和点有股融为一体的感觉，且颜色偏深，不太美观