### PR TITLE
fix: restore tip when mod loader version list is empty

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
@@ -423,7 +423,11 @@ public final class VersionsPage extends Control implements WizardPage, Refreshab
                     if (status == Status.LOADING)
                         transitionPane.setContent(spinner, ContainerAnimations.FADE);
                     else if (status == Status.SUCCESS)
-                        transitionPane.setContent(centerWrapper, ContainerAnimations.FADE);
+                        if (control.versions.isEmpty()) {
+                            transitionPane.setContent(emptyPane, ContainerAnimations.FADE);
+                        } else {
+                            transitionPane.setContent(centerWrapper, ContainerAnimations.FADE);
+                        }
                     else // if (status == Status.FAILED)
                         transitionPane.setContent(failedPane, ContainerAnimations.FADE);
                 });


### PR DESCRIPTION
resolves #5975

CC @anjisuan608

<img width="818" height="508" alt="Image" src="https://github.com/user-attachments/assets/bc7d1fe5-9f7a-4e86-a6bc-c0ade76ed597" />
