### PR TITLE
Fix: Restore subtitle when RemoteVersionListCell is reused

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
@@ -213,6 +213,7 @@ public final class VersionsPage extends Control implements WizardPage, Refreshab
         @Override
         public void updateItem(RemoteVersion remoteVersion, boolean empty) {
             RemoteVersion oldRemoteVersion = getItem();
+            
             super.updateItem(remoteVersion, empty);
 
             if (empty) {
@@ -221,6 +222,8 @@ public final class VersionsPage extends Control implements WizardPage, Refreshab
             }
             setGraphic(pane);
 
+            if (oldRemoteVersion == remoteVersion) return;
+
             twoLineListItem.setTitle(I18n.getDisplayVersion(remoteVersion));
             if (remoteVersion.getReleaseDate() != null) {
                 twoLineListItem.setSubtitle(I18n.formatDateTime(remoteVersion.getReleaseDate()));
@@ -228,67 +231,65 @@ public final class VersionsPage extends Control implements WizardPage, Refreshab
                 twoLineListItem.setSubtitle(null);
             }
 
-            if (oldRemoteVersion != remoteVersion) {
-                twoLineListItem.getTags().clear();
+            twoLineListItem.getTags().clear();
 
-                if (remoteVersion instanceof GameRemoteVersion) {
-                    RemoteVersion.Type versionType = remoteVersion.getVersionType();
-                    GameVersionNumber gameVersion = GameVersionNumber.asGameVersion(remoteVersion.getGameVersion());
+            if (remoteVersion instanceof GameRemoteVersion) {
+                RemoteVersion.Type versionType = remoteVersion.getVersionType();
+                GameVersionNumber gameVersion = GameVersionNumber.asGameVersion(remoteVersion.getGameVersion());
 
-                    switch (versionType) {
-                        case RELEASE -> {
-                            twoLineListItem.addTag(i18n("version.game.release"));
-                            imageView.setImage(VersionIconType.GRASS.getIcon());
-                        }
-                        case SNAPSHOT, PENDING, UNOBFUSCATED -> {
-                            if (versionType == RemoteVersion.Type.SNAPSHOT
-                                    && GameVersionNumber.asGameVersion(remoteVersion.getGameVersion()).isAprilFools()) {
-                                twoLineListItem.addTag(i18n("version.game.april_fools"));
-                                imageView.setImage(VersionIconType.APRIL_FOOLS.getIcon());
-                            } else {
-                                twoLineListItem.addTag(i18n("version.game.snapshot"));
-                                imageView.setImage(VersionIconType.COMMAND.getIcon());
-                            }
-                        }
-                        default -> {
-                            twoLineListItem.addTag(i18n("version.game.old"));
-                            imageView.setImage(VersionIconType.CRAFT_TABLE.getIcon());
+                switch (versionType) {
+                    case RELEASE -> {
+                        twoLineListItem.addTag(i18n("version.game.release"));
+                        imageView.setImage(VersionIconType.GRASS.getIcon());
+                    }
+                    case SNAPSHOT, PENDING, UNOBFUSCATED -> {
+                        if (versionType == RemoteVersion.Type.SNAPSHOT
+                                && GameVersionNumber.asGameVersion(remoteVersion.getGameVersion()).isAprilFools()) {
+                            twoLineListItem.addTag(i18n("version.game.april_fools"));
+                            imageView.setImage(VersionIconType.APRIL_FOOLS.getIcon());
+                        } else {
+                            twoLineListItem.addTag(i18n("version.game.snapshot"));
+                            imageView.setImage(VersionIconType.COMMAND.getIcon());
                         }
                     }
-
-                    switch (NativePatcher.checkSupportedStatus(gameVersion, Platform.SYSTEM_PLATFORM, OperatingSystem.SYSTEM_VERSION)) {
-                        case UNTESTED -> twoLineListItem.addTagWarning(i18n("version.game.support_status.untested"));
-                        case UNSUPPORTED -> twoLineListItem.addTagWarning(i18n("version.game.support_status.unsupported"));
+                    default -> {
+                        twoLineListItem.addTag(i18n("version.game.old"));
+                        imageView.setImage(VersionIconType.CRAFT_TABLE.getIcon());
                     }
-                } else {
-                    VersionIconType iconType;
-                    if (remoteVersion instanceof LiteLoaderRemoteVersion)
-                        iconType = VersionIconType.CHICKEN;
-                    else if (remoteVersion instanceof OptiFineRemoteVersion)
-                        iconType = VersionIconType.OPTIFINE;
-                    else if (remoteVersion instanceof ForgeRemoteVersion)
-                        iconType = VersionIconType.FORGE;
-                    else if (remoteVersion instanceof CleanroomRemoteVersion)
-                        iconType = VersionIconType.CLEANROOM;
-                    else if (remoteVersion instanceof NeoForgeRemoteVersion)
-                        iconType = VersionIconType.NEO_FORGE;
-                    else if (remoteVersion instanceof LegacyFabricRemoteVersion || remoteVersion instanceof LegacyFabricAPIRemoteVersion)
-                        iconType = VersionIconType.LEGACY_FABRIC;
-                    else if (remoteVersion instanceof FabricRemoteVersion || remoteVersion instanceof FabricAPIRemoteVersion)
-                        iconType = VersionIconType.FABRIC;
-                    else if (remoteVersion instanceof QuiltRemoteVersion || remoteVersion instanceof QuiltAPIRemoteVersion)
-                        iconType = VersionIconType.QUILT;
-                    else
-                        iconType = VersionIconType.COMMAND;
-
-                    imageView.setImage(iconType.getIcon());
-                    String displayGameVersion = I18n.getDisplayVersion(GameVersionNumber.asGameVersion(remoteVersion.getGameVersion()));
-
-                    if (twoLineListItem.getSubtitle() == null)
-                        twoLineListItem.setSubtitle(displayGameVersion);
-                    else
-                        twoLineListItem.addTag(displayGameVersion);
                 }
+
+                switch (NativePatcher.checkSupportedStatus(gameVersion, Platform.SYSTEM_PLATFORM, OperatingSystem.SYSTEM_VERSION)) {
+                    case UNTESTED -> twoLineListItem.addTagWarning(i18n("version.game.support_status.untested"));
+                    case UNSUPPORTED -> twoLineListItem.addTagWarning(i18n("version.game.support_status.unsupported"));
+                }
+            } else {
+                VersionIconType iconType;
+                if (remoteVersion instanceof LiteLoaderRemoteVersion)
+                    iconType = VersionIconType.CHICKEN;
+                else if (remoteVersion instanceof OptiFineRemoteVersion)
+                    iconType = VersionIconType.OPTIFINE;
+                else if (remoteVersion instanceof ForgeRemoteVersion)
+                    iconType = VersionIconType.FORGE;
+                else if (remoteVersion instanceof CleanroomRemoteVersion)
+                    iconType = VersionIconType.CLEANROOM;
+                else if (remoteVersion instanceof NeoForgeRemoteVersion)
+                    iconType = VersionIconType.NEO_FORGE;
+                else if (remoteVersion instanceof LegacyFabricRemoteVersion || remoteVersion instanceof LegacyFabricAPIRemoteVersion)
+                    iconType = VersionIconType.LEGACY_FABRIC;
+                else if (remoteVersion instanceof FabricRemoteVersion || remoteVersion instanceof FabricAPIRemoteVersion)
+                    iconType = VersionIconType.FABRIC;
+                else if (remoteVersion instanceof QuiltRemoteVersion || remoteVersion instanceof QuiltAPIRemoteVersion)
+                    iconType = VersionIconType.QUILT;
+                else
+                    iconType = VersionIconType.COMMAND;
+
+                imageView.setImage(iconType.getIcon());
+                String displayGameVersion = I18n.getDisplayVersion(GameVersionNumber.asGameVersion(remoteVersion.getGameVersion()));
+
+                if (twoLineListItem.getSubtitle() == null)
+                    twoLineListItem.setSubtitle(displayGameVersion);
+                else
+                    twoLineListItem.addTag(displayGameVersion);
             }
         }
     }


### PR DESCRIPTION
# 修复`RemoteVersionListCell`副标题消失问题

## 实况

### 更改前

https://github.com/user-attachments/assets/c268af50-9829-4540-aee0-a3f2de662998

### 更改后

https://github.com/user-attachments/assets/7594fc6b-5195-4df1-944f-e7172602fb5a