### PR TITLE
[Bugfix] 修复 HMCL 下载游戏内容时出现空游戏版本条目的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
@@ -273,7 +273,7 @@ public class DownloadPage extends Control implements DecoratorPage {
                         Version game = repository.getResolvedPreservingPatchesVersion(control.version.getVersion());
                         String gameVersion = repository.getGameVersion(game).orElse(null);
 
-                        if (gameVersion != null) {
+                        if (gameVersion != null && control.versions.containsKey(gameVersion)) {
                             List<RemoteMod.Version> modVersions = control.versions.get(gameVersion);
                             if (modVersions != null && !modVersions.isEmpty()) {
                                 Set<ModLoaderType> targetLoaders = LibraryAnalyzer.analyze(game, gameVersion).getModLoaders();


### PR DESCRIPTION
Fixes #5894 