### PR TITLE
优化日志窗口配色

### DIFF
--- a/HMCL/src/main/resources/assets/css/brightness-dark.css
+++ b/HMCL/src/main/resources/assets/css/brightness-dark.css
@@ -10,12 +10,14 @@
     -fixed-log-background: #282828;
     -fixed-log-toggle-selected: #DEE2E6;
     -fixed-log-toggle-unselected: #6C757D;
-    -fixed-log-text-fill: #FFFFFF;
-    -fixed-log-trace: #495057;
-    -fixed-log-debug: #343A40;
-    -fixed-log-info: #212529;
-    -fixed-log-warn:  #413c26;
-    -fixed-log-error: #4e3534;
-    -fixed-log-fatal: #842029;
+    -fixed-log-text-fill: #e3e3e3;
+    -fixed-log-trace-background: #495057;
+    -fixed-log-debug-background: #343A40;
+    -fixed-log-info-background: #212529;
+    -fixed-log-warn-background:  #413c26;
+    -fixed-log-warn-text-fill:  #fdf3aa;
+    -fixed-log-error-background: #4e3534;
+    -fixed-log-error-text-fill: #f9dedc;
+    -fixed-log-fatal-background: #842029;
     -fixed-log-selected: #3e3e3e;
 }

--- a/HMCL/src/main/resources/assets/css/brightness-dark.css
+++ b/HMCL/src/main/resources/assets/css/brightness-dark.css
@@ -7,14 +7,15 @@
 }
 
 .log-window {
+    -fixed-log-background: #282828;
     -fixed-log-toggle-selected: #DEE2E6;
     -fixed-log-toggle-unselected: #6C757D;
     -fixed-log-text-fill: #FFFFFF;
     -fixed-log-trace: #495057;
     -fixed-log-debug: #343A40;
     -fixed-log-info: #212529;
-    -fixed-log-warn: #331904;
-    -fixed-log-error: #58151C;
+    -fixed-log-warn:  #413c26;
+    -fixed-log-error: #4e3534;
     -fixed-log-fatal: #842029;
-    -fixed-log-selected: #6C757D;
+    -fixed-log-selected: #3e3e3e;
 }

--- a/HMCL/src/main/resources/assets/css/brightness-light.css
+++ b/HMCL/src/main/resources/assets/css/brightness-light.css
@@ -10,12 +10,14 @@
     -fixed-log-background: #ffffff;
     -fixed-log-toggle-selected: #000000;
     -fixed-log-toggle-unselected: #6C757D;
-    -fixed-log-text-fill: #000000;
-    -fixed-log-trace: #EEE9E0;
-    -fixed-log-debug: #EEE9E0;
-    -fixed-log-info: #FFFFFF;
-    -fixed-log-warn: #fef6d5;
-    -fixed-log-error: #fcebeb;
-    -fixed-log-fatal: #F7A699;
+    -fixed-log-text-fill: #1f1f1f;
+    -fixed-log-trace-background: #EEE9E0;
+    -fixed-log-debug-background: #EEE9E0;
+    -fixed-log-info-background: #FFFFFF;
+    -fixed-log-warn-background: #fef6d5;
+    -fixed-log-warn-text-fill:  #3e2f00;
+    -fixed-log-error-background: #fcebeb;
+    -fixed-log-error-text-fill: #410e0b;
+    -fixed-log-fatal-background: #F7A699;
     -fixed-log-selected: #f2f2f2;
 }

--- a/HMCL/src/main/resources/assets/css/brightness-light.css
+++ b/HMCL/src/main/resources/assets/css/brightness-light.css
@@ -7,14 +7,15 @@
 }
 
 .log-window {
+    -fixed-log-background: #ffffff;
     -fixed-log-toggle-selected: #000000;
     -fixed-log-toggle-unselected: #6C757D;
     -fixed-log-text-fill: #000000;
     -fixed-log-trace: #EEE9E0;
     -fixed-log-debug: #EEE9E0;
     -fixed-log-info: #FFFFFF;
-    -fixed-log-warn: #FFEECC;
-    -fixed-log-error: #FFCCBB;
+    -fixed-log-warn: #fef6d5;
+    -fixed-log-error: #fcebeb;
     -fixed-log-fatal: #F7A699;
-    -fixed-log-selected: #C4C4C4;
+    -fixed-log-selected: #f2f2f2;
 }

