### PR TITLE
Fix: Fix the alignment issue of the icon in TerracottaControllerPage.

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/terracotta/TerracottaControllerPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/terracotta/TerracottaControllerPage.java
@@ -32,6 +32,8 @@ import javafx.scene.Cursor;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.TextFlow;
@@ -554,6 +556,7 @@ public class TerracottaControllerPage extends StackPane {
         header.getStyleClass().add("no-padding");
         header.setLargeTitle(true);
         header.setMinHeight(LinePane.USE_COMPUTED_SIZE);
+        HBox.setHgrow(header, Priority.ALWAYS);
         header.setMouseTransparent(true);
         header.setLeading(FXUtils.newBuiltinImage("/assets/img/terracotta.png"));
         header.setTitle(i18n("terracotta.from_local.title"));


### PR DESCRIPTION
# 修复`TerracottaControllerPage`中图标的对齐问题

## 实况

### 更改前

<img width="887" height="216" alt="1" src="https://github.com/user-attachments/assets/9f97eb33-0a53-44c0-9250-fc94812feeb9" />

### 更改后

<img width="892" height="227" alt="2" src="https://github.com/user-attachments/assets/eb6bcc93-8607-4e19-91ec-f1ee4667e2b8" />
