### PR TITLE
修复 `JFXColorPicker` 到 `JFXCustomColorPickerDialog` 颜色信息传递问题

### DIFF
--- a/HMCL/src/main/java/com/jfoenix/skins/JFXCustomColorPickerDialog.java
+++ b/HMCL/src/main/java/com/jfoenix/skins/JFXCustomColorPickerDialog.java
@@ -309,6 +309,9 @@ public class JFXCustomColorPickerDialog extends StackPane {
 
     public void setCurrentColor(Color currentColor) {
         this.currentColorProperty.set(currentColor);
+        if (curvedColorPicker != null && currentColor != null) {
+            curvedColorPicker.setColor(currentColor);
+        }
     }
 
     Color getCurrentColor() {


### PR DESCRIPTION
在此 PR 中, 解决了过去现有的 `JFXColorPicker` 色彩信息不能被传递到 `JFXCustomColorPickerDialog` 的问题，在一定程度上缓解了 #5767, 直接 Resolve #5766