### PR TITLE
Parallel modloading

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModManager.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModManager.java
@@ -203,7 +203,7 @@ public final class ModManager {
             // load mods
             var futures = new ArrayList<CompletableFuture<Void>>(modFiles.size());
             var submissionLimit = new Semaphore(10);
-            for (var modFile : modFiles) {
+            for (Path modFile : modFiles) {
                 try {
                     submissionLimit.acquire();
                 } catch (InterruptedException e) {


### PR DESCRIPTION
将`ModMenager.addModInfo(...)`放到了CompletableFuture中，从而尽可能规避了其中IO操作导致的等待。

默认情况下一次性最多10并行，因为`Schedulers.io()`在不支持虚拟线程的版本下如果收到大量任务（比如加载大型整合包的mod列表），会创造大量线程。

这个PR能使得mod列表加载时间从10秒缩减到大约4秒，如果再加上kala-compress方面的优化，应该还能更快