### PR TITLE
修复了macos arm64版本游玩1.19+可能导致的lwjgl natives匹配错误

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/NativePatcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/NativePatcher.java
@@ -151,13 +151,13 @@ public final class NativePatcher {
             if (library.isNative()) {
                 String nativeKey = library.getName() + ":natives";
                 Library replacement = replacements.getOrDefault(nativeKey, NONEXISTENT_LIBRARY);
-                if (replacement == NONEXISTENT_LIBRARY){
+                if (replacement == NONEXISTENT_LIBRARY) {
                     String classifier = library.getClassifier();
                     if (classifier != null) {
                         String classifierKey = library.getName() + ":" + classifier;
                         replacement = replacements.getOrDefault(classifierKey, NONEXISTENT_LIBRARY);
                         if (replacement != NONEXISTENT_LIBRARY) {
-                        LOG.info("Replace " + classifierKey + " with " + replacement.getName());
+                            LOG.info("Replace " + classifierKey + " with " + replacement.getName());
                         }
                     }
                 } else if (replacement != null) {
@@ -296,25 +296,25 @@ public final class NativePatcher {
     }
 
     private static boolean hasLegacyLwjglNatives(Version version) {
-    for (Library lib : version.getLibraries()) {
-        if (!lib.appliesToCurrentEnvironment()) continue;
-        if (!"org.lwjgl".equals(lib.getGroupId())) continue;
-        if (!lib.isNative()) continue;
+        for (Library lib : version.getLibraries()) {
+            if (!lib.appliesToCurrentEnvironment()) continue;
+            if (!"org.lwjgl".equals(lib.getGroupId())) continue;
+            if (!lib.isNative()) continue;
 
-        String classifier = lib.getClassifier();
-        if (classifier == null) {
-            return true;
-        }
+            String classifier = lib.getClassifier();
+            if (classifier == null) {
+                return true;
+            }
 
-        String c = classifier.toLowerCase(Locale.ROOT);
-        boolean arm64Like = c.contains("arm64") || c.contains("aarch64");
-        if (!arm64Like) {
-            // e.g. natives-macos / natives-windows
-            return true;
+            String c = classifier.toLowerCase(Locale.ROOT);
+            boolean arm64Like = c.contains("arm64") || c.contains("aarch64");
+            if (!arm64Like) {
+                // e.g. natives-macos / natives-windows
+                return true;
+            }
         }
+        return false;
     }
-    return false;
-}
 
     public enum SupportStatus {
         OFFICIAL_SUPPORTED,

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/NativePatcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/NativePatcher.java
@@ -150,25 +150,22 @@ public final class NativePatcher {
 
             if (library.isNative()) {
                 String nativeKey = library.getName() + ":natives";
+                String matchedKey = nativeKey;
                 Library replacement = replacements.getOrDefault(nativeKey, NONEXISTENT_LIBRARY);
                 if (replacement == NONEXISTENT_LIBRARY) {
                     String classifier = library.getClassifier();
                     if (classifier != null) {
                         String classifierKey = library.getName() + ":" + classifier;
                         replacement = replacements.getOrDefault(classifierKey, NONEXISTENT_LIBRARY);
-                        if (replacement != NONEXISTENT_LIBRARY) {
-                            LOG.info("Replace " + classifierKey + " with " + replacement.getName());
-                        }
+                        matchedKey = classifierKey;
                     }
-                } else if (replacement != null) {
-                    LOG.info("Replace " + nativeKey + " with " + replacement.getName());
                 }
 
                 if (replacement == NONEXISTENT_LIBRARY) {
                     LOG.warning("No alternative native library " + library.getName() + ":natives provided for platform " + javaVersion.getPlatform());
                     newLibraries.add(library);
                 } else if (replacement != null) {
-                    LOG.info("Replace " + library.getName() + ":natives with " + replacement.getName());
+                    LOG.info("Replace " + matchedKey + " with " + replacement.getName());
                     newLibraries.add(replacement);
                 }
             } else {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/NativePatcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/NativePatcher.java
@@ -132,7 +132,8 @@ public final class NativePatcher {
 
         if (arch == Architecture.ARM64 && (os == OperatingSystem.MACOS || os == OperatingSystem.WINDOWS)
                 && gameVersionNumber != null
-                && gameVersionNumber.compareTo("1.19") >= 0)
+                && gameVersionNumber.compareTo("1.19") >= 0
+                && !hasLegacyLwjglNatives(version))
             return version;
 
         Map<String, Library> replacements = getNatives(javaVersion.getPlatform());
@@ -148,7 +149,21 @@ public final class NativePatcher {
                 continue;
 
             if (library.isNative()) {
-                Library replacement = replacements.getOrDefault(library.getName() + ":natives", NONEXISTENT_LIBRARY);
+                String nativeKey = library.getName() + ":natives";
+                Library replacement = replacements.getOrDefault(nativeKey, NONEXISTENT_LIBRARY);
+                if (replacement == NONEXISTENT_LIBRARY){
+                    String classifier = library.getClassifier();
+                    if (classifier != null) {
+                        String classifierKey = library.getName() + ":" + classifier;
+                        replacement = replacements.getOrDefault(classifierKey, NONEXISTENT_LIBRARY);
+                        if (replacement != NONEXISTENT_LIBRARY) {
+                        LOG.info("Replace " + classifierKey + " with " + replacement.getName());
+                        }
+                    }
+                } else if (replacement != null) {
+                    LOG.info("Replace " + nativeKey + " with " + replacement.getName());
+                }
+
                 if (replacement == NONEXISTENT_LIBRARY) {
                     LOG.warning("No alternative native library " + library.getName() + ":natives provided for platform " + javaVersion.getPlatform());
                     newLibraries.add(library);
@@ -279,6 +294,27 @@ public final class NativePatcher {
 
         return SupportStatus.UNTESTED;
     }
+
+    private static boolean hasLegacyLwjglNatives(Version version) {
+    for (Library lib : version.getLibraries()) {
+        if (!lib.appliesToCurrentEnvironment()) continue;
+        if (!"org.lwjgl".equals(lib.getGroupId())) continue;
+        if (!lib.isNative()) continue;
+
+        String classifier = lib.getClassifier();
+        if (classifier == null) {
+            return true;
+        }
+
+        String c = classifier.toLowerCase(Locale.ROOT);
+        boolean arm64Like = c.contains("arm64") || c.contains("aarch64");
+        if (!arm64Like) {
+            // e.g. natives-macos / natives-windows
+            return true;
+        }
+    }
+    return false;
+}
 
     public enum SupportStatus {
         OFFICIAL_SUPPORTED,

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/NativePatcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/NativePatcher.java
@@ -293,24 +293,23 @@ public final class NativePatcher {
     }
 
     private static boolean hasLegacyLwjglNatives(Version version) {
+        boolean hasx86 = false;
+        boolean hasArm64 = false;
         for (Library lib : version.getLibraries()) {
             if (!lib.appliesToCurrentEnvironment()) continue;
             if (!"org.lwjgl".equals(lib.getGroupId())) continue;
-            if (!lib.isNative()) continue;
 
             String classifier = lib.getClassifier();
-            if (classifier == null) {
-                return true;
-            }
+            if (classifier == null || !classifier.startsWith("natives")) continue;
 
             String c = classifier.toLowerCase(Locale.ROOT);
-            boolean arm64Like = c.contains("arm64") || c.contains("aarch64");
-            if (!arm64Like) {
-                // e.g. natives-macos / natives-windows
-                return true;
+            if (c.contains("arm64") || c.contains("aarch64")) {
+                hasArm64 = true;
+            } else {
+                hasx86 = true;
             }
         }
-        return false;
+        return hasx86 && !hasArm64;
     }
 
     public enum SupportStatus {

--- a/HMCL/src/main/resources/assets/natives.json
+++ b/HMCL/src/main/resources/assets/natives.json
@@ -5199,6 +5199,83 @@
         }
       }
     },
+    "org.lwjgl:lwjgl:3.3.1:natives-macos": {
+      "name": "org.lwjgl:lwjgl:3.3.1:natives-macos-arm64",
+      "downloads": {
+        "artifact": {
+        "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-macos-arm64.jar",
+        "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-macos-arm64.jar",
+        "sha1": "71d0d5e469c9c95351eb949064497e3391616ac9",
+        "size": 42693
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-macos": {
+      "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-macos-arm64",
+      "downloads": {
+        "artifact": {
+        "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-macos-arm64.jar",
+        "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-macos-arm64.jar",
+        "sha1": "e577b87d8ad2ade361aaea2fcf226c660b15dee8",
+        "size": 103475
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-openal:3.3.1:natives-macos": {
+      "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-macos-arm64",
+      "downloads": {
+        "artifact": {
+        "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-macos-arm64.jar",
+        "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-macos-arm64.jar",
+        "sha1": "23d55e7490b57495320f6c9e1936d78fd72c4ef8",
+        "size": 346125
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-opengl:3.3.1:natives-macos": {
+      "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-macos-arm64",
+      "downloads": {
+        "artifact": {
+        "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-macos-arm64.jar",
+        "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-macos-arm64.jar",
+        "sha1": "eafe34b871d966292e8db0f1f3d6b8b110d4e91d",
+        "size": 41665
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-glfw:3.3.1:natives-macos": {
+      "name": "org.lwjgl:lwjgl-glfw:3.3.1:natives-macos-arm64",
+      "downloads": {
+        "artifact": {
+        "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-macos-arm64.jar",
+        "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-macos-arm64.jar",
+        "sha1": "cac0d3f712a3da7641fa174735a5f315de7ffe0a",
+        "size": 129077
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-stb:3.3.1:natives-macos": {
+      "name": "org.lwjgl:lwjgl-stb:3.3.1:natives-macos-arm64",
+      "downloads": {
+        "artifact": {
+        "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-macos-arm64.jar",
+        "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-macos-arm64.jar",
+        "sha1": "fcf073ed911752abdca5f0b00a53cfdf17ff8e8b",
+        "size": 178408
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-macos": {
+      "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-macos-arm64",
+      "downloads": {
+        "artifact": {
+        "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-macos-arm64.jar",
+        "url": "https://libraries.minecraft.net/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-macos-arm64.jar",
+        "sha1": "972ecc17bad3571e81162153077b4d47b7b9eaa9",
+        "size": 41380
+        }
+      }
+    },
     "ca.weblite:java-objc-bridge:1.0.0": {
       "name": "org.glavo.hmcl.mmachina:java-objc-bridge:1.1.0-mmachina.1",
       "downloads": {


### PR DESCRIPTION
### 问题描述：
在macos arm64版本下，导入整合包时，某些Forge/MultiMC导出的manifests会使用LWJGL natives的已经legacy的classifier，如natives-macos。而由于HMCL会将1.19+版本的arm64自动跳过patch, 所以该classifier会继续保持，从而导致下载的LWJGL与系统版本不匹配并路径错误导致找不到。

### 修复方式
对于legacy的classifier做了检测，已经legacy的classifier会做patch