### PR TITLE
fix-5544-neoforge-partial-metadata

### DIFF
--- a/HMCLBoot/bin/main/assets/lang/boot.properties
+++ b/HMCLBoot/bin/main/assets/lang/boot.properties
@@ -1,0 +1,22 @@
+#
+# Hello Minecraft! Launcher
+# Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+boot.unsupported_java_version=HMCL requires Java 17 or later to run, but still supports launching games with Java 6~16. Please install the latest version of Java and try opening HMCL again.\nYou can keep your old version of Java. HMCL can detect and manage multiple Java installations, and will automatically select the appropriate Java version for your game.
+boot.manual_update=HMCL cannot complete automatic updates in the current environment. Please download the latest version of HMCL manually.\nWould you like to go to the download page?
+
+boot.message.error=Error

--- a/HMCLBoot/bin/main/assets/lang/boot_es.properties
+++ b/HMCLBoot/bin/main/assets/lang/boot_es.properties
@@ -1,0 +1,19 @@
+#
+# Hello Minecraft! Launcher
+# Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+boot.unsupported_java_version=HMCL requiere Java 17 o posterior para ejecutarse, pero sigue admitiendo el inicio de juegos con Java 6~16.\nPor favor, instala la última versión de Java e intenta ejecutar HMCL de nuevo.\nPuedes conservar tu versión antigua de Java. HMCL puede detectar y gestionar múltiples instalaciones de Java,\ny seleccionará automáticamente la versión de Java adecuada para tu juego.

--- a/HMCLBoot/bin/main/assets/lang/boot_zh.properties
+++ b/HMCLBoot/bin/main/assets/lang/boot_zh.properties
@@ -1,0 +1,22 @@
+#
+# Hello Minecraft! Launcher
+# Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+boot.unsupported_java_version=HMCL 需要 Java 17 或更高版本才能运行，但依然支持使用 Java 6~16 启动游戏。请安装最新版本的 Java 再尝试启动 HMCL。\n你可以继续保留旧版本 Java。HMCL 能够识别与管理多个 Java，并会自动根据游戏版本为你选择合适的 Java。\n你可以访问 https://docs.hmcl.net/help.html 页面寻求帮助。
+boot.manual_update=HMCL 在当前环境无法完成自动更新，请手动下载最新版本的 HMCL。\n是否前往下载页面？
+
+boot.message.error=错误

