### PR TITLE
Perf: Optimize background opacity calculation for high-res images

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/theme/Themes.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/theme/Themes.java
@@ -29,12 +29,11 @@ import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.SetChangeListener;
+import javafx.embed.swing.SwingFXUtils;
 import javafx.event.EventHandler;
 import javafx.geometry.Insets;
-import javafx.scene.SnapshotParameters;
-import javafx.scene.canvas.Canvas;
-import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.image.Image;
+import javafx.scene.image.PixelFormat;
 import javafx.scene.image.WritableImage;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundFill;
@@ -79,6 +78,9 @@ import org.jackhuang.hmcl.util.platform.windows.WinTypes;
 import org.jetbrains.annotations.NotNullByDefault;
 import org.jetbrains.annotations.Nullable;
 
+import java.awt.Graphics2D;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -955,26 +957,43 @@ public final class Themes {
                     new BackgroundSize(800, 480, false, false, true, true)
             ));
         } else {
-            Canvas canvas = new Canvas(800, 480);
-            GraphicsContext gc = canvas.getGraphicsContext2D();
+            int targetWidth = 800;
+            int targetHeight = 480;
 
             double imageWidth = image.getWidth();
             double imageHeight = image.getHeight();
-            double scale = Math.max(800 / imageWidth, 480 / imageHeight); 
-            
-            gc.setGlobalAlpha(opacity);
-            gc.drawImage(image, 0, 0, imageWidth * scale, imageHeight * scale);
 
-            SnapshotParameters params = new SnapshotParameters();
-            params.setFill(Color.TRANSPARENT);
-            WritableImage tempImage = canvas.snapshot(params, null);
+            double scale = Math.max(targetWidth / imageWidth, targetHeight / imageHeight); 
+
+            BufferedImage srcBuffered = SwingFXUtils.fromFXImage(image, null);
+
+            BufferedImage destBuffered = new BufferedImage(targetWidth, targetHeight, BufferedImage.TYPE_INT_ARGB);
+            Graphics2D g2d = destBuffered.createGraphics();
+            
+            AffineTransform at = new AffineTransform();
+            at.scale(scale, scale);
+            g2d.drawImage(srcBuffered, at, null);
+            g2d.dispose();
+
+            WritableImage tempImage = SwingFXUtils.toFXImage(destBuffered, null);
+
+            int[] buffer = new int[targetWidth * targetHeight];
+            tempImage.getPixelReader().getPixels(0, 0, targetWidth, targetHeight, PixelFormat.getIntArgbInstance(), buffer, 0, targetWidth);
+
+            int alphaMultiplier = (int) (opacity * 255);
+            for (int i = 0; i < buffer.length; i++) {
+                int argb = buffer[i];
+                int a = ((argb >>> 24) * alphaMultiplier) / 255;
+                buffer[i] = (a << 24) | (argb & 0x00FFFFFF);
+            }
+
+            tempImage.getPixelWriter().setPixels(0, 0, targetWidth, targetHeight, PixelFormat.getIntArgbInstance(), buffer, 0, targetWidth);
 
             return new Background(new BackgroundImage(
                     tempImage,
-                    BackgroundRepeat.NO_REPEAT,
-                    BackgroundRepeat.NO_REPEAT,
+                    BackgroundRepeat.NO_REPEAT, BackgroundRepeat.NO_REPEAT,
                     BackgroundPosition.DEFAULT,
-                    new BackgroundSize(800, 480, false, false, true, true)
+                    new BackgroundSize(targetWidth, targetHeight, false, false, true, true)
             ));
         }
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/theme/Themes.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/theme/Themes.java
@@ -946,7 +946,7 @@ public final class Themes {
 
         if (opacity <= 0) {
             return new Background(new BackgroundFill(new Color(1, 1, 1, 0), CornerRadii.EMPTY, Insets.EMPTY));
-        } else if (opacity >= 1.0) {
+        } else if (opacity >= 1.0 || image.getPixelReader() == null) {
             return new Background(new BackgroundImage(
                     image,
                     BackgroundRepeat.NO_REPEAT,

--- a/HMCL/src/main/java/org/jackhuang/hmcl/theme/Themes.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/theme/Themes.java
@@ -31,9 +31,10 @@ import javafx.beans.value.ObservableValue;
 import javafx.collections.SetChangeListener;
 import javafx.event.EventHandler;
 import javafx.geometry.Insets;
+import javafx.scene.SnapshotParameters;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.image.Image;
-import javafx.scene.image.PixelReader;
-import javafx.scene.image.PixelWriter;
 import javafx.scene.image.WritableImage;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundFill;
@@ -941,10 +942,11 @@ public final class Themes {
 
     /// Creates a JavaFX image background with the requested opacity.
     private static Background createBackgroundWithOpacity(Image image, double opacity) {
-        PixelReader pixelReader = image.getPixelReader();
+        if (image == null) return null;
+
         if (opacity <= 0) {
             return new Background(new BackgroundFill(new Color(1, 1, 1, 0), CornerRadii.EMPTY, Insets.EMPTY));
-        } else if (opacity >= 1. || pixelReader == null) {
+        } else if (opacity >= 1.0) {
             return new Background(new BackgroundImage(
                     image,
                     BackgroundRepeat.NO_REPEAT,
@@ -953,15 +955,19 @@ public final class Themes {
                     new BackgroundSize(800, 480, false, false, true, true)
             ));
         } else {
-            WritableImage tempImage = new WritableImage((int) image.getWidth(), (int) image.getHeight());
-            PixelWriter pixelWriter = tempImage.getPixelWriter();
-            for (int y = 0; y < image.getHeight(); y++) {
-                for (int x = 0; x < image.getWidth(); x++) {
-                    Color color = pixelReader.getColor(x, y);
-                    Color newColor = new Color(color.getRed(), color.getGreen(), color.getBlue(), color.getOpacity() * opacity);
-                    pixelWriter.setColor(x, y, newColor);
-                }
-            }
+            Canvas canvas = new Canvas(800, 480);
+            GraphicsContext gc = canvas.getGraphicsContext2D();
+
+            double imageWidth = image.getWidth();
+            double imageHeight = image.getHeight();
+            double scale = Math.max(800 / imageWidth, 480 / imageHeight); 
+            
+            gc.setGlobalAlpha(opacity);
+            gc.drawImage(image, 0, 0, imageWidth * scale, imageHeight * scale);
+
+            SnapshotParameters params = new SnapshotParameters();
+            params.setFill(Color.TRANSPARENT);
+            WritableImage tempImage = canvas.snapshot(params, null);
 
             return new Background(new BackgroundImage(
                     tempImage,


### PR DESCRIPTION
# 优化了高分辨率背景图的透明度计算

## 测试材料

- 来源：[Minecraft Wallpaper - Chaos Cubed Drop](https://www.minecraft.net/content/dam/minecraftnet/games/minecraft/software/wallpapers_chaos_cubed_drop.zip)
- 分辨率：2560 x 1440

<img width="2560" height="1440" alt="Default" src="https://github.com/user-attachments/assets/aacecfea-3ab8-46a8-aff1-145a5085070b" />

## 实况

### 修改前

https://github.com/user-attachments/assets/e59bdb4b-811c-4896-a6a7-665d37c15442

### 修改后

https://github.com/user-attachments/assets/a38f1e5e-d103-44d1-aff0-1a6c63be4f3b