### PR TITLE
Fix: Alignment issue for TwoLineListItem

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
@@ -44,6 +44,8 @@ public class TwoLineListItem extends VBox {
         getStyleClass().add(DEFAULT_STYLE_CLASS);
         setMouseTransparent(true);
 
+        setAlignment(Pos.CENTER);
+
         lblTitle = new Label();
         lblTitle.getStyleClass().add("title");
 


### PR DESCRIPTION
# 修复 TwoLineListItem 对齐问题

## 缘由

合并 #6186 后，在不同字体下， TwoLineListItem 存在对齐问题。

## 涉及的 Issue

#6191

## 更改

- 补充 TwoLineListItem 中的对齐。

## 实况

字体：Tahoma

| 修复前 | 修复后 |
| --- | --- |
|<img width="818" height="508" alt="Before1" src="https://github.com/user-attachments/assets/869b59fc-1c63-42c2-aae9-007d2e1663af" />|<img width="818" height="508" alt="After1" src="https://github.com/user-attachments/assets/f5e195df-8822-4b2b-af37-d2dd038b3706" />|
|<img width="818" height="508" alt="Before2" src="https://github.com/user-attachments/assets/f7c497c7-25b4-47ac-9b90-db200a3774ab" />|<img width="818" height="508" alt="After2" src="https://github.com/user-attachments/assets/14a2964b-97d8-45d7-b5bf-1e5329675857" />|