### PR TITLE
优化 ComboBox 展开图标

### DIFF
--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -1482,6 +1482,11 @@
     -fx-max-width: 1000000000;
 }
 
+.jfx-combo-box .arrow {
+    -fx-background-color: -monet-on-surface;
+    -fx-shape: "M12 15 7 10H17L12 15Z";
+}
+
 .jfx-combo-box .text {
     -fx-fill: -monet-on-surface;
 }

--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -1483,7 +1483,7 @@
 }
 
 .jfx-combo-box .arrow {
-    -fx-background-color: -monet-on-surface;
+    -fx-background-color: -monet-on-surface-variant;
     -fx-shape: "M12 15 7 10H17L12 15Z";
 }
 


### PR DESCRIPTION
<img width="1227" height="762" alt="image" src="https://github.com/user-attachments/assets/b1b904d3-cd6e-40e5-83af-48b2bdcf1b24" />
原来的图标在深色模式观感太差了
