### PR TITLE
fix: 下载页面项目高度明显比实例页面项目高

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
@@ -386,7 +386,7 @@ public final class VersionsPage extends Control implements WizardPage, Refreshab
                         list = new JFXListView<>();
                         list.getStyleClass().add("jfx-list-view-float");
 
-                        list.setFixedCellSize(65);
+                        list.setFixedCellSize(55);
 
                         VBox.setVgrow(list, Priority.ALWAYS);
 


### PR DESCRIPTION
实例页面项目：
<img width="263" height="190" alt="67d8d69fa9dcf58c4e3a33c43d8ef388" src="https://github.com/user-attachments/assets/9e147b4d-16e5-4cd7-b16d-3251e2a79718" />
下载页面项目：
<img width="467" height="313" alt="9ed8f22766213b3dcc3b0b31409e0a5b" src="https://github.com/user-attachments/assets/1c3bdece-72da-4787-acad-c1a5a67591a9" />
本 PR 修复后下载页面项目：
<img width="302" height="213" alt="a0fe67d265881da3f950dcfde798c6fd" src="https://github.com/user-attachments/assets/8ba42a9a-f192-4b38-831e-1143ae5192b7" />
