### PR TITLE
feat: modrinth loader tag aggregate display

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java
@@ -24,11 +24,7 @@ import org.jackhuang.hmcl.mod.LocalModFile;
 import org.jackhuang.hmcl.mod.ModLoaderType;
 import org.jackhuang.hmcl.mod.RemoteMod;
 import org.jackhuang.hmcl.mod.RemoteModRepository;
-import org.jackhuang.hmcl.util.DigestUtils;
-import org.jackhuang.hmcl.util.Immutable;
-import org.jackhuang.hmcl.util.Lang;
-import org.jackhuang.hmcl.util.Pair;
-import org.jackhuang.hmcl.util.StringUtils;
+import org.jackhuang.hmcl.util.*;
 import org.jackhuang.hmcl.util.gson.JsonUtils;
 import org.jackhuang.hmcl.util.io.HttpRequest;
 import org.jackhuang.hmcl.util.io.NetworkUtils;
@@ -44,7 +40,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -65,43 +60,40 @@ public final class ModrinthRemoteModRepository implements RemoteModRepository {
     public static final ModrinthRemoteModRepository RESOURCE_PACKS = new ModrinthRemoteModRepository("resourcepack");
     public static final ModrinthRemoteModRepository SHADER_PACKS = new ModrinthRemoteModRepository("shader");
 
-    private static final List<String> LOADER_TAG_ORDER = List.of(
-            "babric",
-            "bta-babric",
-            "bukkit",
-            "bungeecord",
-            "canvas",
-            "datapack",
-            "fabric",
-            "folia",
-            "forge",
-            "geyser",
-            "iris",
-            "java-agent",
-            "legacy-fabric",
-            "liteloader",
-            "minecraft",
-            "modloader",
-            "mrpack",
-            "neoforge",
-            "nilloader",
-            "optifine",
-            "ornith",
-            "paper",
-            "purpur",
-            "quilt",
-            "rift",
-            "spigot",
-            "sponge",
-            "vanilla",
-            "velocity",
-            "waterfall"
+    private static final Comparator<String> TAG_COMPARATOR = PriorityComparator.of(
+            List.of("babric",
+                    "bta-babric",
+                    "bukkit",
+                    "bungeecord",
+                    "canvas",
+                    "datapack",
+                    "fabric",
+                    "folia",
+                    "forge",
+                    "geyser",
+                    "iris",
+                    "java-agent",
+                    "legacy-fabric",
+                    "liteloader",
+                    "minecraft",
+                    "modloader",
+                    "mrpack",
+                    "neoforge",
+                    "nilloader",
+                    "optifine",
+                    "ornith",
+                    "paper",
+                    "purpur",
+                    "quilt",
+                    "rift",
+                    "spigot",
+                    "sponge",
+                    "vanilla",
+                    "velocity",
+                    "waterfall"),
+            Comparator.naturalOrder(),
+            false
     );
-
-    private static final Map<String, Integer> LOADER_TAG_PRIORITIES = createLoaderTagPriorities();
-    private static final Comparator<String> DISPLAY_CATEGORY_COMPARATOR = Comparator
-            .comparingInt(ModrinthRemoteModRepository::getLoaderTagPriority)
-            .reversed();
 
     private static final Semaphore SEMAPHORE = new Semaphore(16);
 
@@ -135,27 +127,10 @@ public final class ModrinthRemoteModRepository implements RemoteModRepository {
         }
     }
 
-    private static Map<String, Integer> createLoaderTagPriorities() {
-        Map<String, Integer> priorities = new HashMap<>();
-        for (int i = 0; i < LOADER_TAG_ORDER.size(); i++) {
-            priorities.put(LOADER_TAG_ORDER.get(i), i);
-        }
-        return priorities;
-    }
-
-    private static int getLoaderTagPriority(String category) {
-        return LOADER_TAG_PRIORITIES.getOrDefault(category, Integer.MAX_VALUE);
-    }
-
     static List<String> sortDisplayCategories(List<String> displayCategories) {
-        if (displayCategories.isEmpty()) {
-            return displayCategories;
-        }
-
-        List<String> sortedDisplayCategories = new ArrayList<>(displayCategories);
-        
-        sortedDisplayCategories.sort(DISPLAY_CATEGORY_COMPARATOR);
-        return sortedDisplayCategories;
+        return displayCategories != null && !displayCategories.isEmpty()
+                ? displayCategories.stream().sorted(TAG_COMPARATOR).toList()
+                : List.of();
     }
 
     @Override

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java
@@ -42,7 +42,9 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -62,6 +64,44 @@ public final class ModrinthRemoteModRepository implements RemoteModRepository {
     public static final ModrinthRemoteModRepository MODPACKS = new ModrinthRemoteModRepository("modpack");
     public static final ModrinthRemoteModRepository RESOURCE_PACKS = new ModrinthRemoteModRepository("resourcepack");
     public static final ModrinthRemoteModRepository SHADER_PACKS = new ModrinthRemoteModRepository("shader");
+
+    private static final List<String> LOADER_TAG_ORDER = List.of(
+            "babric",
+            "bta-babric",
+            "bukkit",
+            "bungeecord",
+            "canvas",
+            "datapack",
+            "fabric",
+            "folia",
+            "forge",
+            "geyser",
+            "iris",
+            "java-agent",
+            "legacy-fabric",
+            "liteloader",
+            "minecraft",
+            "modloader",
+            "mrpack",
+            "neoforge",
+            "nilloader",
+            "optifine",
+            "ornith",
+            "paper",
+            "purpur",
+            "quilt",
+            "rift",
+            "spigot",
+            "sponge",
+            "vanilla",
+            "velocity",
+            "waterfall"
+    );
+
+    private static final Map<String, Integer> LOADER_TAG_PRIORITIES = createLoaderTagPriorities();
+    private static final Comparator<String> DISPLAY_CATEGORY_COMPARATOR = Comparator
+            .comparingInt(ModrinthRemoteModRepository::getLoaderTagPriority)
+            .reversed();
 
     private static final Semaphore SEMAPHORE = new Semaphore(16);
 
@@ -93,6 +133,29 @@ public final class ModrinthRemoteModRepository implements RemoteModRepository {
             default:
                 throw new IllegalArgumentException("Unsupported sort type " + sortType);
         }
+    }
+
+    private static Map<String, Integer> createLoaderTagPriorities() {
+        Map<String, Integer> priorities = new HashMap<>();
+        for (int i = 0; i < LOADER_TAG_ORDER.size(); i++) {
+            priorities.put(LOADER_TAG_ORDER.get(i), i);
+        }
+        return priorities;
+    }
+
+    private static int getLoaderTagPriority(String category) {
+        return LOADER_TAG_PRIORITIES.getOrDefault(category, Integer.MAX_VALUE);
+    }
+
+    static List<String> sortDisplayCategories(List<String> displayCategories) {
+        if (displayCategories.isEmpty()) {
+            return displayCategories;
+        }
+
+        List<String> sortedDisplayCategories = new ArrayList<>(displayCategories);
+        
+        sortedDisplayCategories.sort(DISPLAY_CATEGORY_COMPARATOR);
+        return sortedDisplayCategories;
     }
 
     @Override
@@ -811,7 +874,7 @@ public final class ModrinthRemoteModRepository implements RemoteModRepository {
                     author,
                     title,
                     description,
-                    displayCategories,
+                    sortDisplayCategories(displayCategories),
                     String.format("https://modrinth.com/%s/%s", projectType, projectId),
                     iconUrl,
                     this

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/PriorityComparator.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/PriorityComparator.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.util;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.*;
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/PriorityComparator.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/PriorityComparator.java
@@ -1,0 +1,98 @@
+/*
+ * Hello Minecraft! Launcher
+ * Copyright (C) 2026 huangyuhui <huanghongxun2008@126.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.jackhuang.hmcl.util;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Unmodifiable;
+
+import java.util.*;
+
+/// A comparator that orders elements based on a predefined priority map,
+/// falling back to another comparator for elements not present in the map.
+///
+/// Elements found in the priority map are compared by their associated priority values.
+/// When only one of the two elements has a priority, the `prioritizedFirst` flag
+/// determines whether the prioritized element is ordered before or after the other.
+///
+/// @param <T> the type of elements to be compared
+public final class PriorityComparator<T> implements Comparator<T> {
+
+    /// Creates a new `PriorityComparator` with a priority map and a fallback comparator.
+    /// Elements with a defined priority are ordered before those without.
+    public static <T extends Comparable<T>> PriorityComparator<T> of(T... values) {
+        Map<T, Integer> priorities = new HashMap<>();
+        for (int i = 0; i < values.length; i++)
+            priorities.put(values[i], i);
+        return new PriorityComparator<>(priorities, Comparator.naturalOrder(), true);
+    }
+
+    /// Creates a new `PriorityComparator` with a priority map, a fallback comparator, and a flag to determine the order of prioritized elements.
+    /// Elements with a defined priority are ordered before those without if `prioritizedFirst` is `true`, otherwise they are ordered after.
+    public static <T> PriorityComparator<T> of(List<T> values, Comparator<? super T> fallback, boolean prioritizedFirst) {
+        Objects.requireNonNull(fallback);
+
+        Map<T, Integer> priorities = new HashMap<>();
+        for (int i = 0; i < values.size(); i++)
+            priorities.put(values.get(i), i);
+        return new PriorityComparator<>(priorities, fallback, prioritizedFirst);
+    }
+
+    /// A mapping from values to their priority. Lower values indicate higher priority.
+    private final @NotNull Map<T, Integer> priorities;
+
+    /// The fallback comparator used when neither element has a defined priority.
+    private final @NotNull Comparator<? super T> fallback;
+
+    /// If `true`, elements with a defined priority are ordered before those without;
+    /// if `false`, they are ordered after.
+    private final boolean prioritizedFirst;
+
+    /// Creates a new `PriorityComparator`.
+    ///
+    /// @param priorities       a map from values to their priority (lower value = higher priority)
+    /// @param fallback         the comparator to use when neither element has a defined priority
+    /// @param prioritizedFirst if `true`, prioritized elements come before non-prioritized ones
+    private PriorityComparator(
+            Map<T, Integer> priorities,
+            Comparator<? super T> fallback,
+            boolean prioritizedFirst) {
+        this.priorities = priorities;
+        this.fallback = fallback;
+        this.prioritizedFirst = prioritizedFirst;
+    }
+
+    @Override
+    public int compare(T value1, T value2) {
+        Integer p1 = priorities.get(value1);
+        Integer p2 = priorities.get(value2);
+
+        if (p1 != null) {
+            if (p2 != null) {
+                return p1.compareTo(p2);
+            }
+
+            return prioritizedFirst ? -1 : 1;
+        } else {
+            if (p2 != null) {
+                return prioritizedFirst ? 1 : -1;
+            } else {
+                return fallback.compare(value1, value2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<img width="1023" height="635" alt="image" src="https://github.com/user-attachments/assets/5eea187b-2823-4cd5-ab5a-fe6f3f75793d" />

将 Modrinth 的 Loader 统一置后显示，而不是杂乱地分布在 tag 中间