### PR TITLE
优化游戏列表 Popup 列表项大小

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/GameListPopupMenu.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/GameListPopupMenu.java
@@ -31,7 +31,6 @@ import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.BorderPane;
-import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import org.jackhuang.hmcl.game.Version;
@@ -66,10 +65,11 @@ public final class GameListPopupMenu extends StackPane {
         this.getStyleClass().add("popup-menu-content");
 
         listView.setCellFactory(Cell::new);
-        listView.setFixedCellSize(60);
+
+        listView.setFixedCellSize(50);
         listView.setPrefWidth(300);
 
-        listView.prefHeightProperty().bind(Bindings.size(getItems()).multiply(60).add(2));
+        listView.prefHeightProperty().bind(Bindings.size(getItems()).multiply(50).add(2));
 
         Label placeholder = new Label(i18n("version.empty"));
         placeholder.setStyle("-fx-padding: 10px; -fx-text-fill: -monet-on-surface-variant; -fx-font-style: italic;");
@@ -94,35 +94,34 @@ public final class GameListPopupMenu extends StackPane {
 
         public Cell(ListView<GameItem> listView) {
             this.setPadding(Insets.EMPTY);
-            HBox root = new HBox();
-
-            root.setSpacing(8);
-            root.setAlignment(Pos.CENTER_LEFT);
-
-            StackPane imageViewContainer = new StackPane();
-            FXUtils.setLimitWidth(imageViewContainer, 32);
-            FXUtils.setLimitHeight(imageViewContainer, 32);
 
             this.imageView = new ImageContainer(32);
-            imageViewContainer.getChildren().setAll(imageView);
+            this.imageView.setMouseTransparent(true);
+            BorderPane.setAlignment(imageView, Pos.CENTER);
 
             this.content = new TwoLineListItem();
+            this.content.setMouseTransparent(true);
             FXUtils.onChangeAndOperate(tag, tag -> {
                 content.getTags().clear();
                 if (StringUtils.isNotBlank(tag)) {
                     content.addTag(tag);
                 }
             });
-            BorderPane.setAlignment(content, Pos.CENTER);
-            root.getChildren().setAll(imageView, content);
 
-            StackPane pane = new StackPane();
-            pane.getChildren().setAll(root);
-            pane.getStyleClass().add("menu-container");
-            root.setMouseTransparent(true);
+            BorderPane container = new BorderPane();
+            container.getStyleClass().add("container");
+            container.setPickOnBounds(false);
+            container.setLeft(imageView);
+            container.setCenter(content);
 
-            RipplerContainer ripplerContainer = new RipplerContainer(pane);
-            FXUtils.onClicked(ripplerContainer, () -> {
+            RipplerContainer ripplerContainer = new RipplerContainer(container);
+            ripplerContainer.maxWidthProperty().bind(listView.widthProperty().subtract(5));
+
+            StackPane rootPane = new StackPane();
+            rootPane.getStyleClass().add("advanced-list-item");
+            rootPane.getChildren().setAll(ripplerContainer);
+
+            FXUtils.onClicked(rootPane, () -> {
                 GameItem item = getItem();
                 if (item != null) {
                     item.getProfile().setSelectedVersion(item.getId());
@@ -130,8 +129,8 @@ public final class GameListPopupMenu extends StackPane {
                         popup.hide();
                 }
             });
-            this.graphic = ripplerContainer;
-            ripplerContainer.maxWidthProperty().bind(listView.widthProperty().subtract(5));
+
+            this.graphic = rootPane;
         }
 
         @Override

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/GameListPopupMenu.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/GameListPopupMenu.java
@@ -115,11 +115,11 @@ public final class GameListPopupMenu extends StackPane {
             container.setCenter(content);
 
             RipplerContainer ripplerContainer = new RipplerContainer(container);
-            ripplerContainer.maxWidthProperty().bind(listView.widthProperty().subtract(5));
 
             StackPane rootPane = new StackPane();
             rootPane.getStyleClass().add("advanced-list-item");
             rootPane.getChildren().setAll(ripplerContainer);
+            rootPane.maxWidthProperty().bind(listView.widthProperty().subtract(5));
 
             FXUtils.onClicked(rootPane, () -> {
                 GameItem item = getItem();


### PR DESCRIPTION
<img width="2423" height="770" alt="image" src="https://github.com/user-attachments/assets/b50a786d-955d-4bab-862f-5ed25addba12" />
<img width="775" height="553" alt="image" src="https://github.com/user-attachments/assets/e2841ac4-43f6-4cc4-a298-e0228a6d3b92" />
之前单个项看起来比账户列表的单个项大很多