### PR TITLE
Refactor: Merge the duplicate logic of PriorityComparator.of(...).

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/PriorityComparator.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/PriorityComparator.java
@@ -33,11 +33,8 @@ public final class PriorityComparator<T> implements Comparator<T> {
 
     /// Creates a new `PriorityComparator` with a priority map and a fallback comparator.
     /// Elements with a defined priority are ordered before those without.
-    public static <T extends Comparable<T>> PriorityComparator<T> of(T... values) {
-        Map<T, Integer> priorities = new HashMap<>();
-        for (int i = 0; i < values.length; i++)
-            priorities.put(values[i], i);
-        return new PriorityComparator<>(priorities, Comparator.naturalOrder(), true);
+    public static <T extends Comparable<T>> PriorityComparator<T> of(List<T> values) {
+        return of(values, Comparator.naturalOrder(), true);
     }
 
     /// Creates a new `PriorityComparator` with a priority map, a fallback comparator, and a flag to determine the order of prioritized elements.

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/PriorityComparator.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/PriorityComparator.java
@@ -34,6 +34,7 @@ public final class PriorityComparator<T> implements Comparator<T> {
     /// Creates a new `PriorityComparator` with a priority map and a fallback comparator.
     /// Elements with a defined priority are ordered before those without.
     public static <T extends Comparable<T>> PriorityComparator<T> of(List<T> values) {
+        Objects.requireNonNull(values);
         return of(values, Comparator.naturalOrder(), true);
     }
 


### PR DESCRIPTION
# 合并`PriorityComparator.of(...)`的重复逻辑

## 变更

- `PriorityComparator.of(T... values))`与`PriorityComparator.of(List<T> values, Comparator<? super T> fallback, boolean prioritizedFirst))`逻辑有重复之处，且`T... values`存在安全隐患，故合并逻辑。