### PR TITLE
Fix: Dynamically lock fixedCellSize of VersionsPageSkin

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
@@ -391,13 +391,11 @@ public final class VersionsPage extends Control implements WizardPage, Refreshab
                         list.getStyleClass().add("jfx-list-view-float");
 
                         RemoteVersionListCell dummyCell = new RemoteVersionListCell(control);
-                        dummyCell.setPadding(Insets.EMPTY);
                         dummyCell.twoLineListItem.setTitle("Dummy");
                         dummyCell.twoLineListItem.setSubtitle("Dummy");
                         dummyCell.imageView.setImage(VersionIconType.GRASS.getIcon());
-                        dummyCell.setGraphic(dummyCell.pane);
-                        prepareNode(dummyCell);
-                        list.setFixedCellSize(dummyCell.prefHeight(-1));
+                        prepareNode(dummyCell.pane);
+                        list.setFixedCellSize(dummyCell.pane.prefHeight(-1));
 
                         VBox.setVgrow(list, Priority.ALWAYS);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
@@ -391,12 +391,13 @@ public final class VersionsPage extends Control implements WizardPage, Refreshab
                         list.getStyleClass().add("jfx-list-view-float");
 
                         RemoteVersionListCell dummyCell = new RemoteVersionListCell(control);
+                        dummyCell.setPadding(Insets.EMPTY);
                         dummyCell.twoLineListItem.setTitle("Dummy");
-                        dummyCell.twoLineListItem.setSubtitle(null);
+                        dummyCell.twoLineListItem.setSubtitle("Dummy");
                         dummyCell.imageView.setImage(VersionIconType.GRASS.getIcon());
                         dummyCell.setGraphic(dummyCell.pane);
                         prepareNode(dummyCell);
-                        list.setFixedCellSize(dummyCell.prefHeight(-1) + 5.0);
+                        list.setFixedCellSize(dummyCell.prefHeight(-1));
 
                         VBox.setVgrow(list, Priority.ALWAYS);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
@@ -390,7 +390,27 @@ public final class VersionsPage extends Control implements WizardPage, Refreshab
                         list = new JFXListView<>();
                         list.getStyleClass().add("jfx-list-view-float");
 
-                        list.setFixedCellSize(65);
+                        list.skinProperty().addListener((obs, oldSkin, newSkin) -> {
+                            if (newSkin != null) {
+                                javafx.application.Platform.runLater(() -> {
+                                    list.lookupAll(".list-cell").stream()
+                                        .filter(node -> node instanceof RemoteVersionListCell)
+                                        .map(node -> (RemoteVersionListCell) node)
+                                        .findFirst()
+                                        .ifPresent(cell -> {
+                                            if (cell.getHeight() > 0) {
+                                                list.setFixedCellSize(cell.getHeight());
+                                            } else {
+                                                cell.heightProperty().addListener((o, oldHeight, newHeight) -> {
+                                                    if (newHeight.doubleValue() > 0 && list.getFixedCellSize() <= 0) {
+                                                        list.setFixedCellSize(newHeight.doubleValue());
+                                                    }
+                                                });
+                                            }
+                                        });
+                                });
+                            }
+                        });
 
                         VBox.setVgrow(list, Priority.ALWAYS);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
@@ -390,27 +390,13 @@ public final class VersionsPage extends Control implements WizardPage, Refreshab
                         list = new JFXListView<>();
                         list.getStyleClass().add("jfx-list-view-float");
 
-                        list.skinProperty().addListener((obs, oldSkin, newSkin) -> {
-                            if (newSkin != null) {
-                                javafx.application.Platform.runLater(() -> {
-                                    list.lookupAll(".list-cell").stream()
-                                        .filter(node -> node instanceof RemoteVersionListCell)
-                                        .map(node -> (RemoteVersionListCell) node)
-                                        .findFirst()
-                                        .ifPresent(cell -> {
-                                            if (cell.getHeight() > 0) {
-                                                list.setFixedCellSize(cell.getHeight());
-                                            } else {
-                                                cell.heightProperty().addListener((o, oldHeight, newHeight) -> {
-                                                    if (newHeight.doubleValue() > 0 && list.getFixedCellSize() <= 0) {
-                                                        list.setFixedCellSize(newHeight.doubleValue());
-                                                    }
-                                                });
-                                            }
-                                        });
-                                });
-                            }
-                        });
+                        RemoteVersionListCell dummyCell = new RemoteVersionListCell(control);
+                        dummyCell.twoLineListItem.setTitle("Dummy");
+                        dummyCell.twoLineListItem.setSubtitle(null);
+                        dummyCell.imageView.setImage(VersionIconType.GRASS.getIcon());
+                        dummyCell.setGraphic(dummyCell.pane);
+                        prepareNode(dummyCell);
+                        list.setFixedCellSize(dummyCell.prefHeight(-1) + 5.0);
 
                         VBox.setVgrow(list, Priority.ALWAYS);
 


### PR DESCRIPTION
# 动态锁定`VersionsPageSkin`列表高度

## 更改

- 只计算一次，之后直接复用高度，避免固定值导致不同环境下的高度问题。