### PR TITLE
Add UI scale setting to personalization page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,8 +72,3 @@ language-subtag-registry
 .codex
 /.gradle-*/
 
-# local/tools
-.workbuddy/
-node_modules/
-/package.json
-/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,9 @@ language-subtag-registry
 !/.gemini/config.yaml
 .codex
 /.gradle-*/
+
+# local/tools
+.workbuddy/
+node_modules/
+/package.json
+/package-lock.json

--- a/HMCL/src/main/java/org/jackhuang/hmcl/EntryPoint.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/EntryPoint.java
@@ -17,6 +17,7 @@
  */
 package org.jackhuang.hmcl;
 
+import org.jackhuang.hmcl.setting.ConfigHolder;
 import org.jackhuang.hmcl.util.FileSaver;
 import org.jackhuang.hmcl.util.SelfDependencyPatcher;
 import org.jackhuang.hmcl.util.SwingUtils;
@@ -86,12 +87,11 @@ public final class EntryPoint {
         }
 
         try {
-            Path configPath = Metadata.HMCL_GLOBAL_DIRECTORY.resolve("config.json");
-            if (!Files.isRegularFile(configPath)) {
+            if (!Files.isRegularFile(ConfigHolder.GLOBAL_CONFIG_PATH)) {
                 return;
             }
 
-            String content = Files.readString(configPath);
+            String content = Files.readString(ConfigHolder.GLOBAL_CONFIG_PATH);
             JsonObject json = JsonParser.parseString(content).getAsJsonObject();
             if (json.has("uiScale") && !json.get("uiScale").isJsonNull()) {
                 String uiScale = json.get("uiScale").getAsString();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/EntryPoint.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/EntryPoint.java
@@ -25,6 +25,8 @@ import org.jackhuang.hmcl.util.io.FileUtils;
 import org.jackhuang.hmcl.util.io.JarUtils;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import javax.swing.JOptionPane;
 import java.io.IOException;
 import java.lang.invoke.MethodHandle;
@@ -52,6 +54,7 @@ public final class EntryPoint {
 
         checkWine();
 
+        applyUiScaleFromGlobalConfig();
         setupJavaFXVMOptions();
 
         if (OperatingSystem.CURRENT_OS == OperatingSystem.MACOS) {
@@ -72,6 +75,34 @@ public final class EntryPoint {
         FileSaver.shutdown();
         LOG.shutdown();
         System.exit(exitCode);
+    }
+
+    /// Reads the UI scale from the global config file and sets it as the {@code hmcl.uiScale} system property,
+    /// so that {@link #setupJavaFXVMOptions()} can apply it before JavaFX initializes.
+    /// This is needed because the config is normally loaded after JavaFX starts.
+    private static void applyUiScaleFromGlobalConfig() {
+        if (System.getProperty("hmcl.uiScale") != null || System.getenv("HMCL_UI_SCALE") != null) {
+            return; // already set via command line or environment variable
+        }
+
+        try {
+            Path configPath = Metadata.HMCL_GLOBAL_DIRECTORY.resolve("config.json");
+            if (!Files.isRegularFile(configPath)) {
+                return;
+            }
+
+            String content = Files.readString(configPath);
+            JsonObject json = JsonParser.parseString(content).getAsJsonObject();
+            if (json.has("uiScale") && !json.get("uiScale").isJsonNull()) {
+                String uiScale = json.get("uiScale").getAsString();
+                if (uiScale != null && !uiScale.isEmpty()) {
+                    System.setProperty("hmcl.uiScale", uiScale);
+                    LOG.info("Applied UI scale from global config: " + uiScale);
+                }
+            }
+        } catch (Throwable e) {
+            LOG.warning("Failed to read UI scale from global config", e);
+        }
     }
 
     private static void setupJavaFXVMOptions() {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/GlobalConfig.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/GlobalConfig.java
@@ -134,6 +134,24 @@ public final class GlobalConfig extends ObservableSetting {
         this.fontAntiAliasing.set(value);
     }
 
+    /// The UI scale factor for the launcher.
+    /// Stored as a percentage string (e.g. `"150%"`), or `null` for auto (system default).
+    /// This setting requires a restart to take effect, as it configures JavaFX Glass properties before toolkit initialization.
+    @SerializedName("uiScale")
+    private final StringProperty uiScale = new SimpleStringProperty();
+
+    public StringProperty uiScaleProperty() {
+        return uiScale;
+    }
+
+    public @Nullable String getUiScale() {
+        return uiScale.get();
+    }
+
+    public void setUiScale(String value) {
+        this.uiScale.set(value);
+    }
+
     @SerializedName("userJava")
     private final ObservableSet<String> userJava = FXCollections.observableSet(new LinkedHashSet<>());
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
@@ -41,6 +41,7 @@ import org.jackhuang.hmcl.ui.SVG;
 import org.jackhuang.hmcl.ui.construct.*;
 import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.javafx.SafeStringConverter;
+import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
 import java.util.Arrays;
 import java.util.Locale;
@@ -116,6 +117,28 @@ public class PersonalizationPage extends StackPane {
             animationButton.selectedProperty().bindBidirectional(config().animationDisabledProperty());
             animationButton.setTitle(i18n("settings.launcher.turn_off_animations"));
             animationButton.setSubtitle(i18n("settings.take_effect_after_restart"));
+        }
+        {
+            var uiScalePane = new LineSelectButton<String>();
+            uiScalePane.setTitle(i18n("settings.launcher.ui_scale"));
+            uiScalePane.setSubtitle(OperatingSystem.CURRENT_OS == OperatingSystem.MACOS
+                    ? i18n("settings.launcher.ui_scale.unsupported")
+                    : i18n("settings.take_effect_after_restart"));
+            uiScalePane.setConverter(name -> "auto".equals(name)
+                    ? i18n("settings.launcher.ui_scale.auto")
+                    : name);
+            uiScalePane.setItems("auto", "100%", "125%", "150%", "175%", "200%", "250%", "300%");
+
+            String currentScale = globalConfig().getUiScale();
+            uiScalePane.setValue(currentScale != null ? currentScale : "auto");
+            FXUtils.onChange(uiScalePane.valueProperty(), value ->
+                    globalConfig().setUiScale("auto".equals(value) ? null : value));
+
+            if (OperatingSystem.CURRENT_OS == OperatingSystem.MACOS) {
+                uiScalePane.setDisable(true);
+            }
+
+            themeList.getContent().add(uiScalePane);
         }
         content.getChildren().addAll(ComponentList.createComponentListTitle(i18n("settings.launcher.appearance")), themeList);
 

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -1510,6 +1510,9 @@ settings.launcher.proxy.username=Username
 settings.launcher.theme=Theme Color
 settings.launcher.title_transparent=Transparent Titlebar
 settings.launcher.turn_off_animations=Disable Animation
+settings.launcher.ui_scale=UI Scale
+settings.launcher.ui_scale.auto=Auto
+settings.launcher.ui_scale.unsupported=Not supported on macOS
 settings.launcher.version_list_source=Version List
 settings.launcher.background.settings.opacity=Opacity
 

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -1300,6 +1300,9 @@ settings.launcher.proxy.username=帳戶
 settings.launcher.theme=主題色
 settings.launcher.title_transparent=標題欄透明
 settings.launcher.turn_off_animations=關閉動畫
+settings.launcher.ui_scale=介面縮放
+settings.launcher.ui_scale.auto=自動
+settings.launcher.ui_scale.unsupported=macOS 不支援
 settings.launcher.version_list_source=版本清單來源
 settings.launcher.background.settings.opacity=不透明度
 

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -1305,6 +1305,9 @@ settings.launcher.proxy.username=账户
 settings.launcher.theme=主题色
 settings.launcher.title_transparent=标题栏透明
 settings.launcher.turn_off_animations=关闭动画
+settings.launcher.ui_scale=界面缩放
+settings.launcher.ui_scale.auto=自动
+settings.launcher.ui_scale.unsupported=macOS 不支持
 settings.launcher.version_list_source=版本列表源
 settings.launcher.background.settings.opacity=不透明度
 


### PR DESCRIPTION
Allows users to configure HMCL UI scaling (100%-300%) via the personalization settings page. The setting is read from global config.json before JavaFX initializes so it takes effect on restart.

Co-authored-by: yi159 <>