### PR TITLE
[Enhancement] `MultiFileItem.FileOption` 文件选择器按钮移到路径文本框左边

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/FileSelector.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/FileSelector.java
@@ -87,6 +87,10 @@ public class FileSelector extends HBox {
     }
 
     public FileSelector() {
+        this(false);
+    }
+
+    public FileSelector(boolean buttonOnLeft) {
         JFXTextField customField = new JFXTextField();
         FXUtils.bindString(customField, valueProperty());
 
@@ -110,7 +114,10 @@ public class FileSelector extends HBox {
 
         setAlignment(Pos.CENTER_LEFT);
         setSpacing(3);
-        getChildren().addAll(customField, selectButton);
+        if (buttonOnLeft)
+            getChildren().addAll(selectButton, customField);
+        else
+            getChildren().addAll(customField, selectButton);
     }
 
     private void openFileChooser(JFXTextField customField) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/MultiFileItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/MultiFileItem.java
@@ -249,7 +249,7 @@ public final class MultiFileItem<T> extends VBox {
     }
 
     public static final class FileOption<T> extends Option<T> {
-        private final FileSelector selector = new FileSelector();
+        private final FileSelector selector = new FileSelector(true);
 
         public FileOption(String title, T data) {
             super(title, data);


### PR DESCRIPTION
<img width="1536" height="502" alt="image" src="https://github.com/user-attachments/assets/d2b80bda-bbb8-4df1-b688-65740a90a2ec" />

这样能跟下面几个文本框对齐，更好看一些