### PR TITLE
Fix: Fixed the alignment of deprecatedJvmMemorySettings memory unit

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/game/GameSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/game/GameSettingsPage.java
@@ -655,7 +655,7 @@ public final class GameSettingsPage<S extends GameSettings> extends StackPane
                     var rightBox = new HBox(8, txtMinMemory, new Label(i18n("settings.memory.unit.mib")));
                     rightBox.setAlignment(Pos.CENTER);
 
-                    minMemoryPane.setRight(new HBox(8, txtMinMemory, rightBox));
+                    minMemoryPane.setRight(rightBox);
                     bindIndependentIntegerTextField(minMemoryPane, txtMinMemory, GameSettings::minMemoryProperty);
                 }
 
@@ -669,7 +669,7 @@ public final class GameSettingsPage<S extends GameSettings> extends StackPane
                     var rightBox = new HBox(8, txtMetaspace, new Label(i18n("settings.memory.unit.mib")));
                     rightBox.setAlignment(Pos.CENTER);
 
-                    metaspacePane.setRight(new HBox(8, txtMetaspace, rightBox));
+                    metaspacePane.setRight(rightBox);
                     bindIndependentTextField(metaspacePane, txtMetaspace, GameSettings::permSizeProperty);
                 }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/game/GameSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/game/GameSettingsPage.java
@@ -653,7 +653,7 @@ public final class GameSettingsPage<S extends GameSettings> extends StackPane
                     txtMinMemory.setPrefWidth(160);
 
                     var rightBox = new HBox(8, txtMinMemory, new Label(i18n("settings.memory.unit.mib")));
-                    rightBox.setAlignment(Pos.CENTER);
+                    rightBox.setAlignment(Pos.CENTER_RIGHT);
 
                     minMemoryPane.setRight(rightBox);
                     bindIndependentIntegerTextField(minMemoryPane, txtMinMemory, GameSettings::minMemoryProperty);
@@ -667,7 +667,7 @@ public final class GameSettingsPage<S extends GameSettings> extends StackPane
                     txtMetaspace.setPrefWidth(160);
 
                     var rightBox = new HBox(8, txtMetaspace, new Label(i18n("settings.memory.unit.mib")));
-                    rightBox.setAlignment(Pos.CENTER);
+                    rightBox.setAlignment(Pos.CENTER_RIGHT);
 
                     metaspacePane.setRight(rightBox);
                     bindIndependentTextField(metaspacePane, txtMetaspace, GameSettings::permSizeProperty);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/game/GameSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/game/GameSettingsPage.java
@@ -651,7 +651,11 @@ public final class GameSettingsPage<S extends GameSettings> extends StackPane
                 {
                     var txtMinMemory = new JFXTextField();
                     txtMinMemory.setPrefWidth(160);
-                    minMemoryPane.setRight(new HBox(8, txtMinMemory, new Label(i18n("settings.memory.unit.mib"))));
+
+                    var rightBox = new HBox(8, txtMinMemory, new Label(i18n("settings.memory.unit.mib")));
+                    rightBox.setAlignment(Pos.CENTER);
+
+                    minMemoryPane.setRight(new HBox(8, txtMinMemory, rightBox));
                     bindIndependentIntegerTextField(minMemoryPane, txtMinMemory, GameSettings::minMemoryProperty);
                 }
 
@@ -661,7 +665,11 @@ public final class GameSettingsPage<S extends GameSettings> extends StackPane
                     var txtMetaspace = new JFXTextField();
                     txtMetaspace.setPromptText(i18n("settings.advanced.java_permanent_generation_space.prompt"));
                     txtMetaspace.setPrefWidth(160);
-                    metaspacePane.setRight(new HBox(8, txtMetaspace, new Label(i18n("settings.memory.unit.mib"))));
+
+                    var rightBox = new HBox(8, txtMetaspace, new Label(i18n("settings.memory.unit.mib")));
+                    rightBox.setAlignment(Pos.CENTER);
+
+                    metaspacePane.setRight(new HBox(8, txtMetaspace, rightBox));
                     bindIndependentTextField(metaspacePane, txtMetaspace, GameSettings::permSizeProperty);
                 }
 


### PR DESCRIPTION
# 修复了`deprecatedJvmMemorySettings`中单位的对齐

## 修改

- 单位居中对齐

## 实况

|修改前|修改后|
|---|---|
|<img width="872" height="258" alt="1" src="https://github.com/user-attachments/assets/19c0c36f-7295-4e11-abe6-5d1de8db8662" />|<img width="869" height="258" alt="2" src="https://github.com/user-attachments/assets/dfeb1dd7-21b5-4a8f-826a-2e29e723f6fe" />|
