### PR TITLE
fix: 不透明度设置为 0% 时鼠标可穿透启动器

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
@@ -240,7 +240,7 @@ public class DecoratorController {
 
     private Background createBackgroundWithOpacity(Image image, int opacity) {
         if (opacity <= 0) {
-            return new Background(new BackgroundFill(new Color(1, 1, 1, 0), CornerRadii.EMPTY, Insets.EMPTY));
+            return new Background(new BackgroundFill(new Color(0, 0, 0, 0.004), CornerRadii.EMPTY, Insets.EMPTY));
         } else if (opacity >= 100 || image.getPixelReader() == null) {
             return new Background(new BackgroundImage(
                     image,


### PR DESCRIPTION
没找到其他方法解决，但是这样看着也是透明的，应该没太大影响（？

环境
```
[19:55:13] [@.Launcher.main/INFO] *** HMCL 3.14.SNAPSHOT ***
[19:55:13] [@.Launcher.main/INFO] Operating System: Windows 11 25H2 10.0.26300.8497
[19:55:13] [@.Launcher.main/INFO] Processor Identifier: Intel64 Family 6 Model 183 Stepping 1, GenuineIntel
[19:55:13] [@.Launcher.main/INFO] System Architecture: x86-64
[19:55:13] [@.Launcher.main/INFO] Java Architecture: x86-64
[19:55:13] [@.Launcher.main/INFO] Java Version: 25.0.3, JetBrains s.r.o.
[19:55:13] [@.Launcher.main/INFO] Java VM Version: OpenJDK 64-Bit Server VM (mixed mode, sharing), JetBrains s.r.o.
[19:55:13] [@.Launcher.start/INFO] JavaFX Version: 25+29
[19:55:13] [@.Launcher.start/INFO] Prism Pipeline: com.sun.prism.d3d.D3DPipeline
[19:55:13] [@.Launcher.start/INFO] Screens:
 - Screen 1: 2561x1601 @ 1.5x 126dpi in 16" (0, 0, 1707, 1067)
```