### PR TITLE
Fix: FontComboBox closes unexpectedly

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/FontComboBox.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/FontComboBox.java
@@ -28,6 +28,9 @@ import com.jfoenix.controls.JFXComboBox;
 import com.jfoenix.controls.JFXListCell;
 
 import javafx.beans.binding.Bindings;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.control.skin.ComboBoxListViewSkin;
 import javafx.scene.text.Font;
 
 public final class FontComboBox extends JFXComboBox<String> {
@@ -60,6 +63,23 @@ public final class FontComboBox extends JFXComboBox<String> {
             itemsProperty().unbind();
             setItems(observableList(Font.getFamilies()));
             loaded = true;
+        });
+
+        skinProperty().addListener((obs, oldSkin, newSkin) -> {
+            if (!(newSkin instanceof ComboBoxListViewSkin<?> skin)) {
+                return;
+            }
+
+            skin.setHideOnClick(false);
+
+            @SuppressWarnings("unchecked")
+            ListView<String> listView = (ListView<String>) skin.getPopupContent();
+
+            listView.setOnMouseClicked(e -> {
+                if (e.getTarget() instanceof ListCell<?>) {
+                    hide();
+                }
+            });
         });
     }
 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/FontComboBox.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/FontComboBox.java
@@ -73,18 +73,17 @@ public final class FontComboBox extends JFXComboBox<String> {
 
             skin.setHideOnClick(false);
 
-            @SuppressWarnings("unchecked")
-            ListView<String> listView = (ListView<String>) skin.getPopupContent();
-
-            listView.setOnMouseClicked(e -> {
-                Node target = e.getTarget() instanceof Node ? (Node) e.getTarget() : null;
-                while (target != null && !(target instanceof ListCell)) {
-                    target = target.getParent();
-                }
-                if (target instanceof ListCell<?> cell && !cell.isEmpty()) {
-                    hide();
-                }
-            });
+            if (skin.getPopupContent() instanceof ListView<?> listView) {
+                listView.addEventHandler(javafx.scene.input.MouseEvent.MOUSE_CLICKED, e -> {
+                    Node target = e.getTarget() instanceof Node ? (Node) e.getTarget() : null;
+                    while (target != null && !(target instanceof ListCell)) {
+                        target = target.getParent();
+                    }
+                    if (target instanceof ListCell<?> cell && !cell.isEmpty()) {
+                        hide();
+                    }
+                });
+            }
         });
     }
 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/FontComboBox.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/FontComboBox.java
@@ -28,6 +28,7 @@ import com.jfoenix.controls.JFXComboBox;
 import com.jfoenix.controls.JFXListCell;
 
 import javafx.beans.binding.Bindings;
+import javafx.scene.Node;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.skin.ComboBoxListViewSkin;
@@ -76,7 +77,11 @@ public final class FontComboBox extends JFXComboBox<String> {
             ListView<String> listView = (ListView<String>) skin.getPopupContent();
 
             listView.setOnMouseClicked(e -> {
-                if (e.getTarget() instanceof ListCell<?>) {
+                Node target = e.getTarget() instanceof Node ? (Node) e.getTarget() : null;
+                while (target != null && !(target instanceof ListCell)) {
+                    target = target.getParent();
+                }
+                if (target instanceof ListCell<?> cell && !cell.isEmpty()) {
                     hide();
                 }
             });


### PR DESCRIPTION
# 修复`FontComboBox`在预期外关闭的问题

## 问题

- 拖动滑条后会关闭Pop
- 单击滑条也会关闭Pop

## 更改

- 关闭条件限制为：选择列表项、点击列表外

## 实况

### 更改前

https://github.com/user-attachments/assets/dbaad123-bda6-41b7-b010-574666f71e3a

### 更改后

https://github.com/user-attachments/assets/136afe32-29f6-406e-a3e0-f5b727cc05a8