### PR TITLE
fix: i18n 键名引用错误

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
@@ -93,7 +93,7 @@ public class DownloadSettingsPage extends StackPane {
 
                 var defaultAddonSourcePane = new LineSelectButton<String>();
                 defaultAddonSourcePane.setTitle(i18n("settings.launcher.default_addon_source"));
-                defaultAddonSourcePane.setNullSafeConverter(key -> I18n.i18n("mods." + key));
+                defaultAddonSourcePane.setNullSafeConverter(key -> I18n.i18n("addon." + key));
                 defaultAddonSourcePane.setItems("modrinth", "curseforge");
                 defaultAddonSourcePane.valueProperty().bindBidirectional(settings().defaultAddonSourceProperty());
 


### PR DESCRIPTION
<img width="878" height="391" alt="image" src="https://github.com/user-attachments/assets/34ce87ec-8c27-4c0d-adab-a2adeec5b8b4" />
