### PR TITLE
fix(build): fix missing icon in the dock/dash of Linux DEs

### DIFF
--- a/HMCL/build.gradle.kts
+++ b/HMCL/build.gradle.kts
@@ -299,6 +299,7 @@ val makeDeb by tasks.registering(CreateDeb::class) {
 
     version.set(project.version.toString())
     releaseType.set(debChannel)
+    launcherClassName.set("org.jackhuang.hmcl.Launcher")
     appShFile.set(layout.file(provider { artifactFile("sh") }))
     iconFile.set(layout.projectDirectory.file("image/hmcl.png"))
     outputFile.set(debFile)

--- a/buildSrc/src/main/java/org/jackhuang/hmcl/gradle/pack/CreateDeb.java
+++ b/buildSrc/src/main/java/org/jackhuang/hmcl/gradle/pack/CreateDeb.java
@@ -76,6 +76,10 @@ public abstract class CreateDeb extends DefaultTask {
     @Input
     public abstract Property<ReleaseType> getReleaseType();
 
+    /// Launcher class name for Linux StartupWMClass property in the .desktop file.
+    @Input
+    public abstract Property<String> getLauncherClassName();
+
     /// Executable `.sh` artifact produced by `makeExecutables`.
     @InputFile
     public abstract RegularFileProperty getAppShFile();
@@ -295,6 +299,7 @@ public abstract class CreateDeb extends DefaultTask {
                 StartupNotify=false
                 Categories=Game;
                 Keywords=mc;minecraft;
-                """.formatted(getCurrentType().getDisplayName(), getLauncherPath(), getIconTargetPath());
+                StartupWMClass=%s
+                """.formatted(getCurrentType().getDisplayName(), getLauncherPath(), getIconTargetPath(), getLauncherClassName().get());
     }
 }


### PR DESCRIPTION
The missing `StartupWMClass` property in the .desktop file is causing the app icon not displaying on the dock/dash of Linux desktop environments.

I'm not sure if there was a better way to retrieve the class name of the `Launcher` class than setting it as a property in the `build.gradle.kts` file with a literal string. If you happen to know how to retrieve the class name programmatically, feel free to tell me how to do it and I'll update the PR accordingly. Thank you.