### PR TITLE
Feat: Added numbered square tag to Java runtime list cells

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaManagementPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaManagementPage.java
@@ -25,6 +25,7 @@ import javafx.collections.FXCollections;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
+import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.Skin;
 import javafx.scene.control.Tooltip;
@@ -226,6 +227,7 @@ public final class JavaManagementPage extends ListPageBase<JavaRuntime> {
 
     private static final class JavaItemCell extends ListCell<JavaRuntime> {
         private final Node graphic;
+        private final Label label = new Label();
         private final TwoLineListItem content;
 
         private SVG removeIcon;
@@ -241,11 +243,17 @@ public final class JavaManagementPage extends ListPageBase<JavaRuntime> {
             center.setSpacing(8);
             center.setAlignment(Pos.CENTER_LEFT);
 
+            label.setAlignment(Pos.CENTER);
+            label.setMinSize(24, 24);
+            label.setMaxSize(24, 24);
+            label.setPrefSize(24, 24);
+            label.setStyle("-fx-background-color: -monet-secondary-container; -fx-background-radius: 2; -fx-padding: 2; -fx-font-weight: normal; -fx-font-size: 12px;");
+
             this.content = new TwoLineListItem();
             HBox.setHgrow(content, Priority.ALWAYS);
 
             BorderPane.setAlignment(content, Pos.CENTER);
-            center.getChildren().setAll(content);
+            center.getChildren().setAll(label, content);
             root.setCenter(center);
 
             HBox right = new HBox();
@@ -293,6 +301,8 @@ public final class JavaManagementPage extends ListPageBase<JavaRuntime> {
             if (empty || item == null) {
                 setGraphic(null);
             } else {
+                label.setText(String.valueOf(item.getParsedVersion()));
+
                 content.setTitle((item.isJDK() ? "JDK" : "JRE") + " " + item.getVersion());
                 content.setSubtitle(item.getBinary().toString());
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaManagementPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaManagementPage.java
@@ -301,7 +301,8 @@ public final class JavaManagementPage extends ListPageBase<JavaRuntime> {
             if (empty || item == null) {
                 setGraphic(null);
             } else {
-                label.setText(String.valueOf(item.getParsedVersion()));
+                int parsedVersion = item.getParsedVersion();
+                label.setText(parsedVersion >= 0 ? String.valueOf(parsedVersion) : "?");
 
                 content.setTitle((item.isJDK() ? "JDK" : "JRE") + " " + item.getVersion());
                 content.setSubtitle(item.getBinary().toString());


### PR DESCRIPTION
# 为`JavaManagementPage`列表添加了版本数字表示

## 实况

|亮色|暗色|
|---|---|
|<img width="1227" height="762" alt="1" src="https://github.com/user-attachments/assets/0aaa0edf-703e-431e-9227-41806f574ffa" />|<img width="1227" height="762" alt="2" src="https://github.com/user-attachments/assets/aa1c7f42-346a-4321-b21c-f0e79bfa3283" />|