### PR TITLE
Fix 5963: 愚人节版本 Minecraft 2.0 的 Legacy Fabric 下载列表为空

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/legacyfabric/LegacyFabricVersionList.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/legacyfabric/LegacyFabricVersionList.java
@@ -68,7 +68,19 @@ public final class LegacyFabricVersionList extends VersionList<LegacyFabricRemot
     private List<String> getGameVersions(String metaUrl) throws IOException {
         String json = NetworkUtils.doGet(downloadProvider.injectURLWithCandidates(metaUrl));
         return JsonUtils.GSON.fromJson(json, listTypeOf(GameVersion.class))
-                .stream().map(GameVersion::getVersion).collect(Collectors.toList());
+                .stream()
+                .map(GameVersion::getVersion)
+                .map(LegacyFabricVersionList::normalizeGameVersion)
+                .collect(Collectors.toList());
+    }
+
+
+    private static String normalizeGameVersion(String gameVersion) {
+        if (gameVersion.startsWith("2point0_")) {
+            return "2.0_" + gameVersion.substring("2point0_".length());
+        }
+
+        return gameVersion;
     }
 
     private static String getLaunchMetaUrl(String gameVersion, String loaderVersion) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/legacyfabric/LegacyFabricVersionList.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/legacyfabric/LegacyFabricVersionList.java
@@ -52,10 +52,13 @@ public final class LegacyFabricVersionList extends VersionList<LegacyFabricRemot
             lock.writeLock().lock();
 
             try {
-                for (String gameVersion : gameVersions)
-                    for (String loaderVersion : loaderVersions)
+                for (String metaGameVersion : gameVersions) {
+                    String gameVersion = normalizeVersion(metaGameVersion);
+                    for (String loaderVersion : loaderVersions) {
                         versions.put(gameVersion, new LegacyFabricRemoteVersion(gameVersion, loaderVersion,
-                                Collections.singletonList(getLaunchMetaUrl(gameVersion, loaderVersion))));
+                                Collections.singletonList(getLaunchMetaUrl(metaGameVersion, loaderVersion))));
+                    }
+                }
             } finally {
                 lock.writeLock().unlock();
             }
@@ -68,19 +71,13 @@ public final class LegacyFabricVersionList extends VersionList<LegacyFabricRemot
     private List<String> getGameVersions(String metaUrl) throws IOException {
         String json = NetworkUtils.doGet(downloadProvider.injectURLWithCandidates(metaUrl));
         return JsonUtils.GSON.fromJson(json, listTypeOf(GameVersion.class))
-                .stream()
-                .map(GameVersion::getVersion)
-                .map(LegacyFabricVersionList::normalizeGameVersion)
-                .collect(Collectors.toList());
+                .stream().map(GameVersion::getVersion).collect(Collectors.toList());
     }
 
-
-    private static String normalizeGameVersion(String gameVersion) {
-        if (gameVersion.startsWith("2point0_")) {
-            return "2.0_" + gameVersion.substring("2point0_".length());
-        }
-
-        return gameVersion;
+    private static String normalizeVersion(String version) {
+        return version.startsWith("2point0_")
+                ? "2.0_" + version.substring("2point0_".length())
+                : version;
     }
 
     private static String getLaunchMetaUrl(String gameVersion, String loaderVersion) {


### PR DESCRIPTION
<img width="605" height="640" alt="image" src="https://github.com/user-attachments/assets/247f3cff-41d4-468b-a6ca-07b0526a2dba" />
