### PR TITLE
[Bugfix] 修复 #6338: macOS 导出整合包默认名称包含2个后缀名

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
@@ -69,6 +69,7 @@ import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.io.FileUtils;
 import org.jackhuang.hmcl.util.javafx.SafeStringConverter;
+import org.jackhuang.hmcl.util.platform.OperatingSystem;
 import org.jetbrains.annotations.NotNullByDefault;
 import org.jetbrains.annotations.Nullable;
 
@@ -323,10 +324,11 @@ public class PersonalizationPage extends StackPane {
     private void exportCurrentThemePack(String packId, String version, String packName, String authorName) {
         FileChooser chooser = new FileChooser();
         chooser.setTitle(i18n("theme_pack.export.title"));
-        String initialFileName = sanitizeThemePackFileName(packName) + ThemePackExporter.FILE_EXTENSION;
-        chooser.setInitialFileName(FileUtils.isNameValid(initialFileName)
-                ? initialFileName
-                : "theme-pack" + ThemePackExporter.FILE_EXTENSION);
+        String initialFileName = sanitizeThemePackFileName(packName);
+        chooser.setInitialFileName(
+                (FileUtils.isNameValid(initialFileName) ? initialFileName : "theme-pack")
+                + (OperatingSystem.CURRENT_OS == OperatingSystem.MACOS ? "" : ThemePackExporter.FILE_EXTENSION)
+        );
         chooser.getExtensionFilters().setAll(
                 new FileChooser.ExtensionFilter(i18n("theme_pack.file"), "*" + ThemePackExporter.FILE_EXTENSION));
 


### PR DESCRIPTION
Fixes #6338