### PR TITLE
将背景图片从默认的左上角适应修改为居中适应

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorController.java
@@ -246,8 +246,14 @@ public class DecoratorController {
                     image,
                     BackgroundRepeat.NO_REPEAT,
                     BackgroundRepeat.NO_REPEAT,
-                    BackgroundPosition.DEFAULT,
-                    new BackgroundSize(800, 480, false, false, true, true)
+                    BackgroundPosition.CENTER,
+                    new BackgroundSize(
+                            BackgroundSize.AUTO,
+                            BackgroundSize.AUTO,
+                            false,
+                            false,
+                            false,
+                            false)
             ));
         } else {
             WritableImage tempImage = new WritableImage((int) image.getWidth(), (int) image.getHeight());
@@ -265,8 +271,14 @@ public class DecoratorController {
                     tempImage,
                     BackgroundRepeat.NO_REPEAT,
                     BackgroundRepeat.NO_REPEAT,
-                    BackgroundPosition.DEFAULT,
-                    new BackgroundSize(800, 480, false, false, true, true)
+                    BackgroundPosition.CENTER,
+                    new BackgroundSize(
+                            BackgroundSize.AUTO,
+                            BackgroundSize.AUTO,
+                            false,
+                            false,
+                            false,
+                            false)
             ));
         }
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/decorator/DecoratorSkin.java
@@ -36,6 +36,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.SkinBase;
 import javafx.scene.effect.BlurType;
 import javafx.scene.effect.DropShadow;
+import javafx.scene.image.Image;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.*;
@@ -183,13 +184,13 @@ public class DecoratorSkin extends SkinBase<Decorator> {
         // and decide whether the whole top bar should be rendered in white or black. TODO
         FXUtils.onChangeAndOperate(skinnable.titleTransparentProperty(), titleTransparent -> {
             if (titleTransparent) {
-                wrapper.backgroundProperty().bind(skinnable.contentBackgroundProperty());
+                bindContentBackground(wrapper, skinnable);
                 container.backgroundProperty().unbind();
                 container.setBackground(null);
                 titleContainer.getStyleClass().remove("background");
                 titleContainer.getStyleClass().add("gray-background");
             } else {
-                container.backgroundProperty().bind(skinnable.contentBackgroundProperty());
+                bindContentBackground(container, skinnable);
                 wrapper.backgroundProperty().unbind();
                 wrapper.setBackground(null);
                 titleContainer.getStyleClass().add("background");
@@ -261,6 +262,86 @@ public class DecoratorSkin extends SkinBase<Decorator> {
         }
 
         getChildren().add(root);
+    }
+
+    /// Binds the target region to a background rebuilt for the region's current size.
+    private void bindContentBackground(Region target, Decorator skinnable) {
+        target.backgroundProperty().unbind();
+        target.backgroundProperty().bind(Bindings.createObjectBinding(
+                () -> createCenteredCoverBackground(
+                        skinnable.getContentBackground(),
+                        target.getWidth(),
+                        target.getHeight()
+                ),
+                skinnable.contentBackgroundProperty(),
+                target.widthProperty(),
+                target.heightProperty()
+        ));
+    }
+
+    /// Creates a background whose image layers use centered cover sizing without JavaFX cover mode.
+    private Background createCenteredCoverBackground(Background background, double regionWidth, double regionHeight) {
+        if (background == null || background.getImages().isEmpty()) {
+            return background;
+        }
+
+        return new Background(
+                background.getFills(),
+                background.getImages().stream()
+                        .map(backgroundImage -> new BackgroundImage(
+                                backgroundImage.getImage(),
+                                backgroundImage.getRepeatX(),
+                                backgroundImage.getRepeatY(),
+                                BackgroundPosition.CENTER,
+                                createCenteredCoverSize(
+                                        backgroundImage.getImage(),
+                                        regionWidth,
+                                        regionHeight
+                                )
+                        ))
+                        .toList()
+        );
+    }
+
+    /// Calculates percentage sizing that fills the region while letting BackgroundPosition center crop the overflow.
+    private BackgroundSize createCenteredCoverSize(Image image, double regionWidth, double regionHeight) {
+        if (image == null
+                || image.getWidth() <= 0
+                || image.getHeight() <= 0
+                || regionWidth <= 0
+                || regionHeight <= 0) {
+            return new BackgroundSize(
+                    BackgroundSize.AUTO,
+                    BackgroundSize.AUTO,
+                    false,
+                    false,
+                    false,
+                    false
+            );
+        }
+
+        double imageRatio = image.getWidth() / image.getHeight();
+        double regionRatio = regionWidth / regionHeight;
+
+        if (regionRatio > imageRatio) {
+            return new BackgroundSize(
+                    1.0,
+                    BackgroundSize.AUTO,
+                    true,
+                    false,
+                    false,
+                    false
+            );
+        } else {
+            return new BackgroundSize(
+                    BackgroundSize.AUTO,
+                    1.0,
+                    false,
+                    true,
+                    false,
+                    false
+            );
+        }
     }
 
     private Node createNavBar(Decorator skinnable, double leftPaneWidth, boolean canBack, boolean canClose, boolean showCloseAsHome, boolean canRefresh, String title, Node titleNode) {


### PR DESCRIPTION
_本 PR 的代码部分完全使用 Codex + GPT 5.5 生成_
修复 https://github.com/HMCL-dev/HMCL/issues/2842
原先的背景图片以左上角为起点，根据窗口大小自动裁切右部与底部，这种展示方式对背景来说不够合适
修改后背景图片默认居中，根据窗口大小自动裁切左右或上下部分，个人认为符合背景的需求
我不确定当前实现是否是最优解，但个人测试下来没什么明显问题，因此尝试开一个 PR 请开发者们看看实现是否合理
<img width="2000" height="1125" alt="image" src="https://github.com/user-attachments/assets/7f0ec483-6e6e-48a3-b88b-f47843755b3b" />