### PR TITLE
Fix: Aligned the height of the jfx-color-picker with the jfx-text-field

### DIFF
--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -1581,7 +1581,7 @@
     -fx-background-color: TRANSPARENT, TRANSPARENT, TRANSPARENT, TRANSPARENT;
     -fx-background-radius: 3px;
     -fx-background-insets: 0px;
-    -fx-min-height: 25px;
+    -fx-min-height: 36px;
 }
 
 .color-palette-region {


### PR DESCRIPTION
# 对齐了`jfx-color-picker`与`jfx-text-field`的高度

## 实况

|更改前|更改后|
|---|---|
|<img width="873" height="185" alt="1" src="https://github.com/user-attachments/assets/aff72aff-db8a-4619-9afa-9df170d3c886" />|<img width="878" height="185" alt="2" src="https://github.com/user-attachments/assets/776f0395-0468-4140-8d95-9e5642153083" />|