### PR TITLE
修正运行路径非法字符 `=` 提示

### DIFF
--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -439,7 +439,7 @@ You can continue to keep the old version of Java.\
 HMCL can recognize and manage multiple Java versions and will automatically select the appropriate Java for you based on the game version.
 fatal.deprecated_java_version.download_link=Download Java %d
 fatal.samba=If you opened Hello Minecraft! Launcher from a Samba network drive, some features might not be working. Please try updating your Java or moving the launcher to another directory.
-fatal.illegal_char=Your user path contains an illegal character "=". You will not be able to use authlib-injector or change the skin of your offline account.
+fatal.illegal_char=Your working directory contains an illegal character "=". You will not be able to use authlib-injector or change the skin of your offline account.
 fatal.unsupported_platform=Minecraft is not fully supported on your platform yet, so you may experience missing features or even be unable to launch the game.\n\
    \n\
    If you cannot launch Minecraft 1.17 and later, you can try switching the "Renderer" to "Mesa LLVMpipe" in "Global/Instance-specific Settings → Advanced Settings" to use CPU rendering for better compatibility.

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -408,7 +408,7 @@ fatal.deprecated_java_version=HMCL 未來需要 Java 17 或更高版本才能執
 fatal.deprecated_java_version.update=更高版本的 HMCL 需要 Java 17 或更高版本才能執行，請安裝最新版本的 Java 以確保 HMCL 能夠完成升級。\n你可以繼續保留舊版本 Java。HMCL 能夠識別與管理多個 Java，並會自動根據遊戲版本為你選取合適的 Java。
 fatal.deprecated_java_version.download_link=下載 Java %d
 fatal.samba=如果您正在透過 Samba 共亯的目錄中開啟 Hello Minecraft! Launcher，啟動器可能無法正常工作，請嘗試更新您的 Java 或在本機目錄內開啟 HMCL。
-fatal.illegal_char=由於您的使用者目錄路徑中存在無效字元『=』，您將無法使用外部登入帳戶以及離線登入更換外觀功能。
+fatal.illegal_char=由於您的執行路徑中存在無效字元『=』，您將無法使用外部登入帳戶以及離線登入更換外觀功能。
 fatal.unsupported_platform=Minecraft 尚未對您的平臺提供完善支援，所以可能影響遊戲體驗或無法啟動遊戲。\n\
   若無法啟動 Minecraft 1.17 及更高版本，可以嘗試在「(全域/實例特定) 遊戲設定 → 進階設定 → 除錯選項」中將「繪製器」切換為「Mesa LLVMpipe」，以獲得更好的相容性。
 fatal.unsupported_platform.loongarch=Hello Minecraft! Launcher 已為龍芯提供支援。\n如果遇到問題，你可以點擊右上角幫助按鈕進行求助。

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -411,7 +411,7 @@ fatal.deprecated_java_version=HMCL 未来需要 Java 17 或更高版本才能运
 fatal.deprecated_java_version.update=更高版本的 HMCL 需要 Java 17 或更高版本才能运行，请安装最新版本的 Java 以确保 HMCL 能够完成升级。\n你可以继续保留旧版本 Java。HMCL 能够识别与管理多个 Java，并会自动根据游戏版本为你选择合适的 Java。
 fatal.deprecated_java_version.download_link=下载 Java %d
 fatal.samba=如果你正在通过 Samba 共享的文件夹中运行 Hello Minecraft! Launcher，启动器可能无法正常工作。请尝试更新你的 Java 或在本地文件夹内运行 HMCL。\n你可以访问 https://docs.hmcl.net/help.html 页面寻求帮助。
-fatal.illegal_char=由于你的用户文件夹路径中存在非法字符“=”，你将无法使用外置登录账户以及离线登录更换皮肤功能。\n你可以访问 https://docs.hmcl.net/help.html 页面寻求帮助。
+fatal.illegal_char=由于你的运行路径中存在非法字符“=”，你将无法使用外置登录账户以及离线登录更换皮肤功能。\n你可以访问 https://docs.hmcl.net/help.html 页面寻求帮助。
 fatal.unsupported_platform=Minecraft 尚未对你的平台提供完善支持，所以可能影响游戏体验或无法启动游戏。\n\
   若无法启动 Minecraft 1.17 及更高版本，可以尝试在“(全局/实例特定) 游戏设置 → 高级设置 → 调试选项”中将“渲染器”切换为“Mesa LLVMpipe”，以获得更好的兼容性。\n\
   如遇到问题，你可以点击右上角帮助按钮进行求助。


### PR DESCRIPTION
`Metadata.HMCL_CURRENT_DIRECTORY` 是运行路径下的 .hmcl 文件夹