### PR TITLE
feat:添加窗口拖动限制 [重启]

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorSkin.java
@@ -25,11 +25,14 @@ import javafx.animation.Timeline;
 import javafx.beans.InvalidationListener;
 import javafx.beans.WeakInvalidationListener;
 import javafx.beans.binding.Bindings;
+import javafx.beans.value.ObservableBooleanValue;
 import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
 import javafx.geometry.Bounds;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.geometry.Rectangle2D;
 import javafx.scene.Cursor;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
@@ -41,6 +44,7 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.*;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
 
 import javafx.util.Duration;
@@ -54,6 +58,8 @@ import org.jackhuang.hmcl.ui.animation.TransitionPane;
 import org.jackhuang.hmcl.ui.wizard.Navigation;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
+import java.util.Objects;
+
 public class DecoratorSkin extends SkinBase<Decorator> {
     private final StackPane root, parent;
     private final StackPane titleContainer;
@@ -65,6 +71,8 @@ public class DecoratorSkin extends SkinBase<Decorator> {
     private final EventHandler<MouseEvent> onTitleBarDoubleClick;
 
     private double mouseInitX, mouseInitY, stageInitX, stageInitY, stageInitWidth, stageInitHeight;
+    private final ObservableBooleanValue isDisplayScalingUniform;
+    private Rectangle2D currentMouseVisualBounds;
 
     /**
      * Constructor for all SkinBase instances.
@@ -93,6 +101,12 @@ public class DecoratorSkin extends SkinBase<Decorator> {
         parent.setClip(clip);
 
         skinnable.getSnackbar().registerSnackbarContainer(parent);
+
+        ObservableList<Screen> screens = Screen.getScreens();
+        isDisplayScalingUniform = Bindings.createBooleanBinding(() -> {
+            Screen firstScreen = screens.get(0);
+            return screens.stream().allMatch(screen -> Objects.equals(firstScreen.getOutputScaleX(), screen.getOutputScaleX()) && Objects.equals(firstScreen.getOutputScaleY(), screen.getOutputScaleY()));
+        }, screens);
 
         EventHandler<MouseEvent> onMouseReleased = this::onMouseReleased;
         EventHandler<MouseEvent> onMouseDragged = this::onMouseDragged;
@@ -470,8 +484,17 @@ public class DecoratorSkin extends SkinBase<Decorator> {
         Cursor cursor = root.getCursor();
         if (getSkinnable().isAllowMove()) {
             if (cursor == Cursor.DEFAULT) {
-                primaryStage.setX(stageInitX + dx);
-                primaryStage.setY(stageInitY + dy);
+                if (!isDisplayScalingUniform.get()) {
+                    primaryStage.setX(stageInitX + dx);
+                    primaryStage.setY(stageInitY + dy);
+                } else {
+                    if (currentMouseVisualBounds == null || !currentMouseVisualBounds.contains(mouseEvent.getScreenX(), mouseEvent.getScreenY())) {
+                        currentMouseVisualBounds = Screen.getScreensForRectangle(new Rectangle2D(mouseEvent.getScreenX(), mouseEvent.getScreenY(), 1, 1)).get(0).getVisualBounds();
+                    }
+                    primaryStage.setX(stageInitX + dx);
+                    primaryStage.setY(Math.max(Math.min(stageInitY + dy, currentMouseVisualBounds.getMaxY() - titleContainer.getHeight()), currentMouseVisualBounds.getMinY() - titleContainer.getHeight()));
+
+                }
                 mouseEvent.consume();
             }
         }


### PR DESCRIPTION
从 #4664 中重启

现在HMCL标题栏不会被拖动到任务栏位置而隐藏到任务栏下方导致无法被拖动
仅在单显示器或多显示器但所有显示器的DPI缩放一致时启用这个功能

需要帮助测试在其它操作系统上是否有意外的行为


https://github.com/user-attachments/assets/c0262845-b8b2-4f27-b125-4e9645b162d0

