### PR TITLE
Fix: Fix the alignment issue in the game download list.

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
@@ -166,6 +166,7 @@ public final class VersionsPage extends Control implements WizardPage, Refreshab
 
             HBox hbox = new HBox(16);
             HBox.setHgrow(twoLineListItem, Priority.ALWAYS);
+            twoLineListItem.setAlignment(Pos.CENTER);
             hbox.setAlignment(Pos.CENTER);
 
             HBox actions = new HBox(8);


### PR DESCRIPTION
# 修复 VersionsPage 对齐问题

## 缘由

- 合并 #6186 后，在不同字体下， `VersionsPage` 存在对齐问题。
- 在 #6193 的讨论中，取消更改`TwoLineListItem`，仅针对`VersionsPage` 。

## 涉及的 Issue

#6191 

## 更改

- 补充 `VersionsPage` 中`TwoLineListItem`的对齐。

## 实况

字体：Tahoma

| 修复前 | 修复后 |
| --- | --- |
|<img width="818" height="508" alt="1" src="https://github.com/user-attachments/assets/4112b35c-740a-4c07-8e4f-e54c726046e6" />|<img width="818" height="508" alt="2" src="https://github.com/user-attachments/assets/7f92db91-00bd-4e6f-b728-3fef71b7e1a2" />|