### PR TITLE
优化工具栏“全选”功能

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DataPackListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DataPackListPageSkin.java
@@ -28,6 +28,7 @@ import javafx.beans.InvalidationListener;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.collections.ListChangeListener;
 import javafx.collections.transformation.FilteredList;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -123,12 +124,20 @@ final class DataPackListPageSkin extends SkinBase<DataPackListPage> {
             enableButton.disableProperty().bind(getSkinnable().readOnly);
             disableButton.disableProperty().bind(getSkinnable().readOnly);
 
+            // reason for not using selectAll() is that selectAll() first clears all selected then selects all, causing the toolbar to flicker
+            var selectAllButton = createToolbarButton2(i18n("button.select_all"), SVG.SELECT_ALL, () -> listView.getSelectionModel().selectRange(0, listView.getItems().size()));
+
+            listView.getSelectionModel().getSelectedItems().addListener(
+                    (ListChangeListener<Object>) change -> {
+                        selectAllButton.setDisable(!listView.getItems().isEmpty()
+                                && listView.getSelectionModel().getSelectedItems().size() == listView.getItems().size());
+                    }
+            );
             selectingToolbar.getChildren().addAll(
                     removeButton,
                     enableButton,
                     disableButton,
-                    createToolbarButton2(i18n("button.select_all"), SVG.SELECT_ALL, () ->
-                            listView.getSelectionModel().selectRange(0, listView.getItems().size())),//reason for not using selectAll() is that selectAll() first clears all selected then selects all, causing the toolbar to flicker
+                    selectAllButton,
                     createToolbarButton2(i18n("button.cancel"), SVG.CANCEL, () ->
                             listView.getSelectionModel().clearSelection())
             );

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DataPackListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DataPackListPageSkin.java
@@ -127,12 +127,14 @@ final class DataPackListPageSkin extends SkinBase<DataPackListPage> {
             // reason for not using selectAll() is that selectAll() first clears all selected then selects all, causing the toolbar to flicker
             var selectAllButton = createToolbarButton2(i18n("button.select_all"), SVG.SELECT_ALL, () -> listView.getSelectionModel().selectRange(0, listView.getItems().size()));
 
-            listView.getSelectionModel().getSelectedItems().addListener(
-                    (ListChangeListener<Object>) change -> {
-                        selectAllButton.setDisable(!listView.getItems().isEmpty()
-                                && listView.getSelectionModel().getSelectedItems().size() == listView.getItems().size());
-                    }
-            );
+            ListChangeListener<Object> listener = change -> {
+                selectAllButton.setDisable(!listView.getItems().isEmpty()
+                        && listView.getSelectionModel().getSelectedItems().size() == listView.getItems().size());
+            };
+
+            listView.getSelectionModel().getSelectedItems().addListener(listener);
+            listView.getItems().addListener(listener);
+
             selectingToolbar.getChildren().addAll(
                     removeButton,
                     enableButton,

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DataPackListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DataPackListPageSkin.java
@@ -98,6 +98,14 @@ final class DataPackListPageSkin extends SkinBase<DataPackListPage> {
         listView = new JFXListView<>();
         filteredList = new FilteredList<>(skinnable.getItems());
 
+        // reason for not using selectAll() is that selectAll() first clears all selected then selects all, causing the toolbar to flicker
+        var selectAllButton = createToolbarButton2(i18n("button.select_all"), SVG.SELECT_ALL, () -> listView.getSelectionModel().selectRange(0, listView.getItems().size()));
+
+        ListChangeListener<Object> listener = change -> {
+            selectAllButton.setDisable(!listView.getItems().isEmpty()
+                    && listView.getSelectionModel().getSelectedItems().size() == listView.getItems().size());
+        };
+
         {
             toolbarPane = new TransitionPane();
             searchBar = new HBox();
@@ -124,16 +132,7 @@ final class DataPackListPageSkin extends SkinBase<DataPackListPage> {
             enableButton.disableProperty().bind(getSkinnable().readOnly);
             disableButton.disableProperty().bind(getSkinnable().readOnly);
 
-            // reason for not using selectAll() is that selectAll() first clears all selected then selects all, causing the toolbar to flicker
-            var selectAllButton = createToolbarButton2(i18n("button.select_all"), SVG.SELECT_ALL, () -> listView.getSelectionModel().selectRange(0, listView.getItems().size()));
-
-            ListChangeListener<Object> listener = change -> {
-                selectAllButton.setDisable(!listView.getItems().isEmpty()
-                        && listView.getSelectionModel().getSelectedItems().size() == listView.getItems().size());
-            };
-
             listView.getSelectionModel().getSelectedItems().addListener(listener);
-            listView.getItems().addListener(listener);
 
             selectingToolbar.getChildren().addAll(
                     removeButton,
@@ -195,6 +194,7 @@ final class DataPackListPageSkin extends SkinBase<DataPackListPage> {
             listView.setCellFactory(x -> new DataPackInfoListCell(listView, getSkinnable().readOnly));
             listView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
             this.listView.setItems(filteredList);
+            listView.getItems().addListener(listener);
 
             // ListViewBehavior would consume ESC pressed event, preventing us from handling it, so we ignore it here
             FXUtils.ignoreEvent(listView, KeyEvent.KEY_PRESSED, e -> e.getCode() == KeyCode.ESCAPE);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
@@ -54,7 +54,10 @@ import org.jackhuang.hmcl.ui.SVG;
 import org.jackhuang.hmcl.ui.animation.ContainerAnimations;
 import org.jackhuang.hmcl.ui.animation.TransitionPane;
 import org.jackhuang.hmcl.ui.construct.*;
-import org.jackhuang.hmcl.util.*;
+import org.jackhuang.hmcl.util.FXThread;
+import org.jackhuang.hmcl.util.Lazy;
+import org.jackhuang.hmcl.util.Pair;
+import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.i18n.I18n;
 import org.jackhuang.hmcl.util.io.CompressingUtils;
 import org.jackhuang.hmcl.util.io.FileUtils;
@@ -154,6 +157,17 @@ final class ModListPageSkin extends SkinBase<ModListPage> {
             );
 
             // Toolbar Selecting
+
+            // reason for not using selectAll() is that selectAll() first clears all selected then selects all, causing the toolbar to flicker
+            var selectAll = createToolbarButton2(i18n("button.select_all"), SVG.SELECT_ALL, () -> listView.getSelectionModel().selectRange(0, listView.getItems().size()));
+
+            listView.getSelectionModel().getSelectedItems().addListener(
+                    (ListChangeListener<Object>) change -> {
+                        selectAll.setDisable(!listView.getItems().isEmpty()
+                                && listView.getSelectionModel().getSelectedItems().size() == listView.getItems().size());
+                    }
+            );
+
             toolbarSelecting.getChildren().setAll(
                     createToolbarButton2(i18n("button.remove"), SVG.DELETE_FOREVER, () -> {
                         Controllers.confirm(i18n("button.remove.confirm"), i18n("button.remove"), () -> {
@@ -171,8 +185,7 @@ final class ModListPageSkin extends SkinBase<ModListPage> {
                                             .toList()
                             )
                     ),
-                    createToolbarButton2(i18n("button.select_all"), SVG.SELECT_ALL, () ->
-                            listView.getSelectionModel().selectAll()),
+                    selectAll,
                     createToolbarButton2(i18n("button.cancel"), SVG.CANCEL, () ->
                             listView.getSelectionModel().clearSelection())
             );

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
@@ -161,12 +161,13 @@ final class ModListPageSkin extends SkinBase<ModListPage> {
             // reason for not using selectAll() is that selectAll() first clears all selected then selects all, causing the toolbar to flicker
             var selectAll = createToolbarButton2(i18n("button.select_all"), SVG.SELECT_ALL, () -> listView.getSelectionModel().selectRange(0, listView.getItems().size()));
 
-            listView.getSelectionModel().getSelectedItems().addListener(
-                    (ListChangeListener<Object>) change -> {
-                        selectAll.setDisable(!listView.getItems().isEmpty()
-                                && listView.getSelectionModel().getSelectedItems().size() == listView.getItems().size());
-                    }
-            );
+            ListChangeListener<Object> listener = change -> {
+                selectAll.setDisable(!listView.getItems().isEmpty()
+                        && listView.getSelectionModel().getSelectedItems().size() == listView.getItems().size());
+            };
+
+            listView.getSelectionModel().getSelectedItems().addListener(listener);
+            listView.getItems().addListener(listener);
 
             toolbarSelecting.getChildren().setAll(
                     createToolbarButton2(i18n("button.remove"), SVG.DELETE_FOREVER, () -> {


### PR DESCRIPTION
- 修复模组管理点击全选会工具栏会闪烁的问题
- 在全选时禁用全选按钮