### PR TITLE
移除主页面 “下载” 按钮的 Tooltip

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/RootPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/RootPage.java
@@ -187,7 +187,6 @@ public class RootPage extends DecoratorAnimatedPage implements DecoratorPage {
                 Controllers.getDownloadPage().showGameDownloads();
                 Controllers.navigate(Controllers.getDownloadPage());
             });
-            FXUtils.installFastTooltip(downloadItem, i18n("download.hint"));
             if (AnimationUtils.isAnimationEnabled()) {
                 FXUtils.prepareOnMouseEnter(downloadItem, Controllers::prepareDownloadPage);
             }

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -353,7 +353,6 @@ curse.sort.total_downloads=Total Downloads
 datetime.format=MMM d, yyyy, h\:mm\:ss a
 
 download=Download
-download.hint=Install games and modpacks or download mods, resource packs, shaders, and worlds.
 download.code.404=File "%s" not found on the remote server.
 download.content=Addons
 download.shader=Shaders

--- a/HMCL/src/main/resources/assets/lang/I18N_ar.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_ar.properties
@@ -344,7 +344,6 @@ curse.sort.total_downloads=إجمالي التنزيلات
 datetime.format=MMM d, yyyy, h\:mm\:ss a
 
 download=تنزيل
-download.hint=ثبّت الألعاب وحزم المودات أو نزّل المودات وحزم الموارد والظلال والعوالم.
 download.code.404=الملف "%s" غير موجود على الخادم البعيد.
 download.content=الإضافات
 download.shader=الظلال

--- a/HMCL/src/main/resources/assets/lang/I18N_es.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_es.properties
@@ -324,7 +324,6 @@ curse.sort.total_downloads=Descargas totales
 datetime.format=d MMM yyyy, H\:mm\:ss
 
 download=Descargar
-download.hint=Instalar juegos y modpacks o descargar mods, paquetes de recursos, sombreadores y mundos.
 download.code.404=Archivo no encontrado en el servidor remoto: %s
 download.content=Complementos
 download.shader=Sombreadores

--- a/HMCL/src/main/resources/assets/lang/I18N_ja.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_ja.properties
@@ -283,7 +283,6 @@ curse.sort.total_downloads=合計ダウンロード数
 datetime.format=yyyy/MM/dd H:mm:ss
 
 download=ダウンロード
-download.hint=ゲームや modpack をインストールするか、mod、リソース パック、マップ、シェーダーをダウンロードします
 download.code.404=リモートサーバーにファイルが見つかりません：%s
 download.content=ゲームコンテンツ
 download.shader=シェーダー

--- a/HMCL/src/main/resources/assets/lang/I18N_lzh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_lzh.properties
@@ -322,7 +322,6 @@ curse.sort.total_downloads=引數
 datetime.format=yyyy 年 MM 月 dd 日 HH:mm:ss
 
 download=引
-download.hint=裝戯事、改囊集，引改囊、資囊、光影與生界
 download.code.404=伺服器無案曰：%s\n君可求助於右上之鈕。
 download.content=戲案
 download.shader=光影

--- a/HMCL/src/main/resources/assets/lang/I18N_ru.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_ru.properties
@@ -321,7 +321,6 @@ curse.sort.total_downloads=Скачиваний
 datetime.format=d MMM yyyy г., HH\:mm\:ss
 
 download=Скачать
-download.hint=Установить игры и модпаки или скачать моды, пакеты ресурсов, шейдеры и миры.
 download.code.404=Файл «%s» не найден на удаленном сервере.
 download.content=Аддоны
 download.shader=Шейдеры

--- a/HMCL/src/main/resources/assets/lang/I18N_uk.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_uk.properties
@@ -320,7 +320,6 @@ curse.sort.total_downloads=Всього завантажень
 datetime.format=dd.MM.yyyy, HH:mm:ss
 
 download=Завантажити
-download.hint=Встановіть ігри та модпаки або завантажте моди, пакети ресурсів, шейдери та світи.
 download.code.404=Файл "%s" не знайдено на віддаленому сервері.
 download.content=Додатки
 download.shader=Шейдери

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -350,7 +350,6 @@ curse.sort.total_downloads=下載量
 datetime.format=yyyy 年 MM 月 dd 日 HH:mm:ss
 
 download=下載
-download.hint=安裝遊戲和模組包或下載模組、資源包、光影和世界
 download.code.404=遠端伺服器沒有需要下載的檔案：%s
 download.content=遊戲內容
 download.shader=光影

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -352,7 +352,6 @@ curse.sort.total_downloads=下载量
 datetime.format=yyyy 年 MM 月 dd 日 HH:mm:ss
 
 download=下载
-download.hint=安装游戏和整合包或下载模组、资源包、光影和世界
 download.code.404=远程服务器不包含需要下载的文件: %s\n你可以点击右上角帮助按钮进行求助。
 download.content=游戏内容
 download.shader=光影


### PR DESCRIPTION
这个页面只要点进来过一次都知道是干什么的，不需要特别提示，每次鼠标碰上来都会跳出来
并且除了“账户”以外主页面只有这一个按钮有 Tooltip ，感觉有点特殊