### PR TITLE
Feat: Added status label opacity when installer item is incompatible

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
@@ -338,10 +338,13 @@ public class InstallerItem extends Control {
                     throw new AssertionError("Unknown state type: " + state.getClass());
                 }
             }, control.resolvedStateProperty));
-            statusLabel.opacityProperty().bind(Bindings.createDoubleBinding(() -> {
-                State state = control.resolvedStateProperty.get();
-                return (state instanceof IncompatibleState) ? 0.6 : 1.0;
-            }, control.resolvedStateProperty));
+            FXUtils.onChangeAndOperate(
+                control.resolvedStateProperty,
+                state -> statusLabel.pseudoClassStateChanged(
+                    PseudoClass.getPseudoClass("incompatible"),
+                    state instanceof IncompatibleState
+                )
+            );
             BorderPane.setMargin(statusLabel, new Insets(0, 0, 0, 8));
             BorderPane.setAlignment(statusLabel, Pos.CENTER_LEFT);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
@@ -338,9 +338,9 @@ public class InstallerItem extends Control {
                     throw new AssertionError("Unknown state type: " + state.getClass());
                 }
             }, control.resolvedStateProperty));
-            statusLabel.styleProperty().bind(Bindings.createStringBinding(() -> {
+            statusLabel.opacityProperty().bind(Bindings.createDoubleBinding(() -> {
                 State state = control.resolvedStateProperty.get();
-                return (state instanceof IncompatibleState) ? "-fx-opacity: 0.6;" : "-fx-opacity: 1.0;";
+                return (state instanceof IncompatibleState) ? 0.6 : 1.0;
             }, control.resolvedStateProperty));
             BorderPane.setMargin(statusLabel, new Insets(0, 0, 0, 8));
             BorderPane.setAlignment(statusLabel, Pos.CENTER_LEFT);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/InstallerItem.java
@@ -338,6 +338,10 @@ public class InstallerItem extends Control {
                     throw new AssertionError("Unknown state type: " + state.getClass());
                 }
             }, control.resolvedStateProperty));
+            statusLabel.styleProperty().bind(Bindings.createStringBinding(() -> {
+                State state = control.resolvedStateProperty.get();
+                return (state instanceof IncompatibleState) ? "-fx-opacity: 0.6;" : "-fx-opacity: 1.0;";
+            }, control.resolvedStateProperty));
             BorderPane.setMargin(statusLabel, new Insets(0, 0, 0, 8));
             BorderPane.setAlignment(statusLabel, Pos.CENTER_LEFT);
 

--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -396,6 +396,10 @@
     -fx-cursor: hand;
 }
 
+.installer-item-status:incompatible {
+    -fx-opacity: 0.6;
+}
+
 .installer-item-wrapper {
     -fx-background-color: -monet-surface;
     -fx-background-radius: 4;


### PR DESCRIPTION
# 为`InstallerItemSkin`的不兼容状态文体添加透明度状态

## 实况

|暗色|亮色|
|---|---|
|<img width="1227" height="762" alt="1" src="https://github.com/user-attachments/assets/679c8dc2-7ae4-446a-8734-02e063151eec" />|<img width="1227" height="762" alt="3" src="https://github.com/user-attachments/assets/46318a2c-7978-4604-9a67-f1873b531fa7" />|
|<img width="1227" height="762" alt="2" src="https://github.com/user-attachments/assets/da3ab1c2-21e8-4b67-b373-01bb91c6509d" />|<img width="1227" height="762" alt="4" src="https://github.com/user-attachments/assets/bf684432-eec3-4954-9742-b206dbd1d44d" />|