### PR TITLE
导出主题时支持设置主题版本

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/theme/ThemePackManager.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/theme/ThemePackManager.java
@@ -77,7 +77,7 @@ public final class ThemePackManager {
     private static final Path USER_THEME_PACKS_DIRECTORY = Metadata.HMCL_USER_HOME.resolve("themes");
 
     /// Default version used when exporting the current launcher appearance.
-    private static final String CURRENT_THEME_PACK_VERSION = "1.0.0";
+    public static final String CURRENT_THEME_PACK_VERSION = "1.0.0";
 
     /// IDs of launcher-bundled theme packs in display order.
     private static final @Unmodifiable List<String> BUILTIN_THEME_PACK_IDS = List.of(
@@ -615,17 +615,6 @@ public final class ThemePackManager {
     ///
     /// @param outputFile the target theme-pack file
     /// @param packId     the exported package identifier
-    /// @param packName   the exported package display name
-    /// @param authorName the exported package author name
-    /// @throws IOException if the current appearance cannot be exported
-    public static void exportCurrent(Path outputFile, String packId, String packName, String authorName) throws IOException {
-        exportCurrent(outputFile, packId, CURRENT_THEME_PACK_VERSION, packName, authorName);
-    }
-
-    /// Exports the current launcher appearance to a theme-pack file.
-    ///
-    /// @param outputFile the target theme-pack file
-    /// @param packId     the exported package identifier
     /// @param version    the exported package version
     /// @param packName   the exported package display name
     /// @param authorName the exported package author name
@@ -645,17 +634,6 @@ public final class ThemePackManager {
                 }
             }
         }
-    }
-
-    /// Creates an exportable theme pack from the current launcher appearance.
-    ///
-    /// @param packId     the exported package identifier
-    /// @param packName   the exported package display name
-    /// @param authorName the exported package author name
-    /// @return the exportable theme-pack descriptor
-    /// @throws IOException if the current appearance cannot be represented as a theme pack
-    public static ExportedThemePack createCurrent(String packId, String packName, String authorName) throws IOException {
-        return createCurrent(packId, CURRENT_THEME_PACK_VERSION, packName, authorName);
     }
 
     /// Creates an exportable theme pack from the current launcher appearance.

