### PR TITLE
优化 JFXCheckBoxSkin

### DIFF
--- a/HMCL/src/main/java/com/jfoenix/skins/JFXCheckBoxSkin.java
+++ b/HMCL/src/main/java/com/jfoenix/skins/JFXCheckBoxSkin.java
@@ -65,7 +65,7 @@ public class JFXCheckBoxSkin extends CheckBoxSkin {
         SVGPath shape = new SVGPath();
         shape.setContent("M384 690l452-452 60 60-512 512-238-238 60-60z");
         this.mark.setShape(shape);
-        this.mark.setMaxSize(15.0, 12.0);
+        this.mark.setMaxSize(13.0, 10.0);
         this.mark.setStyle("-fx-background-color:-monet-on-primary; -fx-border-color:-monet-on-primary; -fx-border-width:2px;");
         this.mark.setVisible(false);
         this.mark.setScaleX(0.0);


### PR DESCRIPTION
缩小 JFXCheckBoxSkin 中 svg 图形的大小

| Before | MD2 | MD3 | After |
| - | - | - | - |
| <img width="50" height="50" alt="image" src="https://github.com/user-attachments/assets/2b94adc0-e61a-4ede-893a-8e70d6e59e37" /> | <img width="50" height="50" alt="image" src="https://github.com/user-attachments/assets/ab9a0f55-98c8-44f5-af80-e31e7d6f8596" /> | <img width="50" height="50" alt="image" src="https://github.com/user-attachments/assets/ed4af7b9-2bf6-423e-a84d-1064d1d92042" /> | <img width="50" height="50" alt="image" src="https://github.com/user-attachments/assets/b2ff9072-1adc-48af-907f-65870da828cb" /> |
