### PR TITLE
在已有账户的情况下移除联机和主页的玩家名称tooltip

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountAdvancedListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountAdvancedListItem.java
@@ -17,7 +17,6 @@
  */
 package org.jackhuang.hmcl.ui.account;
 
-import javafx.beans.binding.Bindings;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ObservableValue;
@@ -27,7 +26,6 @@ import javafx.scene.control.Tooltip;
 import org.jackhuang.hmcl.auth.Account;
 import org.jackhuang.hmcl.auth.authlibinjector.AuthlibInjectorAccount;
 import org.jackhuang.hmcl.auth.authlibinjector.AuthlibInjectorServer;
-import org.jackhuang.hmcl.auth.yggdrasil.YggdrasilAccount;
 import org.jackhuang.hmcl.game.TexturesLoader;
 import org.jackhuang.hmcl.setting.Accounts;
 import org.jackhuang.hmcl.ui.FXUtils;
@@ -42,6 +40,7 @@ import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 public class AccountAdvancedListItem extends AdvancedListItem {
     private final Tooltip tooltip;
     private final Canvas canvas;
+    private boolean tooltipInstalled;
 
     private final ObjectProperty<Account> account = new SimpleObjectProperty<Account>() {
 
@@ -51,10 +50,10 @@ public class AccountAdvancedListItem extends AdvancedListItem {
             if (account == null) {
                 titleProperty().unbind();
                 subtitleProperty().unbind();
-                tooltip.textProperty().unbind();
                 setTitle(i18n("account.missing"));
                 setSubtitle(i18n("account.missing.add"));
                 tooltip.setText(i18n("account.create"));
+                installTooltip();
 
                 TexturesLoader.unbindAvatar(canvas);
                 TexturesLoader.drawAvatar(canvas, TexturesLoader.getDefaultSkinImage());
@@ -62,7 +61,7 @@ public class AccountAdvancedListItem extends AdvancedListItem {
             } else {
                 titleProperty().bind(BindingMapping.of(account, Account::getCharacter));
                 subtitleProperty().bind(accountSubtitle(account));
-                tooltip.textProperty().bind(accountTooltip(account));
+                uninstallTooltip();
                 TexturesLoader.bindAvatar(canvas, account);
             }
         }
@@ -74,7 +73,6 @@ public class AccountAdvancedListItem extends AdvancedListItem {
 
     public AccountAdvancedListItem(Account account) {
         tooltip = new Tooltip();
-        FXUtils.installFastTooltip(this, tooltip);
 
         canvas = new Canvas(32, 32);
         canvas.setMouseTransparent(true);
@@ -103,19 +101,17 @@ public class AccountAdvancedListItem extends AdvancedListItem {
         }
     }
 
-    private static ObservableValue<String> accountTooltip(Account account) {
-        if (account instanceof AuthlibInjectorAccount) {
-            AuthlibInjectorServer server = ((AuthlibInjectorAccount) account).getServer();
-            return Bindings.format("%s (%s) (%s)",
-                    BindingMapping.of(account, Account::getCharacter),
-                    account.getUsername(),
-                    BindingMapping.of(server, AuthlibInjectorServer::getName));
-        } else if (account instanceof YggdrasilAccount) {
-            return Bindings.format("%s (%s)",
-                    BindingMapping.of(account, Account::getCharacter),
-                    account.getUsername());
-        } else {
-            return BindingMapping.of(account, Account::getCharacter);
+    private void installTooltip() {
+        if (!tooltipInstalled) {
+            FXUtils.installFastTooltip(this, tooltip);
+            tooltipInstalled = true;
+        }
+    }
+
+    private void uninstallTooltip() {
+        if (tooltipInstalled) {
+            Tooltip.uninstall(this, tooltip);
+            tooltipInstalled = false;
         }
     }
 


### PR DESCRIPTION
在有真实账号时不再安装/显示玩家名 tooltip
账号为空时仍保留原来的“创建账号”提示
