### PR TITLE
修复了自定义颜色面板打开时没有同步启动器主题颜色，间接修复了bug#5657

### DIFF
--- a/HMCL/src/main/java/com/jfoenix/skins/JFXCustomColorPickerDialog.java
+++ b/HMCL/src/main/java/com/jfoenix/skins/JFXCustomColorPickerDialog.java
@@ -309,6 +309,7 @@ public class JFXCustomColorPickerDialog extends StackPane {
 
     public void setCurrentColor(Color currentColor) {
         this.currentColorProperty.set(currentColor);
+        curvedColorPicker.setColor(currentColor);
     }
 
     Color getCurrentColor() {


### PR DESCRIPTION
修复了 bug#5657

JFXCustomColorPickerDialog 的 setCurrentColor 方法仅仅是设置了内部的 currentColorProperty 属性，但没有将这个颜色应用到颜色选择器 ( curvedColorPicker ) 的 UI 上。所以直接显式调用 curvedColorPicker.setColor(currentColor)即可。
这样下次打开的时候就是和启动同样的颜色，只有当自定义颜色和主题颜色不同的时候，关闭会进行修改