### PR TITLE
清理 DecoratorSkin 冗余 separator

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorSkin.java
@@ -353,12 +353,7 @@ public class DecoratorSkin extends SkinBase<Decorator> {
                 refreshNavButton.onActionProperty().bind(skinnable.onRefreshNavButtonActionProperty());
                 skinnable.forbidDraggingWindow(refreshNavButton);
 
-                Rectangle separator = new Rectangle();
-                separator.visibleProperty().bind(refreshNavButton.visibleProperty());
-                separator.heightProperty().bind(navBar.heightProperty());
-                separator.setFill(Color.GRAY);
-
-                navRight.getChildren().setAll(refreshNavButton, separator);
+                navRight.getChildren().setAll(refreshNavButton);
                 navBar.setRight(navRight);
             }
         }


### PR DESCRIPTION
这个 `separator` 在加入之后一直没有正常显示过（`Rectangle` 的默认 `width` 是 0，如果想要显示需要显式调用 `setWidth`）
且即使通过 `setWidth(1)` 设置后，出现时看上去是闪现出来的，看上去非常突兀