### PR TITLE
自动继承 QT_SCALE_FACTOR 以修复 Wayland 下 JavaFX 分数缩放问题

### DIFF
--- a/HMCL/src/main/resources/assets/HMCLauncher.sh
+++ b/HMCL/src/main/resources/assets/HMCLauncher.sh
@@ -55,9 +55,18 @@ fi
 
 # _HMCL_VM_OPTIONS
 if [ -n "${HMCL_JAVA_OPTS+x}" ]; then
+  # User-specified JVM options take precedence.
   _HMCL_VM_OPTIONS=${HMCL_JAVA_OPTS}
 else
   _HMCL_VM_OPTIONS="-XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=15"
+
+  # JavaFX may not respect KDE Plasma Wayland fractional scaling automatically.
+  # Bridge QT_SCALE_FACTOR to JavaFX's GTK UI scale when available.
+  if [ "$_HMCL_OS" = "linux" ] && [ "$XDG_SESSION_TYPE" = "wayland" ]; then
+    if [ -n "$QT_SCALE_FACTOR" ]; then
+      _HMCL_VM_OPTIONS="$_HMCL_VM_OPTIONS -Dglass.gtk.uiScale=$QT_SCALE_FACTOR"
+    fi
+  fi
 fi
 
 function show_warning_console() {


### PR DESCRIPTION
fix:#6070
## 修改内容

在 Linux Wayland 环境下，自动继承 `QT_SCALE_FACTOR`，并通过：

```bash
-Dglass.gtk.uiScale
```

传递给 JavaFX，用于修复 KDE Plasma 分数缩放环境下 HMCL 界面过小的问题。

同时保留原有逻辑：

* 用户手动设置 `HMCL_JAVA_OPTS` 时仍完全覆盖默认参数
* 不影响 Windows/macOS
* 不影响 X11 环境

## 问题背景

在 KDE Plasma Wayland 环境下启用分数缩放（如 150%、170%）时，HMCL 界面会明显过小。

测试环境：

* Ubuntu Studio 26.04
* KDE Plasma
* Wayland
* Temurin OpenJDK 21

进一步测试发现：

* 170% 缩放：界面过小
* 200% 缩放：显示正常
* 手动添加：

  ```bash
  HMCL_JAVA_OPTS="-Dglass.gtk.uiScale=1.7"
  ```

  后恢复正常

说明 JavaFX 本身支持该缩放，但默认未正确继承 KDE Wayland 的 fractional scaling。

## 修改后的行为

默认情况下：

* Wayland 环境下自动读取 `QT_SCALE_FACTOR`
* 自动追加：

  ```bash
  -Dglass.gtk.uiScale=<QT_SCALE_FACTOR>
  ```

用户仍可通过：

```bash
HMCL_JAVA_OPTS=...
```

完全覆盖默认 JVM 参数。
