### PR TITLE
[Bugfix] 修复 HMCL 在 1.20.1 neoforge 环境下将部分 forge 模组识别为 MixinExtras 的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modinfo/ForgeNewModMetadata.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modinfo/ForgeNewModMetadata.java
@@ -333,7 +333,8 @@ public final class ForgeNewModMetadata {
         }
 
         if (result != null) {
-            if (result != loader) LOG.warning("Loader mismatch for mod " + modID + ", found " + result + ", expecting " + loader);
+            if (result != loader)
+                LOG.warning("Loader mismatch for mod " + modID + ", found " + result + ", expecting " + loader);
             return result;
         } else {
             LOG.warning("Cannot determine the mod loader for mod " + modID + ", expected " + loader);


### PR DESCRIPTION
Fixes #5329

思路：使用 neoforge 的元数据加载器读取 forge 模组时，不再抛出异常，而是正常读取为 forge mod，由 `ModListPage` 处理 neoforge 和 forge 的兼容性检查