### PR TITLE
fix: 下载页面标签显示未进行 `shouldDisplayCategory` 判断

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
@@ -225,6 +225,7 @@ public class DownloadPage extends Control implements DecoratorPage {
                 content.setSubtitle(getSkinnable().addon.getDescription());
                 content.getSubtitleLabel().setWrapText(true);
                 getSkinnable().addon.getCategories().stream()
+                        .filter(category -> getSkinnable().page.shouldDisplayCategory(category))
                         .map(category -> getSkinnable().page.getLocalizedCategory(category))
                         .forEach(content::addTag);
                 descriptionPane.getChildren().add(content);


### PR DESCRIPTION
<img width="1227" height="762" alt="image" src="https://github.com/user-attachments/assets/0c1b802a-cd41-49ce-bd23-3648d5490d1a" />
表现：Modrinth源所有资源包都有多余的 “Minecraft” 标签，且该标签在搜索页面也是不可见的