--- a/HMCL/src/main/java/org/jackhuang/hmcl/theme/ThemePackManager.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/theme/ThemePackManager.java
@@ -619,9 +619,21 @@ public final class ThemePackManager {
     /// @param authorName the exported package author name
     /// @throws IOException if the current appearance cannot be exported
     public static void exportCurrent(Path outputFile, String packId, String packName, String authorName) throws IOException {
+        exportCurrent(outputFile, packId, CURRENT_THEME_PACK_VERSION, packName, authorName);
+    }
+
+    /// Exports the current launcher appearance to a theme-pack file.
+    ///
+    /// @param outputFile the target theme-pack file
+    /// @param packId     the exported package identifier
+    /// @param version    the exported package version
+    /// @param packName   the exported package display name
+    /// @param authorName the exported package author name
+    /// @throws IOException if the current appearance cannot be exported
+    public static void exportCurrent(Path outputFile, String packId, String version, String packName, String authorName) throws IOException {
         Objects.requireNonNull(outputFile);
 
-        ExportedThemePack themePack = createCurrent(packId, packName, authorName);
+        ExportedThemePack themePack = createCurrent(packId, version, packName, authorName);
         try {
             ThemePackExporter.export(themePack.manifest(), themePack.assets(), outputFile);
         } finally {
@@ -643,7 +655,20 @@ public final class ThemePackManager {
     /// @return the exportable theme-pack descriptor
     /// @throws IOException if the current appearance cannot be represented as a theme pack
     public static ExportedThemePack createCurrent(String packId, String packName, String authorName) throws IOException {
+        return createCurrent(packId, CURRENT_THEME_PACK_VERSION, packName, authorName);
+    }
+
+    /// Creates an exportable theme pack from the current launcher appearance.
+    ///
+    /// @param packId     the exported package identifier
+    /// @param version    the exported package version
+    /// @param packName   the exported package display name
+    /// @param authorName the exported package author name
+    /// @return the exportable theme-pack descriptor
+    /// @throws IOException if the current appearance cannot be represented as a theme pack
+    public static ExportedThemePack createCurrent(String packId, String version, String packName, String authorName) throws IOException {
         packId = ThemePackManifest.requirePackageId(packId);
+        version = requireNonBlank(version, "version");
         packName = requireNonBlank(packName, "packName");
         authorName = requireNonBlank(authorName, "authorName");
 
@@ -668,7 +693,7 @@ public final class ThemePackManager {
                     List.of());
             ThemePackManifest manifest = new ThemePackManifest(
                     packId,
-                    CURRENT_THEME_PACK_VERSION,
+                    version,
                     LocalizedText.plain(packName),
                     List.of(new ThemePackAuthor(LocalizedText.plain(authorName))),
                     background.source() instanceof ThemeBackground.Image image ? image.path() : null,

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
@@ -301,7 +301,7 @@ public class PersonalizationPage extends StackPane {
         PromptDialogPane.Builder.StringQuestion versionQuestion = new PromptDialogPane.Builder.StringQuestion(
                 i18n("theme_pack.export.version"),
                 "")
-                .setPromptText("1.0.0");
+                .setPromptText(ThemePackManager.CURRENT_THEME_PACK_VERSION);
         PromptDialogPane.Builder.StringQuestion authorNameQuestion = new PromptDialogPane.Builder.StringQuestion(
                 i18n("theme_pack.export.author"),
                 "")
@@ -312,7 +312,9 @@ public class PersonalizationPage extends StackPane {
                 .addQuestion(versionQuestion)
                 .addQuestion(authorNameQuestion)).thenAccept(questions -> exportCurrentThemePack(
                 defaultPackId,
-                StringUtils.isBlank(versionQuestion.getValue()) ? "1.0.0" : versionQuestion.getValue().trim(),
+                StringUtils.isBlank(versionQuestion.getValue())
+                        ? ThemePackManager.CURRENT_THEME_PACK_VERSION
+                        : versionQuestion.getValue().trim(),
                 StringUtils.isBlank(packNameQuestion.getValue()) ? defaultPackName : packNameQuestion.getValue().trim(),
                 StringUtils.isBlank(authorNameQuestion.getValue()) ? defaultAuthorName : authorNameQuestion.getValue().trim()));
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
@@ -294,10 +294,6 @@ public class PersonalizationPage extends StackPane {
         String userName = System.getProperty("user.name").trim();
         String defaultAuthorName = StringUtils.isBlank(userName) ? "Unknown" : userName;
 
-        PromptDialogPane.Builder.StringQuestion packIdQuestion = new PromptDialogPane.Builder.StringQuestion(
-                i18n("theme_pack.export.id"),
-                "")
-                .setPromptText(defaultPackId);
         PromptDialogPane.Builder.StringQuestion packNameQuestion = new PromptDialogPane.Builder.StringQuestion(
                 i18n("theme_pack.export.name"),
                 "")
@@ -312,11 +308,10 @@ public class PersonalizationPage extends StackPane {
                 .setPromptText(defaultAuthorName);
 
         Controllers.prompt(new PromptDialogPane.Builder(i18n("theme_pack.export.title"), (questions, handler) -> handler.resolve())
-                .addQuestion(packIdQuestion)
                 .addQuestion(packNameQuestion)
                 .addQuestion(versionQuestion)
                 .addQuestion(authorNameQuestion)).thenAccept(questions -> exportCurrentThemePack(
-                StringUtils.isBlank(packIdQuestion.getValue()) ? defaultPackId : packIdQuestion.getValue().trim(),
+                defaultPackId,
                 StringUtils.isBlank(versionQuestion.getValue()) ? "1.0.0" : versionQuestion.getValue().trim(),
                 StringUtils.isBlank(packNameQuestion.getValue()) ? defaultPackName : packNameQuestion.getValue().trim(),
                 StringUtils.isBlank(authorNameQuestion.getValue()) ? defaultAuthorName : authorNameQuestion.getValue().trim()));

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
@@ -302,6 +302,10 @@ public class PersonalizationPage extends StackPane {
                 i18n("theme_pack.export.name"),
                 "")
                 .setPromptText(defaultPackName);
+        PromptDialogPane.Builder.StringQuestion versionQuestion = new PromptDialogPane.Builder.StringQuestion(
+                i18n("theme_pack.export.version"),
+                "")
+                .setPromptText("1.0.0");
         PromptDialogPane.Builder.StringQuestion authorNameQuestion = new PromptDialogPane.Builder.StringQuestion(
                 i18n("theme_pack.export.author"),
                 "")
@@ -310,14 +314,16 @@ public class PersonalizationPage extends StackPane {
         Controllers.prompt(new PromptDialogPane.Builder(i18n("theme_pack.export.title"), (questions, handler) -> handler.resolve())
                 .addQuestion(packIdQuestion)
                 .addQuestion(packNameQuestion)
+                .addQuestion(versionQuestion)
                 .addQuestion(authorNameQuestion)).thenAccept(questions -> exportCurrentThemePack(
                 StringUtils.isBlank(packIdQuestion.getValue()) ? defaultPackId : packIdQuestion.getValue().trim(),
+                StringUtils.isBlank(versionQuestion.getValue()) ? "1.0.0" : versionQuestion.getValue().trim(),
                 StringUtils.isBlank(packNameQuestion.getValue()) ? defaultPackName : packNameQuestion.getValue().trim(),
                 StringUtils.isBlank(authorNameQuestion.getValue()) ? defaultAuthorName : authorNameQuestion.getValue().trim()));
     }
 
     /// Saves current launcher appearance as a theme-pack file with the given package metadata.
-    private void exportCurrentThemePack(String packId, String packName, String authorName) {
+    private void exportCurrentThemePack(String packId, String version, String packName, String authorName) {
         FileChooser chooser = new FileChooser();
         chooser.setTitle(i18n("theme_pack.export.title"));
         String initialFileName = sanitizeThemePackFileName(packName) + ThemePackExporter.FILE_EXTENSION;
@@ -340,6 +346,7 @@ public class PersonalizationPage extends StackPane {
             ThemePackManager.exportCurrent(
                     output,
                     packId,
+                    version,
                     packName,
                     authorName);
             Controllers.dialog(

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -1749,6 +1749,7 @@ theme_pack.export.id=Theme Pack ID
 theme_pack.export.name=Theme Name
 theme_pack.export.subtitle=Save the current launcher appearance as a theme-pack file.
 theme_pack.export.success=Theme pack has been saved to "%s".
+theme_pack.export.version=Theme Version
 theme_pack.export.title=Save theme pack
 theme_pack.file=HMCL Theme Pack
 theme_pack.import=Import Theme Pack

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -1540,6 +1540,7 @@ theme_pack.export.id=主題包 ID
 theme_pack.export.name=主題名稱
 theme_pack.export.subtitle=將目前啟動器外觀儲存為主題包檔案
 theme_pack.export.success=主題包已儲存到「%s」
+theme_pack.export.version=主題版本
 theme_pack.export.title=儲存主題包
 theme_pack.file=HMCL 主題包
 theme_pack.import=匯入主題包

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -1545,6 +1545,7 @@ theme_pack.export.id=主题包 ID
 theme_pack.export.name=主题名称
 theme_pack.export.subtitle=将当前启动器外观保存为主题包文件
 theme_pack.export.success=主题包已保存到“%s”
+theme_pack.export.version=主题版本
 theme_pack.export.title=保存主题包
 theme_pack.file=HMCL 主题包
 theme_pack.import=导入主题包

--- a/HMCL/src/test/java/org/jackhuang/hmcl/theme/ThemePackManagerTest.java
+++ b/HMCL/src/test/java/org/jackhuang/hmcl/theme/ThemePackManagerTest.java
@@ -87,7 +87,7 @@ public final class ThemePackManagerTest {
             launcherSettingsField.set(null, launcherSettings);
 
             ThemePackManager.ExportedThemePack exported =
-                    ThemePackManager.createCurrent("example.export", "Example", "1.0", "Tester");
+                    ThemePackManager.createCurrent("example.export", "1.0", "Example", "Tester");
             Theme theme = exported.manifest().themes().get(0);
             ThemeBackgroundSettings background = Objects.requireNonNull(theme.appearance().background());
             ThemeBackground.Image image = assertInstanceOf(ThemeBackground.Image.class, background.source());
@@ -146,11 +146,7 @@ public final class ThemePackManagerTest {
             launcherSettingsField.set(null, launcherSettings);
 
             ThemePackManager.ExportedThemePack exported =
-                    ThemePackManager.createCurrent(
-                            "example.export",
-                            ThemePackManager.CURRENT_THEME_PACK_VERSION,
-                            "Example",
-                            "Tester");
+                    ThemePackManager.createCurrent("example.export", "1.0", "Example", "Tester");
             try {
                 Theme theme = exported.manifest().themes().get(0);
                 ThemeBackgroundSettings background = Objects.requireNonNull(theme.appearance().background());

--- a/HMCL/src/test/java/org/jackhuang/hmcl/theme/ThemePackManagerTest.java
+++ b/HMCL/src/test/java/org/jackhuang/hmcl/theme/ThemePackManagerTest.java
@@ -87,7 +87,7 @@ public final class ThemePackManagerTest {
             launcherSettingsField.set(null, launcherSettings);
 
             ThemePackManager.ExportedThemePack exported =
-                    ThemePackManager.createCurrent("example.export", "Example", "Tester");
+                    ThemePackManager.createCurrent("example.export", "Example", "1.0", "Tester");
             Theme theme = exported.manifest().themes().get(0);
             ThemeBackgroundSettings background = Objects.requireNonNull(theme.appearance().background());
             ThemeBackground.Image image = assertInstanceOf(ThemeBackground.Image.class, background.source());
@@ -146,7 +146,11 @@ public final class ThemePackManagerTest {
             launcherSettingsField.set(null, launcherSettings);
 
             ThemePackManager.ExportedThemePack exported =
-                    ThemePackManager.createCurrent("example.export", "Example", "Tester");
+                    ThemePackManager.createCurrent(
+                            "example.export",
+                            ThemePackManager.CURRENT_THEME_PACK_VERSION,
+                            "Example",
+                            "Tester");
             try {
                 Theme theme = exported.manifest().themes().get(0);
                 ThemeBackgroundSettings background = Objects.requireNonNull(theme.appearance().background());


### PR DESCRIPTION
解决 #6283，删除了ID的UI（语言文件里没删）
<img width="436" height="232" alt="image" src="https://github.com/user-attachments/assets/e8eef964-328f-4b5d-9ef9-3c5092443ca0" />
