### PR TITLE
优化外置登录账号名称展示

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItem.java
@@ -51,7 +51,6 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
@@ -88,10 +87,7 @@ public class AccountListItem extends RadioButton {
             return StringUtils.isBlank(name) ? account.getProfileID().toString() : name;
         }, account);
         if (account instanceof ClassicAccount classicAccount) {
-            title.bind(Bindings.createStringBinding(() -> {
-                if (Objects.equals(profileName.get(), classicAccount.getLoginName())) return profileName.get();
-                else return profileName.get() + " - " + classicAccount.getLoginName();
-            }, profileName));
+            title.bind(Bindings.concat(profileName, " - ", classicAccount.getLoginName()));
         } else {
             title.bind(profileName);
         }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItem.java
@@ -90,7 +90,7 @@ public class AccountListItem extends RadioButton {
         if (account instanceof ClassicAccount classicAccount) {
             title.bind(Bindings.createStringBinding(() -> {
                 if (Objects.equals(profileName.get(), classicAccount.getLoginName())) return profileName.get();
-                else return classicAccount.getLoginName() + " - " + profileName.get();
+                else return profileName.get() + " - " + classicAccount.getLoginName();
             }, profileName));
         } else {
             title.bind(profileName);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItem.java
@@ -51,14 +51,15 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 
 import static java.util.Collections.emptySet;
 import static javafx.beans.binding.Bindings.createBooleanBinding;
-import static org.jackhuang.hmcl.util.logging.Logger.LOG;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
+import static org.jackhuang.hmcl.util.logging.Logger.LOG;
 
 public class AccountListItem extends RadioButton {
 
@@ -86,8 +87,11 @@ public class AccountListItem extends RadioButton {
             String name = account.getProfileName();
             return StringUtils.isBlank(name) ? account.getProfileID().toString() : name;
         }, account);
-        if (account instanceof ClassicAccount classicAccount && !(account instanceof OfflineAccount)) {
-            title.bind(Bindings.concat(classicAccount.getLoginName(), " - ", profileName));
+        if (account instanceof ClassicAccount classicAccount) {
+            title.bind(Bindings.createStringBinding(() -> {
+                if (Objects.equals(profileName.get(), classicAccount.getLoginName())) return profileName.get();
+                else return classicAccount.getLoginName() + " - " + profileName.get();
+            }, profileName));
         } else {
             title.bind(profileName);
         }


### PR DESCRIPTION
调换位置，和其他账户放一起时更协调

前：
<img width="1227" height="762" alt="image" src="https://github.com/user-attachments/assets/2e699b8f-25aa-4006-a474-2b4410092b86" />
后：
<img width="1227" height="762" alt="image" src="https://github.com/user-attachments/assets/11abaac9-0bce-443f-bf8a-30c95084a6f8" />

同时清理代码
<img width="881" height="125" alt="image" src="https://github.com/user-attachments/assets/409bcf4d-5be5-446b-b203-57ad1217b8da" />