### PR TITLE
上传微软账户皮肤时校验大小

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItem.java
@@ -137,8 +137,8 @@ public class AccountListItem extends RadioButton {
      */
     @Nullable
     public Task<?> uploadSkin() {
-        if (account instanceof OfflineAccount) {
-            Controllers.dialog(new OfflineAccountSkinPane((OfflineAccount) account));
+        if (account instanceof OfflineAccount offlineAccount) {
+            Controllers.dialog(new OfflineAccountSkinPane(offlineAccount));
             return null;
         }
         if (!account.canUploadSkin()) {
@@ -163,6 +163,9 @@ public class AccountListItem extends RadioButton {
                     }
                     if (skinImg.isError()) {
                         throw new InvalidSkinException("Failed to read skin image", skinImg.getException());
+                    }
+                    if (skinImg.getWidth() != 64 || (skinImg.getHeight() != 32 && skinImg.getHeight() != 64)) {
+                        throw new InvalidSkinException("Invalid skin size");
                     }
                     NormalizedSkin skin = new NormalizedSkin(skinImg);
                     String model = skin.isSlim() ? "slim" : "";

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItem.java
@@ -137,8 +137,8 @@ public class AccountListItem extends RadioButton {
      */
     @Nullable
     public Task<?> uploadSkin() {
-        if (account instanceof OfflineAccount offlineAccount) {
-            Controllers.dialog(new OfflineAccountSkinPane(offlineAccount));
+        if (account instanceof OfflineAccount) {
+            Controllers.dialog(new OfflineAccountSkinPane((OfflineAccount) account));
             return null;
         }
         if (!account.canUploadSkin()) {


### PR DESCRIPTION
微软账户上传皮肤仅支持 64x64 与 64x32 大小（`new NormalizedSkin(skinImg)` 不会报错因为 `NormalizedSkin` 支持 128x 皮肤）