### PR TITLE
fix: SettingsMap 缺少 toString 方法

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/SettingsMap.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/SettingsMap.java
@@ -25,7 +25,7 @@ import java.util.Map;
 
 /// A wrapper for `Map<String, Object>`, supporting type-safe reading and writing of values.
 ///
-/// @author Glavo
+///  @author Glavo
 public final class SettingsMap {
     public record Key<T>(String key) {
     }


### PR DESCRIPTION
Wizard 在状态异常时会抛出带有 SettingsMap 信息的异常，类似这样
```
    java.lang.IllegalStateException: error step 2, settings: org.jackhuang.hmcl.util.SettingsMap@540af92f, pages: .......
	at org.jackhuang.hmcl.ui.download.ModpackInstallWizardProvider.createPage(ModpackInstallWizardProvider.java:161)
	at org.jackhuang.hmcl.ui.wizard.WizardController.navigatingTo(WizardController.java:158)
	at org.jackhuang.hmcl.ui.wizard.WizardController.onNext(WizardController.java:82)
```
但是 SettingsMap 缺少 toString 方法导致这串信息无意义，本 PR 修复了本问题
```
    java.lang.IllegalStateException: error step 0, settings: SettingsMap{PROFILE=Profile [gameDir=......, name=Home, useRelativePath=false]}, pages: []
	at org.jackhuang.hmcl.ui.download.ModpackInstallWizardProvider.createPage(ModpackInstallWizardProvider.java:172)
	at org.jackhuang.hmcl.ui.wizard.WizardController.navigatingTo(WizardController.java:158)
	at org.jackhuang.hmcl.ui.wizard.WizardController.onStart(WizardController.java:64)
```
