### PR TITLE
fix(#6154): layout race in instance download page

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
@@ -17,7 +17,6 @@
  */
 package org.jackhuang.hmcl.ui.construct;
 
-import javafx.beans.InvalidationListener;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.StringProperty;
 import javafx.beans.property.StringPropertyBase;
@@ -26,7 +25,6 @@ import javafx.collections.ObservableList;
 import javafx.css.PseudoClass;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
-import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
@@ -168,29 +166,13 @@ public class TwoLineListItem extends VBox {
             var tagsBox = new HBox(8);
             tagsBox.getStyleClass().add("tags");
             tagsBox.setAlignment(Pos.CENTER_LEFT);
+            HBox.setHgrow(tagsBox, Priority.ALWAYS);
             Bindings.bindContent(tagsBox.getChildren(), tags);
+            tagsBox.managedProperty().bind(Bindings.isNotEmpty(tags));
+            tagsBox.visibleProperty().bind(Bindings.isNotEmpty(tags));
 
-            var scrollPane = new ScrollPane(tagsBox);
-            scrollPane.setMinSize(0, 0);
-            HBox.setHgrow(scrollPane, Priority.ALWAYS);
             lblTitle.setMinWidth(Label.USE_PREF_SIZE);
-            scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
-            scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
-            var expectedHeight = Bindings.createDoubleBinding(
-                    () -> {
-                        if (tags.isEmpty()) return 0.0;
-                        double h = tagsBox.prefHeight(-1);
-                        return h > 0 ? h : 24.0;
-                    },
-                    tags, tagsBox.heightProperty()
-            );
-
-            scrollPane.minHeightProperty().bind(expectedHeight);
-            scrollPane.prefHeightProperty().bind(expectedHeight);
-            scrollPane.maxHeightProperty().bind(expectedHeight);
-            firstLine.getChildren().setAll(lblTitle, scrollPane);
-
-            tags.addListener((InvalidationListener) ignored -> scrollPane.requestLayout());
+            firstLine.getChildren().setAll(lblTitle, tagsBox);
         }
         return tags;
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
@@ -28,6 +28,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
+import javafx.scene.shape.Rectangle;
 
 public class TwoLineListItem extends VBox {
     private static final String DEFAULT_STYLE_CLASS = "two-line-list-item";
@@ -172,6 +173,12 @@ public class TwoLineListItem extends VBox {
             tagsBox.managedProperty().bind(isNotEmpty);
             tagsBox.visibleProperty().bind(isNotEmpty);
 
+            // Clip overflow tags, matching the previous ScrollPane behavior.
+            var clip = new Rectangle();
+            tagsBox.setClip(clip);
+            tagsBox.widthProperty().addListener((obs, old, val) -> clip.setWidth(val.doubleValue()));
+            tagsBox.heightProperty().addListener((obs, old, val) -> clip.setHeight(val.doubleValue()));
+
             lblTitle.setMinWidth(Label.USE_PREF_SIZE);
             firstLine.getChildren().setAll(lblTitle, tagsBox);
         }
@@ -181,6 +188,7 @@ public class TwoLineListItem extends VBox {
     public void addTag(String tag, PseudoClass pseudoClass) {
         var tagLabel = new Label(tag);
         tagLabel.getStyleClass().add("tag");
+        tagLabel.setMinWidth(Label.USE_PREF_SIZE);
         if (pseudoClass != null)
             tagLabel.pseudoClassStateChanged(pseudoClass, true);
         getTags().add(tagLabel);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
@@ -173,11 +173,7 @@ public class TwoLineListItem extends VBox {
             tagsBox.managedProperty().bind(isNotEmpty);
             tagsBox.visibleProperty().bind(isNotEmpty);
 
-            // Clip overflow tags, matching the previous ScrollPane behavior.
-            var clip = new Rectangle();
-            tagsBox.setClip(clip);
-            clip.widthProperty().bind(tagsBox.widthProperty());
-            clip.heightProperty().bind(tagsBox.heightProperty());
+            FXUtils.setOverflowHidden(tagsBox);
 
             lblTitle.setMinWidth(Label.USE_PREF_SIZE);
             firstLine.getChildren().setAll(lblTitle, tagsBox);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
@@ -28,7 +28,6 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
-import javafx.scene.shape.Rectangle;
 import org.jackhuang.hmcl.ui.FXUtils;
 
 public class TwoLineListItem extends VBox {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
@@ -29,6 +29,7 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.scene.shape.Rectangle;
+import org.jackhuang.hmcl.ui.FXUtils;
 
 public class TwoLineListItem extends VBox {
     private static final String DEFAULT_STYLE_CLASS = "two-line-list-item";

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
@@ -168,8 +168,9 @@ public class TwoLineListItem extends VBox {
             tagsBox.setAlignment(Pos.CENTER_LEFT);
             HBox.setHgrow(tagsBox, Priority.ALWAYS);
             Bindings.bindContent(tagsBox.getChildren(), tags);
-            tagsBox.managedProperty().bind(Bindings.isNotEmpty(tags));
-            tagsBox.visibleProperty().bind(Bindings.isNotEmpty(tags));
+            var isNotEmpty = Bindings.isNotEmpty(tags);
+            tagsBox.managedProperty().bind(isNotEmpty);
+            tagsBox.visibleProperty().bind(isNotEmpty);
 
             lblTitle.setMinWidth(Label.USE_PREF_SIZE);
             firstLine.getChildren().setAll(lblTitle, tagsBox);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
@@ -176,8 +176,8 @@ public class TwoLineListItem extends VBox {
             // Clip overflow tags, matching the previous ScrollPane behavior.
             var clip = new Rectangle();
             tagsBox.setClip(clip);
-            tagsBox.widthProperty().addListener((obs, old, val) -> clip.setWidth(val.doubleValue()));
-            tagsBox.heightProperty().addListener((obs, old, val) -> clip.setHeight(val.doubleValue()));
+            clip.widthProperty().bind(tagsBox.widthProperty());
+            clip.heightProperty().bind(tagsBox.heightProperty());
 
             lblTitle.setMinWidth(Label.USE_PREF_SIZE);
             firstLine.getChildren().setAll(lblTitle, tagsBox);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
@@ -180,7 +180,7 @@ public class TwoLineListItem extends VBox {
                     () -> {
                         if (tags.isEmpty()) return 0.0;
                         double h = tagsBox.prefHeight(-1);
-                        return h > 0 ? h : Double.NaN;
+                        return h > 0 ? h : 24.0;
                     },
                     tags, tagsBox.heightProperty()
             );

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
@@ -167,6 +167,7 @@ public class TwoLineListItem extends VBox {
             var tagsBox = new HBox(8);
             tagsBox.getStyleClass().add("tags");
             tagsBox.setAlignment(Pos.CENTER_LEFT);
+            tagsBox.setMinWidth(0);
             HBox.setHgrow(tagsBox, Priority.ALWAYS);
             Bindings.bindContent(tagsBox.getChildren(), tags);
             var isNotEmpty = Bindings.isNotEmpty(tags);


### PR DESCRIPTION
Fix #6154

这边怀疑是 race condition 导致没能成功设置标签的 `Height` 属性，所以选择了一个不大不小的值放在上面，暂时解决了问题。*如果可能的话，我会尝试寻找更好的方法修好*

需要更多测试。该修改之后，我已无法再复现此问题，但是不排除测试姿势不对导致的复现失败。