### PR TITLE
使用 jwebp 代替 TwelveMonkeys 加载 WebP 图像

### DIFF
--- a/HMCL/build.gradle.kts
+++ b/HMCL/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     implementation(project(":HMCLCore"))
     implementation(project(":HMCLBoot"))
     implementation("libs:JFoenix")
-    implementation(libs.javafx.webp)
+    implementation(libs.jwebp)
     implementation(libs.fxsvgimage)
     implementation(libs.java.info)
     implementation(libs.monet.fx)

--- a/HMCL/build.gradle.kts
+++ b/HMCL/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     implementation(project(":HMCLCore"))
     implementation(project(":HMCLBoot"))
     implementation("libs:JFoenix")
-    implementation(libs.twelvemonkeys.imageio.webp)
+    implementation(libs.javafx.webp)
     implementation(libs.fxsvgimage)
     implementation(libs.java.info)
     implementation(libs.monet.fx)

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/image/ImageUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/image/ImageUtils.java
@@ -28,7 +28,7 @@ import org.girod.javafx.svgimage.LoaderParameters;
 import org.girod.javafx.svgimage.SVGImage;
 import org.girod.javafx.svgimage.SVGLoader;
 import org.girod.javafx.svgimage.ScaleQuality;
-import org.glavo.webp.WebPDecoder;
+import org.glavo.webp.WebPImage;
 import org.glavo.webp.WebPImageLoadOptions;
 import org.glavo.webp.javafx.WebPFXImage;
 import org.jackhuang.hmcl.task.Schedulers;
