### PR TITLE
修复自动选择线程数的填写框没有做数字校验

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
@@ -161,7 +161,10 @@ public class DownloadSettingsPage extends StackPane {
 
                     JFXTextField threadsField = new JFXTextField();
                     FXUtils.setLimitWidth(threadsField, 60);
-                    FXUtils.bindInt(threadsField, settings().downloadThreadsProperty());
+                    FXUtils.bind(threadsField, settings().downloadThreadsProperty(), SafeStringConverter.fromInteger()
+                            .restrict(it -> it > 0)
+                            .fallbackTo(FetchTask.DEFAULT_CONCURRENCY)
+                            .asPredicate(Validator.addTo(threadsField)));
 
                     AtomicBoolean changedByTextField = new AtomicBoolean(false);
                     FXUtils.onChangeAndOperate(settings().downloadThreadsProperty(), value -> {


### PR DESCRIPTION
<img width="433" height="127" alt="image" src="https://github.com/user-attachments/assets/3c950032-7522-4812-8d1f-43f7950d9d5c" />

之前写0或者负数能随便填，会炸