--- a/HMCLBoot/bin/main/assets/lang/boot_zh_Hant.properties
+++ b/HMCLBoot/bin/main/assets/lang/boot_zh_Hant.properties
@@ -1,0 +1,22 @@
+#
+# Hello Minecraft! Launcher
+# Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+boot.unsupported_java_version=HMCL 需要 Java 17 或更高版本才能執行，但依然支援使用 Java 6~16 啟動遊戲。請安裝最新版本的 Java 再嘗試開啟 HMCL。\n你可以繼續保留舊版本 Java。HMCL 能夠識別與管理多個 Java，並會自動根據遊戲版本為你選取合適的 Java。
+boot.manual_update=HMCL 在當前環境無法完成自動更新，請手動下載最新版本的 HMCL。\n是否前往下載頁面？
+
+boot.message.error=錯誤

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modinfo/ForgeNewModMetadata.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modinfo/ForgeNewModMetadata.java
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.StringJoiner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
@@ -191,7 +193,9 @@ public final class ForgeNewModMetadata {
         ZipArchiveEntry modToml = tree.getEntry(tomlPath);
         if (modToml == null)
             throw new IOException("File " + modFile + " is not a Forge 1.13+ or NeoForge mod.");
-        Toml toml = new Toml().read(tree.readTextEntry(modToml));
+        String tomlContent = tree.readTextEntry(modToml);
+        tomlContent = preprocessToml(tomlContent);
+        Toml toml = new Toml().read(tomlContent);
         ForgeNewModMetadata metadata = toml.to(ForgeNewModMetadata.class);
         if (metadata == null || metadata.getMods().isEmpty())
             throw new IOException("Mod " + modFile + " `mods.toml` is malformed..");
@@ -213,6 +217,78 @@ public final class ForgeNewModMetadata {
                 mod.getAuthors(), jarVersion == null ? mod.getVersion() : mod.getVersion().replace("${file.jarVersion}", jarVersion), "",
                 mod.getDisplayURL(),
                 metadata.getLogoFile());
+    }
+
+    /**
+     * Matches a TOML table / array-of-tables header line only (not inline arrays like {@code loaders=["neoforge"]}).
+     * Group 1: leading whitespace; 2: full header {@code [[...]]} or {@code [...]}; 3: trailing comment/whitespace.
+     */
+    private static final Pattern TOML_TABLE_HEADER_LINE = Pattern.compile(
+            "^(\\s*)(\\[\\[[^\\]]+\\]\\]|\\[[^\\]]+\\])(\\s*(#.*)?)?$");
+
+    /**
+     * Preprocess TOML content to normalize quoted segments in <b>table header</b> keys only.
+     * Some mods use inconsistent quoting like {@code [[dependencies.neoecoae]]} with
+     * {@code [dependencies."neoecoae".mc-publish]}, which can break Moandjiezana's parser.
+     * <p>
+     * Must not touch {@code [ ... ]} inside key-value lines (e.g. {@code loaders=["neoforge"]}), or the file becomes invalid.
+     */
+    private static String preprocessToml(String content) {
+        String[] lines = content.split("\\R", -1);
+        StringJoiner out = new StringJoiner("\n");
+        for (String line : lines) {
+            Matcher m = TOML_TABLE_HEADER_LINE.matcher(line);
+            if (m.matches()) {
+                String ws = m.group(1);
+                String header = m.group(2);
+                String tail = m.group(3) != null ? m.group(3) : "";
+                if (header.startsWith("[[")) {
+                    String inner = header.substring(2, header.length() - 2);
+                    out.add(ws + "[[" + normalizeTableKey(inner) + "]]" + tail);
+                } else {
+                    String inner = header.substring(1, header.length() - 1);
+                    out.add(ws + "[" + normalizeTableKey(inner) + "]" + tail);
+                }
+            } else {
+                out.add(line);
+            }
+        }
+        return out.toString();
+    }
+
+    /**
+     * Normalize a TOML table key by removing quotes from quoted identifiers.
+     * E.g., "dependencies.\"neoecoae\".mc-publish" -> "dependencies.neoecoae.mc-publish"
+     */
+    private static String normalizeTableKey(String tableKey) {
+        StringBuilder result = new StringBuilder(tableKey.length());
+        int i = 0;
+        while (i < tableKey.length()) {
+            char c = tableKey.charAt(i);
+            if (c == '"') {
+                int end = tableKey.indexOf('"', i + 1);
+                if (end == -1) {
+                    result.append(c);
+                    i++;
+                    continue;
+                }
+                result.append(tableKey, i + 1, end);
+                i = end + 1;
+            } else if (c == '\'') {
+                int end = tableKey.indexOf('\'', i + 1);
+                if (end == -1) {
+                    result.append(c);
+                    i++;
+                    continue;
+                }
+                result.append(tableKey, i + 1, end);
+                i = end + 1;
+            } else {
+                result.append(c);
+                i++;
+            }
+        }
+        return result.toString();
     }
 
     private static LocalModFile fromEmbeddedMod(ModManager modManager, Path modFile, ZipFileTree tree, ModLoaderType modLoaderType) throws IOException {

--- a/HMCLCore/src/test/java/org/jackhuang/hmcl/mod/modinfo/ForgeNewModMetadataTomlTest.java
+++ b/HMCLCore/src/test/java/org/jackhuang/hmcl/mod/modinfo/ForgeNewModMetadataTomlTest.java
@@ -1,0 +1,95 @@
+/*
+ * Hello Minecraft! Launcher
+ * Copyright (C) 2026 HMCL contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package org.jackhuang.hmcl.mod.modinfo;
+
+import com.moandjiezana.toml.Toml;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression for GitHub issue: mixed quoted / unquoted keys in neoforge.mods.toml dependencies.
+ */
+public final class ForgeNewModMetadataTomlTest {
+
+    private static String invokePreprocessToml(String content) throws Exception {
+        Method m = ForgeNewModMetadata.class.getDeclaredMethod("preprocessToml", String.class);
+        m.setAccessible(true);
+        return (String) m.invoke(null, content);
+    }
+
+    @Test
+    public void preprocessMustNotCorruptInlineArrays() throws Exception {
+        String in = "[mc-publish]\n    loaders=[\"neoforge\"]\n    game-versions=[\"1.21.1\"]\n";
+        String out = invokePreprocessToml(in);
+        assertTrue(out.contains("loaders=[\"neoforge\"]"), () -> "broken output: " + out);
+        assertTrue(out.contains("game-versions=[\"1.21.1\"]"), () -> "broken output: " + out);
+    }
+
+    @Test
+    public void preprocessNormalizesQuotedTableKeyInHeader() throws Exception {
+        String in = "[[dependencies.neoecoae]]\n[dependencies.\"neoecoae\".mc-publish]\n";
+        String out = invokePreprocessToml(in);
+        assertTrue(out.contains("[[dependencies.neoecoae]]"));
+        assertTrue(out.contains("[dependencies.neoecoae.mc-publish]"));
+        assertFalse(out.contains("\"neoecoae\""));
+    }
+
+    @Test
+    public void mixedDependencyQuotesAndMcPublishParses() throws Exception {
+        String toml = """
+                modLoader="javafml"
+                loaderVersion="[4,)"
+                license="GPLv3"
+
+                [[mods]]
+                modId="neoecoae"
+                version="1.0.0"
+                displayName="Neo ECO AE Extension"
+                authors="A, B"
+                description='''d'''
+
+                [[dependencies.neoecoae]]
+                modId="neoforge"
+                type="required"
+                versionRange="[21.1.0,)"
+                ordering="NONE"
+                side="BOTH"
+
+                [[dependencies.neoecoae]]
+                modId="ae2"
+                type="required"
+                versionRange="[1,)"
+                ordering="NONE"
+                side="BOTH"
+                    [dependencies."neoecoae".mc-publish]
+                        modrinth="ae2"
+
+                [mc-publish]
+                modrinth="x"
+                curseforge=1
+                loaders=["neoforge"]
+                game-versions=["1.21.1"]
+                """;
+        String preprocessed = invokePreprocessToml(toml);
+        Toml parsed = new Toml().read(preprocessed);
+        ForgeNewModMetadata meta = parsed.to(ForgeNewModMetadata.class);
+        assertNotNull(meta);
+        assertFalse(meta.getMods().isEmpty());
+        assertEquals("neoecoae", meta.getMods().get(0).getModId());
+        assertEquals("Neo ECO AE Extension", meta.getMods().get(0).getDisplayName());
+        assertEquals("A, B", meta.getMods().get(0).getAuthors());
+    }
+}


### PR DESCRIPTION
Fixes #5544
- 问题定位：
日志中可见:`Suppressed: java.io.IOException: File neoecoae-1.0.0.jar is not a Forge 1.13+ or NeoForge mod.` 这说明 HMCL 的模组解析流程全部失败，最终回落到「未知模组」兜底逻辑
从#5544 mod的构建的JAR中解压出 META-INF/neoforge.mods.toml，发现依赖声明中引号格式不一致：
```
# 表头无引号
[[dependencies.neoecoae]]
    modId="neoforge"
    ...
# 后续子表却用了带引号的复合键
[[dependencies.neoecoae]]
    modId="ae2"
    ...
    [dependencies."neoecoae".mc-publish]   #这里有引号
        modrinth="ae2"
```
TOML 规范要求同一层级结构键的引号风格必须一致。这种混合写法导致 `Moandjiezana TOML 解析器（toml4j 0.7.2）`在解析 `dependencies` 表时失败，进而使 mods 数组解析失败，`ForgeNewModMetadata.getMods()` 返回空列表，`fromFile0()` 抛出 `IOException`，所有 `reader` 均失败后回落到"未知模组"兜底逻辑
修复这个问题要完善HMCL 对TOML 预处理逻辑，对表头键的引号进行规范化处理。
- 修复方案：
在` ForgeNewModMetadata.java `新增 `preprocessToml()` 方法，在 TOML 解析前统一移除表头键中的引号：
1、**修改文件**: `HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modinfo/ForgeNewModMetadata.java`
2、**新增方法**: `preprocessToml(String content)` - 按行匹配 TOML 表头，正规化引号
3、**调用位置**: `fromFile0()` 方法中，读取 TOML 内容后立即预处理
修复后，以下格式均能正确解析：
```toml
[[dependencies.neoecoae]]           # 无引号 - 保留
[dependencies."neoecoae".mc-publish] # 有引号 -> 规范化为 [dependencies.neoecoae.mc-publish]
```

- 单元测试:
新增 ForgeNewModMetadataTomlTest 测试类，确保了：
1、行内数组不被破坏 `(loaders=["neoforge"])`
2、表头引号被正确规范化
3、完整 TOML 解析成功，模组信息读取正确

- 最终效果:
重新运行`.\gradlew.bat run`后，问题已解决

<img width="993" height="604" alt="60b4489c117989ced2eba9ded4b44b7" src="https://github.com/user-attachments/assets/5d593a52-0089-44b7-b81a-a94816a9416f" />
<img width="999" height="612" alt="1773902060522" src="https://github.com/user-attachments/assets/ec728a10-a5d8-45a9-b6f3-8965c00284f9" />

