### PR TITLE
Fix: Reduce excessive bottom margin of image container

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
@@ -301,7 +301,7 @@ public class InstallerItem extends Control {
                 pane.getChildren().add(imageContainer);
 
                 if (control.style == Style.CARD) {
-                    VBox.setMargin(imageContainer, new Insets(8, 0, 16, 0));
+                    VBox.setMargin(imageContainer, new Insets(8, 0, 8, 0));
                 }
             }
 


### PR DESCRIPTION
# 修复`InstallerItemSkin`中图标容器底部间距过高的问题

## 缘由

- 原来的上边距为8，下边距为16，看起来图标比较靠近顶部

## 实况

|修改前|修改后|
|---|---|
|<img width="285" height="199" alt="111" src="https://github.com/user-attachments/assets/65a336d8-e2f4-4e4e-af95-9eced40d3196" />|<img width="284" height="205" alt="222" src="https://github.com/user-attachments/assets/57084e8a-42d1-4815-b7e7-a5a55fc3a245" />|
|<img width="874" height="199" alt="11" src="https://github.com/user-attachments/assets/edd51422-4325-481f-b576-16a11473ccd2" />|<img width="868" height="205" alt="22" src="https://github.com/user-attachments/assets/84d56253-667a-4fd4-a2d1-1165184c5715" />|
|<img width="1227" height="762" alt="1" src="https://github.com/user-attachments/assets/c086a57f-bfe6-4639-94ed-b9267805fbd6" />|<img width="1227" height="762" alt="2" src="https://github.com/user-attachments/assets/f18981ad-1991-42b3-888e-46c786c80e6d" />|