--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -1410,7 +1410,7 @@
 }
 
 .log-window {
-    -fx-background-color: -monet-surface-container;
+    -fx-background-color: -fixed-log-background;
 }
 
 .log-window .scroll-bar .thumb {

--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -1382,27 +1382,27 @@
 }
 
 .log-toggle.fatal {
-    -fx-background-color: -fixed-log-fatal;
+    -fx-background-color: -fixed-log-fatal-background;
 }
 
 .log-toggle.error {
-    -fx-background-color: -fixed-log-error;
+    -fx-background-color: -fixed-log-error-background;
 }
 
 .log-toggle.warn {
-    -fx-background-color: -fixed-log-warn;
+    -fx-background-color: -fixed-log-warn-background;
 }
 
 .log-toggle.info {
-    -fx-background-color: -fixed-log-info;
+    -fx-background-color: -fixed-log-info-background;
 }
 
 .log-toggle.debug {
-    -fx-background-color: -fixed-log-debug;
+    -fx-background-color: -fixed-log-debug-background;
 }
 
 .log-toggle.trace {
-    -fx-background-color: -fixed-log-trace;
+    -fx-background-color: -fixed-log-trace-background;
 }
 
 .log-window-list-cell:selected {
@@ -1433,36 +1433,36 @@
 
 .log-window-list-cell:fatal {
     -fx-text-fill: -fixed-log-text-fill;
-    -fx-background-color: -fixed-log-fatal;
+    -fx-background-color: -fixed-log-fatal-background;
 }
 
 .log-window-list-cell:error {
-    -fx-text-fill: -fixed-log-text-fill;
-    -fx-background-color: -fixed-log-error;
+    -fx-text-fill: -fixed-log-error-text-fill;
+    -fx-background-color: -fixed-log-error-background;
 }
 
 .log-window-list-cell:warn {
-    -fx-text-fill: -fixed-log-text-fill;
-    -fx-background-color: -fixed-log-warn;
+    -fx-text-fill: -fixed-log-warn-text-fill;
+    -fx-background-color: -fixed-log-warn-background;
 }
 
 .log-window-list-cell:info {
     -fx-text-fill: -fixed-log-text-fill;
-    -fx-background-color: -fixed-log-info;
+    -fx-background-color: -fixed-log-info-background;
 }
 
 .log-window-list-cell {
-    -fx-background-color: -fixed-log-info;
+    -fx-background-color: -fixed-log-info-background;
 }
 
 .log-window-list-cell:debug {
     -fx-text-fill: -fixed-log-text-fill;
-    -fx-background-color: -fixed-log-debug;
+    -fx-background-color: -fixed-log-debug-background;
 }
 
 .log-window-list-cell:trace {
     -fx-text-fill: -fixed-log-text-fill;
-    -fx-background-color: -fixed-log-trace;
+    -fx-background-color: -fixed-log-trace-background;
 }
 
 .log-window-list-cell:selected {


### PR DESCRIPTION
<img width="1204" height="767" alt="f7b01198e3e9adeaa8e0011267e8c29d" src="https://github.com/user-attachments/assets/1d24b43c-4953-4a8c-9bc7-7abb04992f31" />
<img width="1204" height="767" alt="40f3d42328d70983ff79318a5ffd35e2" src="https://github.com/user-attachments/assets/6146226e-40bf-4a93-8f00-2ab217b64ad1" />

颜色取自 Chrome Devtools（Chrome 中 Error、Warning 的配色是固定的，与主题色设置无关）