### PR TITLE
Fix: WorldListPage MDListCell tags

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/MDListCell.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/MDListCell.java
@@ -54,10 +54,11 @@ public abstract class MDListCell<T> extends ListCell<T> {
     @Override
     protected void updateItem(T item, boolean empty) {
         T oldItem = getItem();
+        boolean oldEmpty = isEmpty();
 
         super.updateItem(item, empty);
 
-        if (oldItem == item) return;
+        if (oldItem == item && oldEmpty == empty) return;
 
         updateControl(item, empty);
         if (empty) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/MDListCell.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/MDListCell.java
@@ -53,7 +53,11 @@ public abstract class MDListCell<T> extends ListCell<T> {
 
     @Override
     protected void updateItem(T item, boolean empty) {
+        T oldItem = getItem();
+
         super.updateItem(item, empty);
+
+        if (oldItem == item) return;
 
         updateControl(item, empty);
         if (empty) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/WorldListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/WorldListPage.java
@@ -315,10 +315,11 @@ public final class WorldListPage extends ListPageBase<World> implements VersionP
         @Override
         protected void updateItem(World world, boolean empty) {
             World oldWorld = getItem();
+            boolean oldEmpty = isEmpty();
 
             super.updateItem(world, empty);
 
-            if (oldWorld == world) return;
+            if (oldWorld == world && oldEmpty == empty) return;
 
             this.content.getTags().clear();
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/WorldListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/WorldListPage.java
@@ -314,7 +314,11 @@ public final class WorldListPage extends ListPageBase<World> implements VersionP
 
         @Override
         protected void updateItem(World world, boolean empty) {
+            World oldWorld = getItem();
+
             super.updateItem(world, empty);
+
+            if (oldWorld == world) return;
 
             this.content.getTags().clear();
 


### PR DESCRIPTION
# 修复`WorldListPage`和`MDListCell`的标签闪烁