### PR TITLE
fix: 模组名字过长导致下载页面布局异常

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
@@ -147,6 +147,10 @@ public class TwoLineListItem extends VBox {
         subtitleProperty().set(subtitle);
     }
 
+    public HBox getFirstLine() {
+        return firstLine;
+    }
+
     public Label getTitleLabel() {
         return lblTitle;
     }
@@ -168,6 +172,7 @@ public class TwoLineListItem extends VBox {
             Bindings.bindContent(tagsBox.getChildren(), tags);
 
             var scrollPane = new ScrollPane(tagsBox);
+            scrollPane.setMinSize(0, 0);
             HBox.setHgrow(scrollPane, Priority.ALWAYS);
             lblTitle.setMinWidth(Label.USE_PREF_SIZE);
             scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
@@ -227,6 +227,7 @@ public class DownloadPage extends Control implements DecoratorPage {
                 getSkinnable().addon.getCategories().stream()
                         .map(category -> getSkinnable().page.getLocalizedCategory(category))
                         .forEach(content::addTag);
+                content.getTitleLabel().setMinWidth(0);
                 descriptionPane.getChildren().add(content);
 
                 if (getSkinnable().mod != null) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
@@ -227,7 +227,7 @@ public class DownloadPage extends Control implements DecoratorPage {
                 getSkinnable().addon.getCategories().stream()
                         .map(category -> getSkinnable().page.getLocalizedCategory(category))
                         .forEach(content::addTag);
-                content.getTitleLabel().setMinWidth(0);
+                content.getFirstLine().setMinWidth(0);
                 descriptionPane.getChildren().add(content);
 
                 if (getSkinnable().mod != null) {


### PR DESCRIPTION
例：C2ME
<img width="818" height="508" alt="348631861d924534ea828928a3c27970" src="https://github.com/user-attachments/assets/02716fad-5839-4dd6-baeb-e5588026e201" />
