### PR TITLE
Perf: Set fixed cell size for versions list

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
@@ -384,6 +384,9 @@ public final class VersionsPage extends Control implements WizardPage, Refreshab
                     {
                         list = new JFXListView<>();
                         list.getStyleClass().add("jfx-list-view-float");
+
+                        list.setFixedCellSize(65);
+
                         VBox.setVgrow(list, Priority.ALWAYS);
 
                         control.versions.addListener((InvalidationListener) o -> updateList());


### PR DESCRIPTION
# 游戏版本下载列表性能优化

## 缘由
- 在版本下载界面切换到“全部”分类后，由于 ListView 中版本数量较多，首次滚动时会出现明显卡顿。

## 原因推测

- 每个 ListCell 需要动态计算 prefHeight

## 修改内容

- 为 ListView 启用 setFixedCellSize()

## 优化效果

- 首次滚动卡顿明显减少

## 对比

录屏好像有问题，切换选项时没有被采集（

### 修改前

https://github.com/user-attachments/assets/d552b871-8af1-4d40-8964-c790d387121c

### 修改后

https://github.com/user-attachments/assets/aa1fe238-76f7-4777-8494-e6fc3dc2e8a2