### PR TITLE
Fix: Fixed truncated authlib injector warning text

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AddAuthlibInjectorServerPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AddAuthlibInjectorServerPane.java
@@ -92,6 +92,8 @@ public final class AddAuthlibInjectorServerPane extends TransitionPane implement
 
             lblCreationWarning.setPrefWidth(0);
             lblCreationWarning.maxWidthProperty().bind(body.widthProperty());
+            lblCreationWarning.visibleProperty().bind(lblCreationWarning.textProperty().isNotEmpty());
+            lblCreationWarning.managedProperty().bind(lblCreationWarning.visibleProperty());
 
             body.getChildren().addAll(
                 txtServerUrl,

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AddAuthlibInjectorServerPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AddAuthlibInjectorServerPane.java
@@ -87,8 +87,19 @@ public final class AddAuthlibInjectorServerPane extends TransitionPane implement
                 actions.getChildren().setAll(cancel, nextPane);
             }
 
-            addServerPane.setBody(txtServerUrl);
-            addServerPane.setActions(lblCreationWarning, actions);
+            VBox body = new VBox();
+            body.setSpacing(8);
+
+            lblCreationWarning.prefWidthProperty().bind(body.widthProperty());
+            lblCreationWarning.setWrapText(true);
+
+            body.getChildren().addAll(
+                txtServerUrl,
+                lblCreationWarning
+            );
+
+            addServerPane.setBody(body);
+            addServerPane.setActions(actions);
 
             txtServerUrl.getValidators().addAll(new RequiredValidator(), new URLValidator());
             FXUtils.setValidateWhileTextChanged(txtServerUrl, true);
@@ -154,7 +165,6 @@ public final class AddAuthlibInjectorServerPane extends TransitionPane implement
 
         this.setContent(addServerPane, ContainerAnimations.NONE);
 
-        lblCreationWarning.maxWidthProperty().bind(((FlowPane) lblCreationWarning.getParent()).widthProperty());
         nextPane.hideSpinner();
 
         onEscPressed(this, this::onAddCancel);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AddAuthlibInjectorServerPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AddAuthlibInjectorServerPane.java
@@ -90,8 +90,8 @@ public final class AddAuthlibInjectorServerPane extends TransitionPane implement
             VBox body = new VBox();
             body.setSpacing(8);
 
-            lblCreationWarning.prefWidthProperty().bind(body.widthProperty());
-            lblCreationWarning.setWrapText(true);
+            lblCreationWarning.setPrefWidth(0);
+            lblCreationWarning.maxWidthProperty().bind(body.widthProperty());
 
             body.getChildren().addAll(
                 txtServerUrl,

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AddAuthlibInjectorServerPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AddAuthlibInjectorServerPane.java
@@ -90,6 +90,7 @@ public final class AddAuthlibInjectorServerPane extends TransitionPane implement
             VBox body = new VBox();
             body.setSpacing(8);
 
+            lblCreationWarning.setMinWidth(0);
             lblCreationWarning.setPrefWidth(0);
             lblCreationWarning.maxWidthProperty().bind(body.widthProperty());
             lblCreationWarning.visibleProperty().bind(lblCreationWarning.textProperty().isNotEmpty());


### PR DESCRIPTION
# 修复`AddAuthlibInjectorServerPane`中警告信息被截断的问题

## 实况

|修改前|修改后|
|---|---|
|<img width="706" height="341" alt="1" src="https://github.com/user-attachments/assets/ce827b06-89e8-4802-a7a5-245d4a9a6d86" />|<img width="727" height="406" alt="2" src="https://github.com/user-attachments/assets/23c14a92-bc7e-4b48-b61f-4e83ed3d84f8" />|