### PR TITLE
缓解离线皮肤 CSL 输入框打一个字弹窗一个 toast  “操作失败” 问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
@@ -21,6 +21,7 @@ import com.jfoenix.controls.JFXButton;
 import com.jfoenix.controls.JFXComboBox;
 import com.jfoenix.controls.JFXDialogLayout;
 import com.jfoenix.controls.JFXTextField;
+import javafx.animation.PauseTransition;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.geometry.Insets;
@@ -29,6 +30,7 @@ import javafx.scene.control.Label;
 import javafx.scene.input.DragEvent;
 import javafx.scene.input.TransferMode;
 import javafx.scene.layout.*;
+import javafx.util.Duration;
 import org.jackhuang.hmcl.auth.offline.OfflineAccount;
 import org.jackhuang.hmcl.auth.offline.Skin;
 import org.jackhuang.hmcl.auth.yggdrasil.TextureModel;
@@ -135,7 +137,9 @@ public class OfflineAccountSkinPane extends StackPane {
             capeSelector.setValue(account.getSkin().getLocalCapePath());
         }
 
-        skinBinding = FXUtils.observeWeak(() -> {
+        PauseTransition pauseTransition = new PauseTransition(Duration.seconds(1));
+
+        Runnable loadSkin = () -> {
             getSkin().load(account.getUsername())
                     .whenComplete(Schedulers.javafx(), (result, exception) -> {
                         if (exception != null) {
@@ -157,6 +161,23 @@ public class OfflineAccountSkinPane extends StackPane {
                                     result.getCape() != null ? result.getCape().getImage() : null);
                         }
                     }).start();
+        };
+
+        pauseTransition.setOnFinished(e -> loadSkin.run());
+
+        skinBinding = FXUtils.observeWeak(() -> {
+            Skin.Type selectedType = skinItem.getSelectedData();
+
+            if (selectedType == Skin.Type.CUSTOM_SKIN_LOADER_API) {
+                if (!cslApiField.validate()) {
+                    pauseTransition.stop();
+                    return;
+                }
+                pauseTransition.playFromStart();
+            } else {
+                pauseTransition.stop();
+                loadSkin.run();
+            }
         }, skinItem.selectedDataProperty(), cslApiField.textProperty(), modelCombobox.valueProperty(), skinSelector.valueProperty(), capeSelector.valueProperty());
 
         FXUtils.onChangeAndOperate(skinItem.selectedDataProperty(), selectedData -> {


### PR DESCRIPTION
目前如果手打 Blessing Skin 链接，打一个字就会刷新一次皮肤，就会弹一次 “操作失败” toast。
本 PR 通过添加 1 秒延时和校验不通过情况不刷新缓解了本问题。