### PR TITLE
Fix: Center toast message

### DIFF
--- a/HMCL/src/main/java/com/jfoenix/controls/JFXSnackbarLayout.java
+++ b/HMCL/src/main/java/com/jfoenix/controls/JFXSnackbarLayout.java
@@ -54,7 +54,8 @@ public class JFXSnackbarLayout extends BorderPane {
         StackPane toastContainer = new StackPane(toast);
         toastContainer.setPadding(new Insets(20));
         actionContainer = new StackPane();
-        actionContainer.setPadding(Insets.EMPTY);
+        actionContainer.setVisible(false);
+        actionContainer.setManaged(false);
 
         toast.prefWidthProperty().bind(Bindings.createDoubleBinding(() -> {
             if (getPrefWidth() == -1) {

--- a/HMCL/src/main/java/com/jfoenix/controls/JFXSnackbarLayout.java
+++ b/HMCL/src/main/java/com/jfoenix/controls/JFXSnackbarLayout.java
@@ -54,7 +54,7 @@ public class JFXSnackbarLayout extends BorderPane {
         StackPane toastContainer = new StackPane(toast);
         toastContainer.setPadding(new Insets(20));
         actionContainer = new StackPane();
-        actionContainer.setPadding(new Insets(0, 10, 0, 0));
+        actionContainer.setPadding(Insets.EMPTY);
 
         toast.prefWidthProperty().bind(Bindings.createDoubleBinding(() -> {
             if (getPrefWidth() == -1) {
@@ -78,6 +78,7 @@ public class JFXSnackbarLayout extends BorderPane {
             actionContainer.getChildren().add(action);
 
             if (!actionText.isEmpty()) {
+                actionContainer.setPadding(new Insets(0, 10, 0, 0));
                 action.setVisible(true);
                 actionContainer.setVisible(true);
                 actionContainer.setManaged(true);


### PR DESCRIPTION
# 修复`toast`提示文本未居中显示

## 原因

- 在`com.jfoenix.controls.JFXSnackbarLayout`中（行57），默认为右侧设置了 **Padding**，这一设计是为右侧按钮设置的，但是在没有按钮的情况下，`DecoratorController.showToast(String content)`内容也会有偏移

```
actionContainer.setPadding(new Insets(0, 10, 0, 0));
```

## 更改

- 添加条件判断

## 实况

### 修改前

<img width="232" height="109" alt="1" src="https://github.com/user-attachments/assets/04629acf-8ff9-4533-ae67-3116f0fe1bab" />

### 修改
<img width="220" height="109" alt="2" src="https://github.com/user-attachments/assets/eecb2cbe-74d3-4257-805a-ceeee9fd6929" />