### PR TITLE
fix: JFXDialog 弹窗过程中模糊

### DIFF
--- a/HMCL/src/main/java/com/jfoenix/controls/JFXDialog.java
+++ b/HMCL/src/main/java/com/jfoenix/controls/JFXDialog.java
@@ -375,6 +375,10 @@ public class JFXDialog extends StackPane {
         @Override
         protected void starting() {
         }
+
+        @Override
+        protected void stopping() {
+        }
     }
 
     /***************************************************************************


### PR DESCRIPTION
resolves #5073 
这样禁用缓存可能会出现一些性能问题，但在我的设备上没什么区别
https://github.com/user-attachments/assets/4cb523ff-3b92-4aa6-881b-948955bbf151

