### PR TITLE
优化 DownloadPage

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/Controllers.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/Controllers.java
@@ -112,6 +112,7 @@ public final class Controllers {
         return gameListPage;
     });
     private static Lazy<RootPage> rootPage = new Lazy<>(RootPage::new);
+    private static Lazy<org.jackhuang.hmcl.ui.versions.DownloadPage> downloadVersionListPage = new Lazy<>(org.jackhuang.hmcl.ui.versions.DownloadPage::new);
     private static DecoratorController decorator;
     private static DownloadPage downloadPage;
     private static Lazy<AccountListPage> accountListPage = new Lazy<>(() -> {
@@ -135,7 +136,7 @@ public final class Controllers {
         return stage;
     }
 
-    // FXThread
+    @FXThread
     public static VersionPage getVersionPage() {
         if (versionPage == null) {
             versionPage = new VersionPage();
@@ -151,17 +152,17 @@ public final class Controllers {
         }
     }
 
-    // FXThread
+    @FXThread
     public static GameListPage getGameListPage() {
         return gameListPage.get();
     }
 
-    // FXThread
+    @FXThread
     public static RootPage getRootPage() {
         return rootPage.get();
     }
 
-    // FXThread
+    @FXThread
     public static LauncherSettingsPage getSettingsPage() {
         if (settingsPage == null) {
             settingsPage = new LauncherSettingsPage();
@@ -177,12 +178,17 @@ public final class Controllers {
         }
     }
 
-    // FXThread
+    @FXThread
     public static AccountListPage getAccountListPage() {
         return accountListPage.get();
     }
 
-    // FXThread
+    @FXThread
+    public static org.jackhuang.hmcl.ui.versions.DownloadPage getDownloadVersionListPage() {
+        return downloadVersionListPage.get();
+    }
+
+    @FXThread
     public static DownloadPage getDownloadPage() {
         if (downloadPage == null) {
             downloadPage = new DownloadPage();
@@ -198,12 +204,12 @@ public final class Controllers {
         }
     }
 
-    // FXThread
+    @FXThread
     public static Node getTerracottaPage() {
         return terracottaPage.get();
     }
 
-    // FXThread
+    @FXThread
     public static DecoratorController getDecorator() {
         return decorator;
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadListPage.java
@@ -560,8 +560,11 @@ public class DownloadListPage extends Control implements DecoratorPage, VersionP
 
                         FXUtils.onClicked(wrapper, () -> {
                             RemoteMod item = getItem();
-                            if (item != null)
-                                Controllers.navigate(new DownloadPage(getSkinnable(), item, getSkinnable().getProfileVersion(), getSkinnable().callback));
+                            if (item != null) {
+                                var page = Controllers.getDownloadVersionListPage();
+                                page.loadMod(getSkinnable(), item, getSkinnable().getProfileVersion(), getSkinnable().callback);
+                                Controllers.navigate(page);
+                            }
                         });
 
                         setPrefWidth(0);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
@@ -66,17 +66,17 @@ public class DownloadPage extends Control implements DecoratorPage {
     private final BooleanProperty loaded = new SimpleBooleanProperty(false);
     private final BooleanProperty loading = new SimpleBooleanProperty(false);
     private final BooleanProperty failed = new SimpleBooleanProperty(false);
-    private final RemoteModRepository repository;
-    private final ModTranslations translations;
-    private final RemoteMod addon;
-    private final ModTranslations.Mod mod;
-    private final Profile.ProfileVersion version;
-    private final DownloadCallback callback;
-    private final DownloadListPage page;
+    private RemoteModRepository repository;
+    private ModTranslations translations;
+    private RemoteMod addon;
+    private ModTranslations.Mod mod;
+    private Profile.ProfileVersion version;
+    private DownloadCallback callback;
+    private DownloadListPage page;
 
     private SimpleMultimap<String, RemoteMod.Version, List<RemoteMod.Version>> versions;
 
-    public DownloadPage(DownloadListPage page, RemoteMod addon, Profile.ProfileVersion version, @Nullable DownloadCallback callback) {
+    public void loadMod(DownloadListPage page, RemoteMod addon, Profile.ProfileVersion version, @Nullable DownloadCallback callback) {
         this.page = page;
         this.repository = page.repository;
         this.addon = addon;
@@ -91,7 +91,10 @@ public class DownloadPage extends Control implements DecoratorPage {
 
     private void loadModVersions() {
         setLoading(true);
+        loaded.set(false);
         setFailed(false);
+
+        versions = null;
 
         Task.supplyAsync(() -> {
             Stream<RemoteMod.Version> versions = addon.getData().loadVersions(repository, page.getDownloadProvider());
@@ -211,7 +214,10 @@ public class DownloadPage extends Control implements DecoratorPage {
             descriptionPane.setAlignment(Pos.CENTER);
             pane.getChildren().add(descriptionPane);
             descriptionPane.getStyleClass().add("card-non-transparent");
-            {
+
+            Runnable updateDescriptionPane = () -> {
+                descriptionPane.getChildren().clear();
+
                 var imageContainer = new ImageContainer(40);
                 if (StringUtils.isNotBlank(getSkinnable().addon.getIconUrl())) {
                     imageContainer.imageProperty().bind(FXUtils.newRemoteImage(getSkinnable().addon.getIconUrl(), 80, 80, true, true));
@@ -240,7 +246,10 @@ public class DownloadPage extends Control implements DecoratorPage {
                 openUrlButton.setExternalLink(getSkinnable().addon.getPageUrl());
                 descriptionPane.getChildren().add(openUrlButton);
                 openUrlButton.setMinWidth(Region.USE_PREF_SIZE);
-            }
+            };
+
+            FXUtils.onChangeAndOperate(control.loadingProperty(), loading -> updateDescriptionPane.run());
+
 
             SpinnerPane spinnerPane = new SpinnerPane();
             VBox.setVgrow(spinnerPane, Priority.ALWAYS);
@@ -266,8 +275,8 @@ public class DownloadPage extends Control implements DecoratorPage {
                 spinnerPane.setContent(scrollPane);
 
                 FXUtils.onChangeAndOperate(control.loaded, loaded -> {
-                    if (control.versions == null) return;
-
+                    if (control.versions == null || !loaded) return;
+                    list.getContent().clear();
                     if (control.version.getProfile() != null && control.version.getVersion() != null) {
                         HMCLGameRepository repository = control.version.getProfile().getRepository();
                         Version game = repository.getResolvedPreservingPatchesVersion(control.version.getVersion());
@@ -374,7 +383,9 @@ public class DownloadPage extends Control implements DecoratorPage {
             RipplerContainer container = new RipplerContainer(pane);
             FXUtils.onClicked(container, () -> {
                 fireEvent(new DialogCloseEvent());
-                Controllers.navigate(new DownloadPage(page, addon, version, callback));
+                var downloadPage = new DownloadPage();
+                downloadPage.loadMod(page, addon, version, callback);
+                Controllers.navigate(downloadPage);
             });
             getChildren().setAll(container);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
@@ -54,7 +54,10 @@ import org.jackhuang.hmcl.ui.SVG;
 import org.jackhuang.hmcl.ui.animation.ContainerAnimations;
 import org.jackhuang.hmcl.ui.animation.TransitionPane;
 import org.jackhuang.hmcl.ui.construct.*;
-import org.jackhuang.hmcl.util.*;
+import org.jackhuang.hmcl.util.FXThread;
+import org.jackhuang.hmcl.util.Lazy;
+import org.jackhuang.hmcl.util.Pair;
+import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.i18n.I18n;
 import org.jackhuang.hmcl.util.io.CompressingUtils;
 import org.jackhuang.hmcl.util.io.FileUtils;
@@ -490,12 +493,12 @@ final class ModListPageSkin extends SkinBase<ModListPage> {
 
                                 button.setOnAction(e -> {
                                     fireEvent(new DialogCloseEvent());
-                                    Controllers.navigate(new DownloadPage(
-                                            repository instanceof CurseForgeRemoteModRepository ? HMCLLocalizedDownloadListPage.ofCurseForgeMod(null, false) : HMCLLocalizedDownloadListPage.ofModrinthMod(null, false),
+                                    var page = Controllers.getDownloadVersionListPage();
+                                    page.loadMod(repository instanceof CurseForgeRemoteModRepository ? HMCLLocalizedDownloadListPage.ofCurseForgeMod(null, false) : HMCLLocalizedDownloadListPage.ofModrinthMod(null, false),
                                             remoteMod,
                                             new Profile.ProfileVersion(ModListPageSkin.this.getSkinnable().getProfile(), ModListPageSkin.this.getSkinnable().getInstanceId()),
-                                            (downloadProvider, profile, version, mod, file) -> org.jackhuang.hmcl.ui.download.DownloadPage.download(downloadProvider, profile, version, file, "mods")
-                                    ));
+                                            (downloadProvider, profile, version, mod, file) -> org.jackhuang.hmcl.ui.download.DownloadPage.download(downloadProvider, profile, version, file, "mods"));
+                                    Controllers.navigate(page);
                                 });
                                 button.setDisable(false);
                             });


### PR DESCRIPTION
- 在下载列表、模组列表中跳转时，使用 Singleton
- 在模组下载弹窗中以“依赖项”/“可选”等项目跳转时，创建新实例