### PR TITLE
启动时对会丢失游戏数据的情况添加 5 秒确认

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
@@ -112,7 +112,7 @@ public final class Launcher extends Application {
             if (OperatingSystem.CURRENT_OS == OperatingSystem.MACOS
                     && ConfigHolder.isNewlyCreated()
                     && System.getProperty("user.dir").startsWith("/private/var/folders/")) {
-                if (showAlertWithCountdown(AlertType.WARNING, i18n("fatal.mac_app_translocation"), 5, ButtonType.YES, ButtonType.NO) == ButtonType.NO)
+                if (!confirmWithCountdown(AlertType.WARNING, i18n("fatal.mac_app_translocation"), 5))
                     return;
             } else {
                 checkConfigInTempDir();
@@ -183,9 +183,8 @@ public final class Launcher extends Application {
         return new Alert(alertType, contentText, buttons).showAndWait().orElse(null);
     }
 
-    private static ButtonType showAlertWithCountdown(Alert.AlertType alertType, String contentText, int seconds, ButtonType... buttons) {
-        Alert alert = new Alert(alertType, contentText, buttons);
-
+    private static boolean confirmWithCountdown(Alert.AlertType alertType, String contentText, int seconds) {
+        Alert alert = new Alert(alertType, contentText, ButtonType.YES, ButtonType.NO);
         Button okButton = (Button) alert.getDialogPane().lookupButton(ButtonType.YES);
 
         okButton.setDisable(true);
@@ -202,8 +201,7 @@ public final class Launcher extends Application {
         Timeline timeline = new Timeline(keyFrames);
         alert.setOnShown(e -> timeline.play());
         alert.setOnCloseRequest(e -> timeline.stop());
-
-        return alert.showAndWait().orElse(null);
+        return alert.showAndWait().orElse(null) == ButtonType.YES;
     }
 
     private static boolean isConfigInTempDir() {
@@ -245,7 +243,7 @@ public final class Launcher extends Application {
 
     private static void checkConfigInTempDir() {
         if (ConfigHolder.isNewlyCreated() && isConfigInTempDir()
-                && showAlertWithCountdown(AlertType.WARNING, i18n("fatal.config_in_temp_dir"), 5, ButtonType.YES, ButtonType.NO) == ButtonType.NO) {
+                && !confirmWithCountdown(AlertType.WARNING, i18n("fatal.config_in_temp_dir"), 5)) {
             EntryPoint.exit(0);
         }
     }


### PR DESCRIPTION
被 macOS 隔离或者在压缩包中运行（临时目录）都会导致游戏数据在启动器退出后丢失，但观察到用户群很多人看都不看直接点确认回头问自己实例怎么没了