### PR TITLE
使用 WebURL for Java 解析 URI

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
@@ -1166,9 +1166,7 @@ public final class FXUtils {
         }
     }
 
-    public static Image loadImage(String url) throws Exception {
-        URI uri = NetworkUtils.toURI(url);
-
+    public static Image loadImage(URI uri) throws Exception {
         URLConnection connection = NetworkUtils.createConnection(uri);
         if (connection instanceof HttpURLConnection)
             connection = NetworkUtils.resolveConnection((HttpURLConnection) connection);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
@@ -62,6 +62,7 @@ import javafx.stage.Stage;
 import javafx.util.Callback;
 import javafx.util.Duration;
 import javafx.util.StringConverter;
+import org.glavo.url.WebURL;
 import org.jackhuang.hmcl.setting.StyleSheets;
 import org.jackhuang.hmcl.task.CacheFileTask;
 import org.jackhuang.hmcl.task.Schedulers;
@@ -1166,10 +1167,10 @@ public final class FXUtils {
         }
     }
 
-    public static Image loadImage(URI uri) throws Exception {
-        URLConnection connection = NetworkUtils.createConnection(uri);
-        if (connection instanceof HttpURLConnection)
-            connection = NetworkUtils.resolveConnection((HttpURLConnection) connection);
+    public static Image loadImage(WebURL url) throws Exception {
+        URLConnection connection = NetworkUtils.createConnection(url);
+        if (connection instanceof HttpURLConnection httpConnection)
+            connection = NetworkUtils.resolveConnection(httpConnection);
 
         try (BufferedInputStream input = new BufferedInputStream(connection.getInputStream())) {
             String contentType = Objects.requireNonNull(connection.getContentType(), "");

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
@@ -47,6 +47,7 @@ import org.jackhuang.hmcl.ui.construct.ClassTitle;
 import org.jackhuang.hmcl.ui.decorator.DecoratorAnimatedPage;
 import org.jackhuang.hmcl.ui.decorator.DecoratorPage;
 import org.jackhuang.hmcl.util.i18n.LocaleUtils;
+import org.jackhuang.hmcl.util.io.NetworkUtils;
 import org.jackhuang.hmcl.util.javafx.BindingMapping;
 import org.jackhuang.hmcl.util.javafx.MappedObservableList;
 
@@ -152,7 +153,7 @@ public final class AccountListPage extends DecoratorAnimatedPage implements Deco
                         item.titleProperty().bind(title);
                         String host = "";
                         try {
-                            host = WebURL.toURI(server.getUrl()).getHost();
+                            host = NetworkUtils.toURI(server.getUrl()).getHost();
                         } catch (IllegalArgumentException e) {
                             LOG.warning("Unparsable authlib-injector server url " + server.getUrl(), e);
                         }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
@@ -35,6 +35,7 @@ import javafx.scene.control.Skin;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
+import org.glavo.url.WebURL;
 import org.jackhuang.hmcl.auth.Account;
 import org.jackhuang.hmcl.auth.authlibinjector.AuthlibInjectorServer;
 import org.jackhuang.hmcl.setting.Accounts;
@@ -152,7 +153,7 @@ public final class AccountListPage extends DecoratorAnimatedPage implements Deco
                         item.titleProperty().bind(title);
                         String host = "";
                         try {
-                            host = NetworkUtils.toURI(server.getUrl()).getHost();
+                            host = WebURL.toURI(server.getUrl()).getHost();
                         } catch (IllegalArgumentException e) {
                             LOG.warning("Unparsable authlib-injector server url " + server.getUrl(), e);
                         }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
@@ -47,7 +47,6 @@ import org.jackhuang.hmcl.ui.construct.ClassTitle;
 import org.jackhuang.hmcl.ui.decorator.DecoratorAnimatedPage;
 import org.jackhuang.hmcl.ui.decorator.DecoratorPage;
 import org.jackhuang.hmcl.util.i18n.LocaleUtils;
-import org.jackhuang.hmcl.util.io.NetworkUtils;
 import org.jackhuang.hmcl.util.javafx.BindingMapping;
 import org.jackhuang.hmcl.util.javafx.MappedObservableList;
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
@@ -35,7 +35,6 @@ import javafx.scene.control.Skin;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
-import org.glavo.url.WebURL;
 import org.jackhuang.hmcl.auth.Account;
 import org.jackhuang.hmcl.auth.authlibinjector.AuthlibInjectorServer;
 import org.jackhuang.hmcl.setting.Accounts;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/URLValidator.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/URLValidator.java
@@ -20,8 +20,8 @@ package org.jackhuang.hmcl.ui.construct;
 import com.jfoenix.validation.base.ValidatorBase;
 import javafx.beans.NamedArg;
 import javafx.scene.control.TextInputControl;
+import org.glavo.url.WebURL;
 import org.jackhuang.hmcl.util.StringUtils;
-import org.jackhuang.hmcl.util.io.NetworkUtils;
 
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
@@ -54,12 +54,7 @@ public class URLValidator extends ValidatorBase {
         if (StringUtils.isBlank(textField.getText()))
             hasErrors.set(!nullable);
         else {
-            try {
-                NetworkUtils.toURI(textField.getText());
-                hasErrors.set(false);
-            } catch (IllegalArgumentException e) {
-                hasErrors.set(true);
-            }
+            hasErrors.set(WebURL.tryParseBrowserInput(textField.getText()) == null);
         }
     }
 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
@@ -34,6 +34,7 @@ import javafx.scene.paint.Color;
 import javafx.scene.paint.Paint;
 import javafx.stage.Stage;
 import javafx.util.Duration;
+import org.glavo.url.WebURL;
 import org.jackhuang.hmcl.Metadata;
 import org.jackhuang.hmcl.auth.authlibinjector.AuthlibInjectorDnD;
 import org.jackhuang.hmcl.setting.EnumBackgroundImage;
@@ -205,7 +206,7 @@ public class DecoratorController {
                 String backgroundImageUrl = config().getBackgroundImageUrl();
                 if (backgroundImageUrl != null) {
                     try {
-                        image = FXUtils.loadImage(backgroundImageUrl);
+                        image = FXUtils.loadImage(WebURL.parseBrowserInput(backgroundImageUrl).toURI());
                     } catch (Exception e) {
                         LOG.warning("Couldn't load background image", e);
                     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
@@ -206,7 +206,7 @@ public class DecoratorController {
                 String backgroundImageUrl = config().getBackgroundImageUrl();
                 if (backgroundImageUrl != null) {
                     try {
-                        image = FXUtils.loadImage(WebURL.parseBrowserInput(backgroundImageUrl).toURI());
+                        image = FXUtils.loadImage(WebURL.parseBrowserInputToURI(backgroundImageUrl));
                     } catch (Exception e) {
                         LOG.warning("Couldn't load background image", e);
                     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
@@ -206,7 +206,7 @@ public class DecoratorController {
                 String backgroundImageUrl = config().getBackgroundImageUrl();
                 if (backgroundImageUrl != null) {
                     try {
-                        image = FXUtils.loadImage(WebURL.parseBrowserInputToURI(backgroundImageUrl));
+                        image = FXUtils.loadImage(WebURL.parseBrowserInput(backgroundImageUrl));
                     } catch (Exception e) {
                         LOG.warning("Couldn't load background image", e);
                     }

--- a/HMCL/src/main/resources/assets/about/deps.json
+++ b/HMCL/src/main/resources/assets/about/deps.json
@@ -98,5 +98,10 @@
     "title": "TomlJ",
     "subtitle": "Licensed under the Apache 2.0 License.",
     "externalLink": "https://github.com/tomlj/tomlj"
+  },
+  {
+    "title": "WebURL for Java",
+    "subtitle": "Licensed under the Apache 2.0 License.",
+    "externalLink": "https://github.com/Glavo/weburl-java"
   }
 ]

--- a/HMCLCore/build.gradle.kts
+++ b/HMCLCore/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     api(libs.jna)
     api(libs.pci.ids)
     api(libs.hello.nbt)
+    api(libs.weburl)
 
     compileOnlyApi(libs.jetbrains.annotations)
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/authlibinjector/AuthlibInjectorServer.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/authlibinjector/AuthlibInjectorServer.java
@@ -30,6 +30,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import org.glavo.url.WebURL;
+import org.glavo.url.WebURLParseException;
 import org.jackhuang.hmcl.auth.yggdrasil.YggdrasilService;
 import org.jackhuang.hmcl.util.io.HttpRequest;
 import org.jackhuang.hmcl.util.io.NetworkUtils;
@@ -58,13 +60,17 @@ public class AuthlibInjectorServer implements Observable {
     public static AuthlibInjectorServer locateServer(String url) throws IOException {
         try {
             url = NetworkUtils.addHttpsIfMissing(url);
-            HttpURLConnection conn = NetworkUtils.createHttpConnection(url);
+
+            WebURL webURL = WebURL.parseBrowserInput(url);
+            url = webURL.toString();
+
+            HttpURLConnection conn = NetworkUtils.createHttpConnection(webURL);
             conn = NetworkUtils.resolveConnection(conn);
 
             String ali = conn.getHeaderField("x-authlib-injector-api-location");
             if (ali != null) {
-                URI absoluteAli = conn.getURL().toURI().resolve(NetworkUtils.toURI(ali));
-                if (!urlEqualsIgnoreSlash(url, absoluteAli.toString())) {
+                WebURL absoluteAli = WebURL.parse(ali, WebURL.of(conn.getURL()));
+                if (!urlEqualsIgnoreSlash(webURL.toString(), absoluteAli.toString())) {
                     conn.disconnect();
                     url = absoluteAli.toString();
                     conn = NetworkUtils.resolveConnection(NetworkUtils.createHttpConnection(absoluteAli));
@@ -81,7 +87,7 @@ public class AuthlibInjectorServer implements Observable {
             } finally {
                 conn.disconnect();
             }
-        } catch (IllegalArgumentException | URISyntaxException e) {
+        } catch (IllegalArgumentException e) {
             throw new IOException(e);
         }
     }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/authlibinjector/AuthlibInjectorServer.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/authlibinjector/AuthlibInjectorServer.java
@@ -24,14 +24,11 @@ import static org.jackhuang.hmcl.util.logging.Logger.LOG;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
 import org.glavo.url.WebURL;
-import org.glavo.url.WebURLParseException;
 import org.jackhuang.hmcl.auth.yggdrasil.YggdrasilService;
 import org.jackhuang.hmcl.util.io.HttpRequest;
 import org.jackhuang.hmcl.util.io.NetworkUtils;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/NetworkUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/NetworkUtils.java
@@ -25,9 +25,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
 import java.net.*;
-import java.net.http.HttpClient;
-import java.net.http.HttpHeaders;
-import java.net.http.HttpResponse;
 import java.nio.charset.Charset;
 import java.util.*;
 import java.util.Map.Entry;
@@ -446,14 +443,6 @@ public final class NetworkUtils {
     /// @throws IllegalArgumentException if the string is not a valid URI
     public static @NotNull URI toURI(@NotNull String uri) {
         return WebURL.toURI(uri);
-    }
-
-    public static @NotNull HttpResponse.ResponseInfo getResponseInfo(@NotNull HttpResponse<?> response) {
-        record ResponseInfoImpl(int statusCode, HttpHeaders headers, HttpClient.Version version)
-                implements HttpResponse.ResponseInfo {
-        }
-
-        return new ResponseInfoImpl(response.statusCode(), response.headers(), response.version());
     }
 
     public static @Nullable URI toURIOrNull(String uri) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/NetworkUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/NetworkUtils.java
@@ -437,7 +437,7 @@ public final class NetworkUtils {
 
     /// @throws IllegalArgumentException if the string is not a valid URI
     public static @NotNull URI toURI(@NotNull String uri) {
-        return WebURL.toURI(uri);
+        return WebURL.parseBrowserInput(uri).toURI();
     }
 
     public static @NotNull HttpResponse.ResponseInfo getResponseInfo(@NotNull HttpResponse<?> response) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/NetworkUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/NetworkUtils.java
@@ -17,6 +17,7 @@
  */
 package org.jackhuang.hmcl.util.io;
 
+import org.glavo.url.WebURL;
 import org.jackhuang.hmcl.util.Pair;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -436,16 +437,7 @@ public final class NetworkUtils {
 
     /// @throws IllegalArgumentException if the string is not a valid URI
     public static @NotNull URI toURI(@NotNull String uri) {
-        try {
-            return new URI(encodeLocation(uri));
-        } catch (URISyntaxException e) {
-            // Possibly an Internationalized Domain Name (IDN)
-            return URI.create(uri);
-        }
-    }
-
-    public static @NotNull URI toURI(@NotNull URL url) {
-        return toURI(url.toExternalForm());
+        return WebURL.toURI(uri);
     }
 
     public static @NotNull HttpResponse.ResponseInfo getResponseInfo(@NotNull HttpResponse<?> response) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/NetworkUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/NetworkUtils.java
@@ -163,10 +163,10 @@ public final class NetworkUtils {
         }
     }
 
-    public static URLConnection createConnection(URI uri) throws IOException {
+    public static URLConnection createConnection(WebURL url) throws IOException {
         URLConnection connection;
         try {
-            connection = uri.toURL().openConnection();
+            connection = url.toURL().openConnection();
         } catch (IllegalArgumentException | MalformedURLException e) {
             throw new IOException(e);
         }
@@ -180,8 +180,16 @@ public final class NetworkUtils {
         return connection;
     }
 
+    public static URLConnection createConnection(URI uri) throws IOException {
+        return createConnection(WebURL.of(uri));
+    }
+
+    public static HttpURLConnection createHttpConnection(WebURL url) throws IOException {
+        return (HttpURLConnection) createConnection(url);
+    }
+
     public static HttpURLConnection createHttpConnection(String url) throws IOException {
-        return (HttpURLConnection) createConnection(toURI(url));
+        return (HttpURLConnection) createConnection(WebURL.parse(url));
     }
 
     public static HttpURLConnection createHttpConnection(URI url) throws IOException {
@@ -437,7 +445,7 @@ public final class NetworkUtils {
 
     /// @throws IllegalArgumentException if the string is not a valid URI
     public static @NotNull URI toURI(@NotNull String uri) {
-        return WebURL.parseBrowserInput(uri).toURI();
+        return WebURL.toURI(uri);
     }
 
     public static @NotNull HttpResponse.ResponseInfo getResponseInfo(@NotNull HttpResponse<?> response) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ monet-fx = "0.4.0"
 terracotta = "0.4.2"
 nayuki-qrcodegen = "1.8.0"
 jwebp = "0.2.0"
-weburl = "0.1.0"
+weburl = "0.2.0"
 
 # testing
 junit = "6.0.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ monet-fx = "0.4.0"
 terracotta = "0.4.2"
 nayuki-qrcodegen = "1.8.0"
 jwebp = "0.2.0"
+weburl = "0.1.0"
 
 # testing
 junit = "6.0.1"
@@ -58,6 +59,7 @@ lwjgl-unsafe-agent = { module = "org.glavo:lwjgl-unsafe-agent", version.ref = "l
 monet-fx = { module = "org.glavo:MonetFX", version.ref = "monet-fx" }
 nayuki-qrcodegen = { module = "io.nayuki:qrcodegen", version.ref = "nayuki-qrcodegen" }
 jwebp = { module = "org.glavo:webp", version.ref = "jwebp" }
+weburl = { module = "org.glavo:weburl", version.ref = "weburl" }
 
 # testing
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }


### PR DESCRIPTION
Java 标准库的 `URI` 类仅支持老旧的 RFC 2396 标准，无法解析大量现实中的 URL。

为了解决这个问题，我开发了 [WebURL for Java](https://github.com/Glavo/weburl-java) 库，支持解析符合 WHATWG URL 规范的 URL。

此外，该库还支持宽松解析模式，支持类似浏览器地址栏的启发式算法补全 URL（比如将 `glavo.site` 解析为 `https://glavo.site`），更适合处理用户的输入。