### PR TITLE
优化关于页组件间距使整体风格更加统一协调

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/AboutPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/AboutPage.java
@@ -43,7 +43,7 @@ public final class AboutPage extends SpinnerPane {
 
     public AboutPage() {
         VBox content = new VBox();
-        content.getStyleClass().add("content");
+        content.getStyleClass().add("spinner-pane-content");
         ScrollPane scrollPane = new ScrollPane(content);
         scrollPane.setFitToWidth(true);
         FXUtils.smoothScrolling(scrollPane);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/FeedbackPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/FeedbackPage.java
@@ -36,7 +36,7 @@ public class FeedbackPage extends SpinnerPane {
 
     public FeedbackPage() {
         VBox content = new VBox();
-        content.getStyleClass().add("content");
+        content.getStyleClass().add("spinner-pane-content");
         ScrollPane scrollPane = new ScrollPane(content);
         scrollPane.setFitToWidth(true);
         FXUtils.smoothScrolling(scrollPane);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/HelpPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/HelpPage.java
@@ -41,7 +41,7 @@ public class HelpPage extends SpinnerPane {
 
     public HelpPage() {
         content = new VBox();
-        content.getStyleClass().add("content");
+        content.getStyleClass().add("spinner-pane-content");
         ScrollPane scrollPane = new ScrollPane(content);
         scrollPane.setFitToWidth(true);
         FXUtils.smoothScrolling(scrollPane);

--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -1463,7 +1463,7 @@
     -jfx-radius: 9;
 }
 
-.spinner-pane .content {
+.spinner-pane .spinner-pane-content {
     -fx-padding: 10px;
     -fx-spacing: 10px;
 }


### PR DESCRIPTION
- 关于页相比于反馈页和帮助页的组件间距较大，调整后三个页面的组件间距一致，使其与整体页面风格更加协调一致。
- 使用 css 公共样式替代行内样式。
- 移除反馈页多余的 `this.setContent(content)`

---

| Before | After |
| - | - |
| <img width="818" height="508" alt="image" src="https://github.com/user-attachments/assets/afcc2c3d-2752-4cc6-9b2e-6f22ee3125c6" /> | <img width="818" height="508" alt="image" src="https://github.com/user-attachments/assets/af3987a3-9eea-4d3e-a922-9a05d891356f" /> |
