### PR TITLE
Fix: Adjust account item spacing

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
@@ -21,6 +21,7 @@ import com.jfoenix.controls.JFXButton;
 import com.jfoenix.controls.JFXRadioButton;
 import com.jfoenix.effects.JFXDepthManager;
 import javafx.beans.binding.Bindings;
+import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Cursor;
 import javafx.scene.canvas.Canvas;
@@ -86,6 +87,7 @@ public final class AccountListItemSkin extends SkinBase<AccountListItem> {
 
         center.getChildren().setAll(canvas, item);
         root.setCenter(center);
+        BorderPane.setMargin(center, new Insets(0, 0, 0, 8));
 
         HBox right = new HBox();
         right.setAlignment(Pos.CENTER_RIGHT);


### PR DESCRIPTION
# 调整`AccountListItemSkin`中的起始位置

## 实况

|更改前|更改后|
|---|---|
|<img width="288" height="205" alt="1" src="https://github.com/user-attachments/assets/482f8a24-2e8f-4726-a9e1-3b4ccd7d6316" />|<img width="285" height="227" alt="2" src="https://github.com/user-attachments/assets/4299e7e9-fb72-4298-841e-643cc94e0f9f" />|

### 整体效果

<img width="1227" height="762" alt="3" src="https://github.com/user-attachments/assets/608f7293-e8ca-4367-bfd5-402f3ec71caf" />