### PR TITLE
[release/3.13] 修复 CurseForge 源中内容不显示 Minecraft 26.x 版本的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseAddon.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseAddon.java
@@ -24,6 +24,7 @@ import org.jackhuang.hmcl.mod.RemoteModRepository;
 import org.jackhuang.hmcl.util.Immutable;
 import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.Pair;
+import org.jackhuang.hmcl.util.versioning.GameVersionNumber;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
@@ -585,7 +586,7 @@ public class CurseAddon implements RemoteMod.IMod {
                         }
                         return RemoteMod.Dependency.ofGeneral(RELATION_TYPE.get(dependency.getRelationType()), CurseForgeRemoteModRepository.MODS, Integer.toString(dependency.getModId()));
                     }).distinct().filter(Objects::nonNull).collect(Collectors.toList()),
-                    gameVersions.stream().filter(ver -> ver.startsWith("1.") || ver.contains("w")).collect(Collectors.toList()),
+                    gameVersions.stream().filter(GameVersionNumber::isKnown).toList(),
                     gameVersions.stream().flatMap(version -> {
                         if ("fabric".equalsIgnoreCase(version)) return Stream.of(ModLoaderType.FABRIC);
                         else if ("forge".equalsIgnoreCase(version)) return Stream.of(ModLoaderType.FORGE);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/versioning/GameVersionNumber.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/versioning/GameVersionNumber.java
@@ -95,6 +95,18 @@ public abstract sealed class GameVersionNumber implements Comparable<GameVersion
         return VersionRange.atMost(asGameVersion(maximum));
     }
 
+    /// Determines whether the given version string corresponds to a known Minecraft version.
+    ///
+    /// If the version string cannot be parsed as any known version type (release, snapshot, pre-release, etc.)
+    /// and is not a known April Fools snapshot, it is considered an unknown version.
+    ///
+    /// @param version the version string to check, e.g. `"1.21.4"`, `"25w14craftmine"`, etc.
+    /// @return {@code true} if the version string corresponds to a known Minecraft version, {@code false} otherwise
+    /// @see #asGameVersion(String)
+    public static boolean isKnown(String version) {
+        return !(asGameVersion(version) instanceof Special special && special.prev == null);
+    }
+
     final String value;
     final String normalized;
 
@@ -151,7 +163,7 @@ public abstract sealed class GameVersionNumber implements Comparable<GameVersion
     ///
     /// ```java
     /// GameVersionNumber.asVersion("...").isAtLeast("1.13", "17w43a");
-    ///```
+    /// ```
     ///
     /// @param strictReleaseVersion When `strictReleaseVersion` is `false`, `releaseVersion` is considered less than
     ///                             its corresponding pre/rc versions.


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/pull/5994