### PR TITLE
导出 MultiMC 整合包时不再写入 `MaxMemAlloc`

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ExportWizardProvider.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ExportWizardProvider.java
@@ -214,7 +214,7 @@ public final class ExportWizardProvider implements WizardProvider {
                                 vs.isFullscreen(),
                                 vs.getWidth(),
                                 vs.getHeight(),
-                                vs.getMaxMemory(),
+                                null,
                                 exportInfo.getMinMemory(),
                                 vs.isShowLogs(),
                                 /* showConsoleOnError */ true,


### PR DESCRIPTION
<img width="1227" height="762" alt="image" src="https://github.com/user-attachments/assets/0ed1f546-8d63-4e53-b9ee-366efeb83f15" />

目前 `MaxMemAlloc` 写入的是实例设置中的 `游戏内存` 项，但导出时只要求输入了最小内存，用户很难联想和这里有关系，并且可能会导致 `MaxMemAlloc` 比 `MinMemAlloc` 还小的情况

<img width="169" height="34" alt="adfc7b6df7675cc82cce738643d6ae50" src="https://github.com/user-attachments/assets/5b0c55b9-eeb8-41d6-bc37-297dddf56f10" />
