### PR TITLE
Feat: Added rippler for AccountListItemSkin

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
@@ -55,6 +55,11 @@ public final class AccountListItemSkin extends SkinBase<AccountListItem> {
         super(skinnable);
 
         BorderPane root = new BorderPane();
+        RipplerContainer rootRippler = new RipplerContainer(root);
+
+        rootRippler.setPickOnBounds(true);
+        rootRippler.setCursor(Cursor.HAND);
+        FXUtils.onClicked(rootRippler, skinnable::fire);
 
         JFXRadioButton chkSelected = new JFXRadioButton();
         chkSelected.setMouseTransparent(true);
@@ -80,7 +85,7 @@ public final class AccountListItemSkin extends SkinBase<AccountListItem> {
             Tooltip tooltip = new Tooltip();
             AuthlibInjectorServer server = ((AuthlibInjectorAccount) skinnable.getAccount()).getServer();
             tooltip.textProperty().bind(BindingMapping.of(server, AuthlibInjectorServer::toString));
-            FXUtils.installSlowTooltip(root, tooltip);
+            FXUtils.installSlowTooltip(rootRippler, tooltip);
         }
         VBox item = new VBox(title, subtitle);
         item.getStyleClass().add("two-line-list-item");
@@ -174,11 +179,6 @@ public final class AccountListItemSkin extends SkinBase<AccountListItem> {
         root.setRight(right);
 
         root.setStyle("-fx-padding: 8 8 8 0;");
-
-        RipplerContainer rootRippler = new RipplerContainer(root);
-        rootRippler.setPickOnBounds(true);
-        rootRippler.setCursor(Cursor.HAND);
-        FXUtils.onClicked(rootRippler, skinnable::fire);
 
         Region background = new Region();
         background.setMouseTransparent(true);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
@@ -55,6 +55,7 @@ public final class AccountListItemSkin extends SkinBase<AccountListItem> {
         super(skinnable);
 
         BorderPane root = new BorderPane();
+        root.setPickOnBounds(false);
         RipplerContainer rootRippler = new RipplerContainer(root);
 
         rootRippler.setPickOnBounds(true);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
@@ -185,9 +185,9 @@ public final class AccountListItemSkin extends SkinBase<AccountListItem> {
         Region background = new Region();
         background.setMouseTransparent(true);
         background.setStyle("-fx-background-color: -monet-surface-container-low-transparent-80; -fx-background-radius: 4;");
-        JFXDepthManager.setDepth(background, 1);
 
         rootRippler.getChildren().add(0, background);
+        JFXDepthManager.setDepth(rootRippler, 1);
 
         getChildren().setAll(rootRippler);
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
@@ -59,6 +59,7 @@ public final class AccountListItemSkin extends SkinBase<AccountListItem> {
 
         rootRippler.setPickOnBounds(true);
         rootRippler.setCursor(Cursor.HAND);
+        FXUtils.setOverflowHidden(rootRippler, 8);
         FXUtils.onClicked(rootRippler, skinnable::fire);
 
         JFXRadioButton chkSelected = new JFXRadioButton();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
@@ -19,7 +19,6 @@ package org.jackhuang.hmcl.ui.account;
 
 import com.jfoenix.controls.JFXButton;
 import com.jfoenix.controls.JFXRadioButton;
-import com.jfoenix.effects.JFXDepthManager;
 import javafx.beans.binding.Bindings;
 import javafx.geometry.Pos;
 import javafx.scene.Cursor;
@@ -29,6 +28,7 @@ import javafx.scene.control.SkinBase;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import org.jackhuang.hmcl.auth.Account;
 import org.jackhuang.hmcl.auth.authlibinjector.AuthlibInjectorAccount;
@@ -41,6 +41,7 @@ import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.ui.Controllers;
 import org.jackhuang.hmcl.ui.FXUtils;
 import org.jackhuang.hmcl.ui.SVG;
+import org.jackhuang.hmcl.ui.construct.RipplerContainer;
 import org.jackhuang.hmcl.ui.construct.SpinnerPane;
 import org.jackhuang.hmcl.util.javafx.BindingMapping;
 
@@ -52,8 +53,6 @@ public final class AccountListItemSkin extends SkinBase<AccountListItem> {
         super(skinnable);
 
         BorderPane root = new BorderPane();
-        root.setCursor(Cursor.HAND);
-        FXUtils.onClicked(root, skinnable::fire);
 
         JFXRadioButton chkSelected = new JFXRadioButton();
         chkSelected.setMouseTransparent(true);
@@ -64,6 +63,7 @@ public final class AccountListItemSkin extends SkinBase<AccountListItem> {
         HBox center = new HBox();
         center.setSpacing(8);
         center.setAlignment(Pos.CENTER_LEFT);
+        center.setMouseTransparent(true);
 
         Canvas canvas = new Canvas(32, 32);
         TexturesLoader.bindAvatar(canvas, skinnable.getAccount());
@@ -171,11 +171,16 @@ public final class AccountListItemSkin extends SkinBase<AccountListItem> {
         right.getChildren().add(btnRemove);
         root.setRight(right);
 
-        root.getStyleClass().add("card");
         root.setStyle("-fx-padding: 8 8 8 0;");
-        JFXDepthManager.setDepth(root, 1);
 
-        getChildren().setAll(root);
+        RipplerContainer rootRippler = new RipplerContainer(root);
+        rootRippler.setCursor(Cursor.HAND);
+        FXUtils.onClicked(rootRippler, skinnable::fire);
+
+        Region background = new Region();
+        background.setStyle("-fx-background-color: -monet-surface-container-low-transparent-80; -fx-background-radius: 4;");
+
+        getChildren().setAll(background, rootRippler);
     }
 
     /// Moves the account between local and user account files.

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
@@ -19,6 +19,8 @@ package org.jackhuang.hmcl.ui.account;
 
 import com.jfoenix.controls.JFXButton;
 import com.jfoenix.controls.JFXRadioButton;
+import com.jfoenix.effects.JFXDepthManager;
+
 import javafx.beans.binding.Bindings;
 import javafx.geometry.Pos;
 import javafx.scene.Cursor;
@@ -78,7 +80,7 @@ public final class AccountListItemSkin extends SkinBase<AccountListItem> {
             Tooltip tooltip = new Tooltip();
             AuthlibInjectorServer server = ((AuthlibInjectorAccount) skinnable.getAccount()).getServer();
             tooltip.textProperty().bind(BindingMapping.of(server, AuthlibInjectorServer::toString));
-            FXUtils.installSlowTooltip(subtitle, tooltip);
+            FXUtils.installSlowTooltip(root, tooltip);
         }
         VBox item = new VBox(title, subtitle);
         item.getStyleClass().add("two-line-list-item");
@@ -179,7 +181,9 @@ public final class AccountListItemSkin extends SkinBase<AccountListItem> {
         FXUtils.onClicked(rootRippler, skinnable::fire);
 
         Region background = new Region();
+        background.setMouseTransparent(true);
         background.setStyle("-fx-background-color: -monet-surface-container-low-transparent-80; -fx-background-radius: 4;");
+        JFXDepthManager.setDepth(background, 1);
 
         getChildren().setAll(background, rootRippler);
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
@@ -174,6 +174,7 @@ public final class AccountListItemSkin extends SkinBase<AccountListItem> {
         root.setStyle("-fx-padding: 8 8 8 0;");
 
         RipplerContainer rootRippler = new RipplerContainer(root);
+        rootRippler.setPickOnBounds(true);
         rootRippler.setCursor(Cursor.HAND);
         FXUtils.onClicked(rootRippler, skinnable::fire);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
@@ -187,7 +187,9 @@ public final class AccountListItemSkin extends SkinBase<AccountListItem> {
         background.setStyle("-fx-background-color: -monet-surface-container-low-transparent-80; -fx-background-radius: 4;");
         JFXDepthManager.setDepth(background, 1);
 
-        getChildren().setAll(background, rootRippler);
+        rootRippler.getChildren().add(0, background);
+
+        getChildren().setAll(rootRippler);
     }
 
     /// Moves the account between local and user account files.


### PR DESCRIPTION
# 为`AccountListItemSkin`添加了水波纹效果

## 实况

https://github.com/user-attachments/assets/ac9d59be-29a8-4a8d-add7-8c72a471f20a

## 注
- `background.setStyle("-fx-background-color: -monet-surface-container-low-transparent-80; -fx-background-radius: 4;");`仍然来自原来的`card`背景样式：

```
.card {
    -fx-background-color: -monet-surface-container-low-transparent-80;
    -fx-background-radius: 4;
    -fx-padding: 8px;

    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.26), 10, 0.12, -1, 2);
}
```