### PR TITLE
Refactor: OfflineAccountSkinPane

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItem.java
@@ -141,12 +141,7 @@ public class AccountListItem extends RadioButton {
     @Nullable
     public Task<?> uploadSkin() {
         if (account instanceof OfflineAccount) {
-            OfflineAccountSkinPane pane = new OfflineAccountSkinPane((OfflineAccount) account);
-
-            pane.setScaleX(0.85);
-            pane.setScaleY(0.85);
-
-            Controllers.dialog(pane);
+            Controllers.dialog(new OfflineAccountSkinPane((OfflineAccount) account));
             return null;
         }
         if (!account.canUploadSkin()) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItem.java
@@ -141,7 +141,12 @@ public class AccountListItem extends RadioButton {
     @Nullable
     public Task<?> uploadSkin() {
         if (account instanceof OfflineAccount) {
-            Controllers.dialog(new OfflineAccountSkinPane((OfflineAccount) account));
+            OfflineAccountSkinPane pane = new OfflineAccountSkinPane((OfflineAccount) account);
+
+            pane.setScaleX(0.85);
+            pane.setScaleY(0.85);
+
+            Controllers.dialog(pane);
             return null;
         }
         if (!account.canUploadSkin()) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
@@ -107,11 +107,6 @@ public class OfflineAccountSkinPane extends StackPane {
         modelCombobox.setMaxWidth(Double.MAX_VALUE);
         cslApiField.setMaxWidth(Double.MAX_VALUE);
 
-        GridPane.setHgrow(modelCombobox, Priority.ALWAYS);
-        GridPane.setHgrow(skinSelector, Priority.ALWAYS);
-        GridPane.setHgrow(capeSelector, Priority.ALWAYS);
-        GridPane.setHgrow(cslApiField, Priority.ALWAYS);
-
         layout.setBody(pane);
 
         cslApiField.setPromptText(i18n("account.skin.type.csl_api.location.hint"));
@@ -184,15 +179,6 @@ public class OfflineAccountSkinPane extends StackPane {
             }
         }, skinItem.selectedDataProperty(), cslApiField.textProperty(), modelCombobox.valueProperty(), skinSelector.valueProperty(), capeSelector.valueProperty());
 
-        GridPane gridPane = new GridPane();
-        gridPane.setPadding(new Insets(0, 0, 0, 10));
-        gridPane.setHgap(16);
-        gridPane.setVgap(12);
-
-        ColumnConstraints column = new ColumnConstraints();
-        column.setHgrow(Priority.ALWAYS);
-        gridPane.getColumnConstraints().setAll(column);
-
         VBox right = new VBox();
         right.setPadding(new Insets(0, 0, 0, 10));
         right.setSpacing(12);
@@ -209,38 +195,40 @@ public class OfflineAccountSkinPane extends StackPane {
         FXUtils.onChangeAndOperate(skinItem.selectedDataProperty(), selectedData -> {
             right.getChildren().clear();
 
-            switch (selectedData) {
-                case DEFAULT:
-                case STEVE:
-                case ALEX:
-                    break;
+            if (selectedData != null) {
+                switch (selectedData) {
+                    case DEFAULT:
+                    case STEVE:
+                    case ALEX:
+                        break;
 
-                case LITTLE_SKIN:
-                    HintPane hint = new HintPane(MessageDialogPane.MessageType.INFO);
-                    hint.setText(i18n("account.skin.type.little_skin.hint"));
+                    case LITTLE_SKIN:
+                        HintPane hint = new HintPane(MessageDialogPane.MessageType.INFO);
+                        hint.setText(i18n("account.skin.type.little_skin.hint"));
 
-                    hint.setMaxWidth(Double.MAX_VALUE);
+                        hint.setMaxWidth(Double.MAX_VALUE);
 
-                    right.getChildren().add(hint);
-                    break;
+                        right.getChildren().add(hint);
+                        break;
 
-                case LOCAL_FILE:
-                    right.getChildren().addAll(
-                        new Label(i18n("account.skin.model")),
-                        modelCombobox,
-                        new Label(i18n("account.skin")),
-                        skinSelector,
-                        new Label(i18n("account.cape")),
-                        capeSelector
-                    );
-                    break;
+                    case LOCAL_FILE:
+                        right.getChildren().addAll(
+                            new Label(i18n("account.skin.model")),
+                            modelCombobox,
+                            new Label(i18n("account.skin")),
+                            skinSelector,
+                            new Label(i18n("account.cape")),
+                            capeSelector
+                        );
+                        break;
 
-                case CUSTOM_SKIN_LOADER_API:
-                    right.getChildren().addAll(
-                        new Label(i18n("account.skin.type.csl_api.location")),
-                        cslApiField
-                    );
-                    break;
+                    case CUSTOM_SKIN_LOADER_API:
+                        right.getChildren().addAll(
+                            new Label(i18n("account.skin.type.csl_api.location")),
+                            cslApiField
+                        );
+                        break;
+                }
             }
 
             if (right.getChildren().isEmpty()) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
@@ -193,7 +193,9 @@ public class OfflineAccountSkinPane extends StackPane {
         column.setHgrow(Priority.ALWAYS);
         gridPane.getColumnConstraints().setAll(column);
 
-        VBox right = new VBox(gridPane);
+        VBox right = new VBox();
+        right.setPadding(new Insets(0, 0, 0, 10));
+        right.setSpacing(12);
         right.setPrefWidth(230);
         HBox.setHgrow(right, Priority.ALWAYS);
 
@@ -205,7 +207,7 @@ public class OfflineAccountSkinPane extends StackPane {
         skinOptionPane.getChildren().setAll(body);
 
         FXUtils.onChangeAndOperate(skinItem.selectedDataProperty(), selectedData -> {
-            gridPane.getChildren().clear();
+            right.getChildren().clear();
 
             switch (selectedData) {
                 case DEFAULT:
@@ -218,29 +220,30 @@ public class OfflineAccountSkinPane extends StackPane {
                     hint.setText(i18n("account.skin.type.little_skin.hint"));
 
                     hint.setMaxWidth(Double.MAX_VALUE);
-                    GridPane.setHgrow(hint, Priority.ALWAYS);
 
-                    gridPane.addRow(0, hint);
+                    right.getChildren().add(hint);
                     break;
 
                 case LOCAL_FILE:
-                    gridPane.addRow(0, new Label(i18n("account.skin.model")));
-                    gridPane.addRow(1, modelCombobox);
-
-                    gridPane.addRow(2, new Label(i18n("account.skin")));
-                    gridPane.addRow(3, skinSelector);
-
-                    gridPane.addRow(4, new Label(i18n("account.cape")));
-                    gridPane.addRow(5, capeSelector);
+                    right.getChildren().addAll(
+                        new Label(i18n("account.skin.model")),
+                        modelCombobox,
+                        new Label(i18n("account.skin")),
+                        skinSelector,
+                        new Label(i18n("account.cape")),
+                        capeSelector
+                    );
                     break;
 
                 case CUSTOM_SKIN_LOADER_API:
-                    gridPane.addRow(0, new Label(i18n("account.skin.type.csl_api.location")));
-                    gridPane.addRow(1, cslApiField);
+                    right.getChildren().addAll(
+                        new Label(i18n("account.skin.type.csl_api.location")),
+                        cslApiField
+                    );
                     break;
             }
 
-            if (gridPane.getChildren().isEmpty()) {
+            if (right.getChildren().isEmpty()) {
                 body.getChildren().remove(right);
             } else if (!body.getChildren().contains(right)) {
                 body.getChildren().add(right);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
@@ -76,8 +76,8 @@ public class OfflineAccountSkinPane extends StackPane {
 
         SkinCanvas canvas = new SkinCanvas(TexturesLoader.getDefaultSkinImage(), 260, 260, true);
         StackPane canvasPane = new StackPane(canvas);
-        canvasPane.setPrefWidth(300);
-        canvasPane.setPrefHeight(300);
+        canvasPane.setPrefWidth(260);
+        canvasPane.setPrefHeight(260);
         pane.setCenter(canvasPane);
         canvas.getAnimationPlayer().addSkinAnimation(new SkinAniWavingArms(100, 2000, 7.5, canvas), new SkinAniRunning(100, 100, 30, canvas));
         canvas.enableRotation(.5);
@@ -184,16 +184,28 @@ public class OfflineAccountSkinPane extends StackPane {
             }
         }, skinItem.selectedDataProperty(), cslApiField.textProperty(), modelCombobox.valueProperty(), skinSelector.valueProperty(), capeSelector.valueProperty());
 
+        GridPane gridPane = new GridPane();
+        gridPane.setPadding(new Insets(0, 0, 0, 10));
+        gridPane.setHgap(16);
+        gridPane.setVgap(12);
+
+        ColumnConstraints column = new ColumnConstraints();
+        column.setHgrow(Priority.ALWAYS);
+        gridPane.getColumnConstraints().setAll(column);
+
+        VBox right = new VBox(gridPane);
+        right.setPrefWidth(230);
+        HBox.setHgrow(right, Priority.ALWAYS);
+
+        HBox body = new HBox(20);
+        skinItem.setPrefWidth(170);
+        skinItem.setMinWidth(170);
+        body.getChildren().add(skinItem);
+
+        skinOptionPane.getChildren().setAll(body);
+
         FXUtils.onChangeAndOperate(skinItem.selectedDataProperty(), selectedData -> {
-            GridPane gridPane = new GridPane();
-
-            gridPane.setPadding(new Insets(0, 0, 0, 10));
-            gridPane.setHgap(16);
-            gridPane.setVgap(12);
-
-            ColumnConstraints column = new ColumnConstraints();
-            column.setHgrow(Priority.ALWAYS);
-            gridPane.getColumnConstraints().setAll(column);
+            gridPane.getChildren().clear();
 
             switch (selectedData) {
                 case DEFAULT:
@@ -228,24 +240,11 @@ public class OfflineAccountSkinPane extends StackPane {
                     break;
             }
 
-            HBox body = new HBox(20);
-
-            skinItem.setPrefWidth(170);
-            skinItem.setMinWidth(170);
-
-            body.getChildren().add(skinItem);
-
-            if (!gridPane.getChildren().isEmpty()) {
-                VBox right = new VBox();
-                right.getChildren().add(gridPane);
-
-                right.setPrefWidth(230);
-                HBox.setHgrow(right, Priority.ALWAYS);
-
+            if (gridPane.getChildren().isEmpty()) {
+                body.getChildren().remove(right);
+            } else if (!body.getChildren().contains(right)) {
                 body.getChildren().add(right);
             }
-
-            skinOptionPane.getChildren().setAll(body);
         });
 
         JFXButton acceptButton = new JFXButton(i18n("button.ok"));

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
@@ -75,7 +75,7 @@ public class OfflineAccountSkinPane extends StackPane {
 
         BorderPane pane = new BorderPane();
 
-        SkinCanvas canvas = new SkinCanvas(TexturesLoader.getDefaultSkinImage(), 300, 300, true);
+        SkinCanvas canvas = new SkinCanvas(TexturesLoader.getDefaultSkinImage(), 260, 260, true);
         StackPane canvasPane = new StackPane(canvas);
         canvasPane.setPrefWidth(300);
         canvasPane.setPrefHeight(300);
@@ -101,12 +101,17 @@ public class OfflineAccountSkinPane extends StackPane {
         });
 
         StackPane skinOptionPane = new StackPane();
-        skinOptionPane.setMaxWidth(300);
-        VBox optionPane = new VBox(skinItem, skinOptionPane);
-        pane.setRight(optionPane);
+        pane.setRight(skinOptionPane);
 
-        skinSelector.maxWidthProperty().bind(skinOptionPane.maxWidthProperty().multiply(0.7));
-        capeSelector.maxWidthProperty().bind(skinOptionPane.maxWidthProperty().multiply(0.7));
+        skinSelector.setMaxWidth(Double.MAX_VALUE);
+        capeSelector.setMaxWidth(Double.MAX_VALUE);
+        modelCombobox.setMaxWidth(Double.MAX_VALUE);
+        cslApiField.setMaxWidth(Double.MAX_VALUE);
+
+        GridPane.setHgrow(modelCombobox, Priority.ALWAYS);
+        GridPane.setHgrow(skinSelector, Priority.ALWAYS);
+        GridPane.setHgrow(capeSelector, Priority.ALWAYS);
+        GridPane.setHgrow(cslApiField, Priority.ALWAYS);
 
         layout.setBody(pane);
 
@@ -182,48 +187,77 @@ public class OfflineAccountSkinPane extends StackPane {
 
         FXUtils.onChangeAndOperate(skinItem.selectedDataProperty(), selectedData -> {
             GridPane gridPane = new GridPane();
-            // Increase bottom padding to prevent the prompt from overlapping with the dialog action area
 
-            gridPane.setPadding(new Insets(0, 0, 45, 10));
+            gridPane.setPadding(new Insets(0, 0, 0, 10));
             gridPane.setHgap(16);
-            gridPane.setVgap(8);
-            gridPane.getColumnConstraints().setAll(new ColumnConstraints(), FXUtils.getColumnHgrowing());
+            gridPane.setVgap(12);
+
+            ColumnConstraints column = new ColumnConstraints();
+            column.setHgrow(Priority.ALWAYS);
+            gridPane.getColumnConstraints().setAll(column);
 
             switch (selectedData) {
                 case DEFAULT:
                 case STEVE:
                 case ALEX:
                     break;
+
                 case LITTLE_SKIN:
                     HintPane hint = new HintPane(MessageDialogPane.MessageType.INFO);
                     hint.setText(i18n("account.skin.type.little_skin.hint"));
 
-                    // Spanning two columns and expanding horizontally
-                    GridPane.setColumnSpan(hint, 2);
-                    GridPane.setHgrow(hint, Priority.ALWAYS);
                     hint.setMaxWidth(Double.MAX_VALUE);
-
-                    // Force top alignment within cells (to avoid vertical offset caused by the baseline)
-                    GridPane.setValignment(hint, VPos.TOP);
-
-                    // Set a fixed height as the preferred height to prevent the GridPane from stretching or leaving empty space.
-                    hint.setMaxHeight(Region.USE_PREF_SIZE);
-                    hint.setMinHeight(Region.USE_PREF_SIZE);
+                    GridPane.setHgrow(hint, Priority.ALWAYS);
 
                     gridPane.addRow(0, hint);
                     break;
+
                 case LOCAL_FILE:
-                    gridPane.setPadding(new Insets(0, 0, 0, 10));
-                    gridPane.addRow(0, new Label(i18n("account.skin.model")), modelCombobox);
-                    gridPane.addRow(1, new Label(i18n("account.skin")), skinSelector);
-                    gridPane.addRow(2, new Label(i18n("account.cape")), capeSelector);
+                    modelCombobox.setMaxWidth(Double.MAX_VALUE);
+                    skinSelector.setMaxWidth(Double.MAX_VALUE);
+                    capeSelector.setMaxWidth(Double.MAX_VALUE);
+
+                    GridPane.setHgrow(modelCombobox, Priority.ALWAYS);
+                    GridPane.setHgrow(skinSelector, Priority.ALWAYS);
+                    GridPane.setHgrow(capeSelector, Priority.ALWAYS);
+
+                    gridPane.addRow(0, new Label(i18n("account.skin.model")));
+                    gridPane.addRow(1, modelCombobox);
+
+                    gridPane.addRow(2, new Label(i18n("account.skin")));
+                    gridPane.addRow(3, skinSelector);
+
+                    gridPane.addRow(4, new Label(i18n("account.cape")));
+                    gridPane.addRow(5, capeSelector);
                     break;
+
                 case CUSTOM_SKIN_LOADER_API:
-                    gridPane.addRow(0, new Label(i18n("account.skin.type.csl_api.location")), cslApiField);
+                    cslApiField.setMaxWidth(Double.MAX_VALUE);
+                    GridPane.setHgrow(cslApiField, Priority.ALWAYS);
+
+                    gridPane.addRow(0, new Label(i18n("account.skin.type.csl_api.location")));
+                    gridPane.addRow(1, cslApiField);
                     break;
             }
 
-            skinOptionPane.getChildren().setAll(gridPane);
+            HBox body = new HBox(20);
+
+            skinItem.setPrefWidth(170);
+            skinItem.setMinWidth(170);
+
+            body.getChildren().add(skinItem);
+
+            if (!gridPane.getChildren().isEmpty()) {
+                VBox right = new VBox();
+                right.getChildren().add(gridPane);
+
+                right.setPrefWidth(230);
+                HBox.setHgrow(right, Priority.ALWAYS);
+
+                body.getChildren().add(right);
+            }
+
+            skinOptionPane.getChildren().setAll(body);
         });
 
         JFXButton acceptButton = new JFXButton(i18n("button.ok"));

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
@@ -78,7 +78,7 @@ public class OfflineAccountSkinPane extends StackPane {
         StackPane canvasPane = new StackPane(canvas);
         canvasPane.setPrefWidth(300);
         canvasPane.setPrefHeight(300);
-        pane.setCenter(canvas);
+        pane.setCenter(canvasPane);
         canvas.getAnimationPlayer().addSkinAnimation(new SkinAniWavingArms(100, 2000, 7.5, canvas), new SkinAniRunning(100, 100, 30, canvas));
         canvas.enableRotation(.5);
 
@@ -212,14 +212,6 @@ public class OfflineAccountSkinPane extends StackPane {
                     break;
 
                 case LOCAL_FILE:
-                    modelCombobox.setMaxWidth(Double.MAX_VALUE);
-                    skinSelector.setMaxWidth(Double.MAX_VALUE);
-                    capeSelector.setMaxWidth(Double.MAX_VALUE);
-
-                    GridPane.setHgrow(modelCombobox, Priority.ALWAYS);
-                    GridPane.setHgrow(skinSelector, Priority.ALWAYS);
-                    GridPane.setHgrow(capeSelector, Priority.ALWAYS);
-
                     gridPane.addRow(0, new Label(i18n("account.skin.model")));
                     gridPane.addRow(1, modelCombobox);
 
@@ -231,9 +223,6 @@ public class OfflineAccountSkinPane extends StackPane {
                     break;
 
                 case CUSTOM_SKIN_LOADER_API:
-                    cslApiField.setMaxWidth(Double.MAX_VALUE);
-                    GridPane.setHgrow(cslApiField, Priority.ALWAYS);
-
                     gridPane.addRow(0, new Label(i18n("account.skin.type.csl_api.location")));
                     gridPane.addRow(1, cslApiField);
                     break;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
@@ -25,7 +25,6 @@ import javafx.animation.PauseTransition;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.geometry.Insets;
-import javafx.geometry.VPos;
 import javafx.scene.control.Label;
 import javafx.scene.input.DragEvent;
 import javafx.scene.input.TransferMode;


### PR DESCRIPTION
# 重构`OfflineAccountSkinPane`

## 缘由

- `OfflineAccountSkinPane`由`Controllers.dialog()`进行调用，在其内容过多的情况下，可能占满整个窗口的高度。

## 更改

- 减低了`OfflineAccountSkinPane`的高度。
- 拆分了面板。
- 整理了语句。

## 实况

|更改前|更改后|
|---|---|
|<img width="1227" height="762" alt="A1" src="https://github.com/user-attachments/assets/e884d7ec-e12a-4328-9926-cff9d04de514" />|<img width="1227" height="762" alt="B1" src="https://github.com/user-attachments/assets/0d62b826-df45-4a76-9862-d9b6ccba1f9e" />|
|<img width="1227" height="762" alt="A2" src="https://github.com/user-attachments/assets/fe40af74-6bf5-4d59-be3c-ca7929dc4947" />|<img width="1227" height="762" alt="B2" src="https://github.com/user-attachments/assets/1f55d7b5-8d02-4230-8018-15495c4b6959" />|