@@ -69,7 +69,7 @@ public final class ImageUtils {
 
     public static final ImageLoader WEBP = (input, requestedWidth, requestedHeight, preserveRatio, smooth) -> {
         var options = new WebPImageLoadOptions(requestedWidth, requestedHeight, preserveRatio, smooth);
-        return new WebPFXImage(WebPDecoder.decodeAll(input, options));
+        return new WebPFXImage(WebPImage.read(input, options));
     };
 
     public static final ImageLoader SVG = (input, requestedWidth, requestedHeight, preserveRatio, smooth) -> {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/image/ImageUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/image/ImageUtils.java
@@ -42,13 +42,8 @@ import org.jackhuang.hmcl.ui.image.apng.chunks.PngFrameControl;
 import org.jackhuang.hmcl.ui.image.apng.error.PngException;
 import org.jackhuang.hmcl.ui.image.apng.error.PngIntegrityException;
 import org.jackhuang.hmcl.ui.image.internal.AnimationImageImpl;
-import org.jackhuang.hmcl.util.SwingFXUtils;
 import org.jetbrains.annotations.Nullable;
 
-import javax.imageio.ImageIO;
-import javax.imageio.ImageReader;
-import javax.imageio.stream.ImageInputStream;
-import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/image/ImageUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/image/ImageUtils.java
@@ -17,7 +17,6 @@
  */
 package org.jackhuang.hmcl.ui.image;
 
-import com.twelvemonkeys.imageio.plugins.webp.WebPImageReaderSpi;
 import javafx.animation.Timeline;
 import javafx.application.Platform;
 import javafx.scene.SnapshotParameters;
@@ -29,6 +28,11 @@ import org.girod.javafx.svgimage.LoaderParameters;
 import org.girod.javafx.svgimage.SVGImage;
 import org.girod.javafx.svgimage.SVGLoader;
 import org.girod.javafx.svgimage.ScaleQuality;
+import org.glavo.javafx.webp.LoopCount;
+import org.glavo.javafx.webp.WebPDecoder;
+import org.glavo.javafx.webp.WebPFrame;
+import org.glavo.javafx.webp.WebPImage;
+import org.glavo.javafx.webp.WebPImageLoadOptions;
 import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.ui.image.apng.Png;
 import org.jackhuang.hmcl.ui.image.apng.argb8888.Argb8888Bitmap;
@@ -71,17 +75,38 @@ public final class ImageUtils {
     };
 
     public static final ImageLoader WEBP = (input, requestedWidth, requestedHeight, preserveRatio, smooth) -> {
-        WebPImageReaderSpi spi = new WebPImageReaderSpi();
-        ImageReader reader = spi.createReaderInstance(null);
-        BufferedImage bufferedImage;
-        try (ImageInputStream imageInput = ImageIO.createImageInputStream(input)) {
-            reader.setInput(imageInput, true, true);
-            bufferedImage = reader.read(0, reader.getDefaultReadParam());
-        } finally {
-            reader.dispose();
+
+        WebPImage image = WebPDecoder.decodeAll(input, WebPImageLoadOptions.builder()
+                .requestedWidth(requestedWidth)
+                .requestedHeight(requestedHeight)
+                .preserveRatio(preserveRatio)
+                .smooth(smooth)
+                .build());
+
+        if (image.isAnimated()) {
+
+            List<WebPFrame> frames = image.getFrames();
+
+            int[][] framePixels = new int[frames.size()][];
+            int[] durations = new int[framePixels.length];
+
+            for (int frameIndex = 0; frameIndex < frames.size(); frameIndex++) {
+                WebPFrame frame = frames.get(frameIndex);
+                framePixels[frameIndex] = rgbaToArgb(frame.getPixels());
+                durations[frameIndex] = frame.getDurationMillis();
+            }
+
+            LoopCount loopCount = image.getLoopCount();
+            int cycleCount = loopCount.isForever() ? Timeline.INDEFINITE : loopCount.getRepetitions();
+
+            return new AnimationImageImpl(image.getWidth(), image.getHeight(),
+                    framePixels, durations, cycleCount);
+        } else {
+            return image.getFirstFrame().orElseThrow().toWritableImage();
         }
-        return SwingFXUtils.toFXImage(bufferedImage, requestedWidth, requestedHeight, preserveRatio, smooth);
     };
+
+
 
     public static final ImageLoader SVG = (input, requestedWidth, requestedHeight, preserveRatio, smooth) -> {
         String content = new String(input.readAllBytes(), StandardCharsets.UTF_8);
@@ -466,6 +491,19 @@ public final class ImageUtils {
             return new AnimationImageImpl(targetWidth, targetHeight, framePixels, durations, cycleCount);
         else
             return new AnimationImageImpl(width, height, framePixels, durations, cycleCount);
+    }
+
+    private static int[] rgbaToArgb(ByteBuffer rgba) {
+        int pixelCount = rgba.remaining() / 4;
+        int[] argb = new int[pixelCount];
+        for (int i = 0; i < pixelCount; i++) {
+            int r = rgba.get() & 0xFF;
+            int g = rgba.get() & 0xFF;
+            int b = rgba.get() & 0xFF;
+            int a = rgba.get() & 0xFF;
+            argb[i] = (a << 24) | (r << 16) | (g << 8) | b;
+        }
+        return argb;
     }
 
     private ImageUtils() {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/image/ImageUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/image/ImageUtils.java
@@ -28,11 +28,9 @@ import org.girod.javafx.svgimage.LoaderParameters;
 import org.girod.javafx.svgimage.SVGImage;
 import org.girod.javafx.svgimage.SVGLoader;
 import org.girod.javafx.svgimage.ScaleQuality;
-import org.glavo.javafx.webp.LoopCount;
-import org.glavo.javafx.webp.WebPDecoder;
-import org.glavo.javafx.webp.WebPFrame;
-import org.glavo.javafx.webp.WebPImage;
-import org.glavo.javafx.webp.WebPImageLoadOptions;
+import org.glavo.webp.WebPDecoder;
+import org.glavo.webp.WebPImageLoadOptions;
+import org.glavo.webp.javafx.WebPFXImage;
 import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.ui.image.apng.Png;
 import org.jackhuang.hmcl.ui.image.apng.argb8888.Argb8888Bitmap;
@@ -70,38 +68,9 @@ public final class ImageUtils {
     };
 
     public static final ImageLoader WEBP = (input, requestedWidth, requestedHeight, preserveRatio, smooth) -> {
-
-        WebPImage image = WebPDecoder.decodeAll(input, WebPImageLoadOptions.builder()
-                .requestedWidth(requestedWidth)
-                .requestedHeight(requestedHeight)
-                .preserveRatio(preserveRatio)
-                .smooth(smooth)
-                .build());
-
-        if (image.isAnimated()) {
-
-            List<WebPFrame> frames = image.getFrames();
-
-            int[][] framePixels = new int[frames.size()][];
-            int[] durations = new int[framePixels.length];
-
-            for (int frameIndex = 0; frameIndex < frames.size(); frameIndex++) {
-                WebPFrame frame = frames.get(frameIndex);
-                framePixels[frameIndex] = rgbaToArgb(frame.getPixels());
-                durations[frameIndex] = frame.getDurationMillis();
-            }
-
-            LoopCount loopCount = image.getLoopCount();
-            int cycleCount = loopCount.isForever() ? Timeline.INDEFINITE : loopCount.getRepetitions();
-
-            return new AnimationImageImpl(image.getWidth(), image.getHeight(),
-                    framePixels, durations, cycleCount);
-        } else {
-            return image.getFirstFrame().orElseThrow().toWritableImage();
-        }
+        var options = new WebPImageLoadOptions(requestedWidth, requestedHeight, preserveRatio, smooth);
+        return new WebPFXImage(WebPDecoder.decodeAll(input, options));
     };
-
-
 
     public static final ImageLoader SVG = (input, requestedWidth, requestedHeight, preserveRatio, smooth) -> {
         String content = new String(input.readAllBytes(), StandardCharsets.UTF_8);

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,6 @@ hello-nbt = "0.3.0"
 nanohttpd = "2.3.1"
 jsoup = "1.21.2"
 chardet = "2.5.0"
-twelvemonkeys = "3.13.1"
 fxsvgimage = "1.3"
 jna = "5.18.1"
 pci-ids = "0.4.0"
@@ -23,6 +22,7 @@ lwjgl-unsafe-agent = "2.0"
 monet-fx = "0.4.0"
 terracotta = "0.4.2"
 nayuki-qrcodegen = "1.8.0"
+javafx-webp = "4f0dfc2b28"
 
 # testing
 junit = "6.0.1"
@@ -47,7 +47,6 @@ hello-nbt = { module = "org.glavo:HelloNBT", version.ref = "hello-nbt" }
 nanohttpd = { module = "org.nanohttpd:nanohttpd", version.ref = "nanohttpd" }
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 chardet = { module = "org.glavo:chardet", version.ref = "chardet" }
-twelvemonkeys-imageio-webp = { module = "com.twelvemonkeys.imageio:imageio-webp", version.ref = "twelvemonkeys" }
 fxsvgimage = { module = "com.github.hervegirod:fxsvgimage", version.ref = "fxsvgimage" }
 jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 jna-platform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }
@@ -57,6 +56,7 @@ authlib-injector = { module = "org.glavo.hmcl:authlib-injector", version.ref = "
 lwjgl-unsafe-agent = { module = "org.glavo:lwjgl-unsafe-agent", version.ref = "lwjgl-unsafe-agent" }
 monet-fx = { module = "org.glavo:MonetFX", version.ref = "monet-fx" }
 nayuki-qrcodegen = { module = "io.nayuki:qrcodegen", version.ref = "nayuki-qrcodegen" }
+javafx-webp = { module = "com.github.Glavo:javafx-webp", version.ref = "javafx-webp" }
 
 # testing
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ lwjgl-unsafe-agent = "2.0"
 monet-fx = "0.4.0"
 terracotta = "0.4.2"
 nayuki-qrcodegen = "1.8.0"
-jwebp = "245f340ca1"
+jwebp = "999cb5ff9d"
 
 # testing
 junit = "6.0.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ lwjgl-unsafe-agent = "2.0"
 monet-fx = "0.4.0"
 terracotta = "0.4.2"
 nayuki-qrcodegen = "1.8.0"
-jwebp = "999cb5ff9d"
+jwebp = "0.2.0"
 
 # testing
 junit = "6.0.1"
@@ -56,7 +56,7 @@ authlib-injector = { module = "org.glavo.hmcl:authlib-injector", version.ref = "
 lwjgl-unsafe-agent = { module = "org.glavo:lwjgl-unsafe-agent", version.ref = "lwjgl-unsafe-agent" }
 monet-fx = { module = "org.glavo:MonetFX", version.ref = "monet-fx" }
 nayuki-qrcodegen = { module = "io.nayuki:qrcodegen", version.ref = "nayuki-qrcodegen" }
-javafx-webp = { module = "com.github.Glavo:jwebp", version.ref = "jwebp" }
+jwebp = { module = "org.glavo:webp", version.ref = "jwebp" }
 
 # testing
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ lwjgl-unsafe-agent = "2.0"
 monet-fx = "0.4.0"
 terracotta = "0.4.2"
 nayuki-qrcodegen = "1.8.0"
-javafx-webp = "4f0dfc2b28"
+jwebp = "245f340ca1"
 
 # testing
 junit = "6.0.1"
@@ -56,7 +56,7 @@ authlib-injector = { module = "org.glavo.hmcl:authlib-injector", version.ref = "
 lwjgl-unsafe-agent = { module = "org.glavo:lwjgl-unsafe-agent", version.ref = "lwjgl-unsafe-agent" }
 monet-fx = { module = "org.glavo:MonetFX", version.ref = "monet-fx" }
 nayuki-qrcodegen = { module = "io.nayuki:qrcodegen", version.ref = "nayuki-qrcodegen" }
-javafx-webp = { module = "com.github.Glavo:javafx-webp", version.ref = "javafx-webp" }
+javafx-webp = { module = "com.github.Glavo:jwebp", version.ref = "jwebp" }
 
 # testing
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }


### PR DESCRIPTION
目前 HMCL 在使用 TwelveMonkeys 加载 WebP 图像，但它存在几个问题：

- 不支持动画 WebP
- 解码有损 WebP 图像时色彩存在异常 (https://github.com/haraldk/TwelveMonkeys/issues/734)
- 依赖于 `ImageIO`，使用时需要加载更多类

为了解决这个问题，我在 Codex (GPT 5.4) 辅助下将 [image-rs/image-webp](https://github.com/image-rs/image-webp) 移植为一个纯 Java 库：[Glavo/javafx-webp](https://github.com/Glavo/jwebp)。该库支持动画 WebP，同时解码图像也不会出现颜色异常。

TODO：jwebp 的 Java 代码目前基本由 GPT 5.4 自行完成，我还需要对 API 进行一定的人工调整才能投入使用。
