### PR TITLE
Refactor: Launch pane button

### DIFF
--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -448,16 +448,24 @@
 }
 
 .launch-pane > .jfx-button.launch-button {
-    -fx-max-width: 207px;
-    -fx-min-width: 207px;
+    -fx-max-width: 200px;
+    -fx-min-width: 200px;
     -fx-border-width: 0 3px 0 0;
-    -fx-border-color: -monet-on-surface-variant;
+    -fx-border-color: linear-gradient(
+        to bottom, 
+        transparent 0%, 
+        transparent 20%, 
+        -monet-on-surface-variant 20%,
+        -monet-on-surface-variant 80%,
+        transparent 80%, 
+        transparent 100%
+    );
     -fx-background-radius: 4px 0 0 4px;
 }
 
 .launch-pane > .jfx-button.menu-button {
-    -fx-max-width: 20px;
-    -fx-min-width: 20px;
+    -fx-max-width: 27px;
+    -fx-min-width: 27px;
     -fx-font-size: 15px;
     -fx-background-radius: 0 4px 4px 0;
 }


### PR DESCRIPTION
# 调整了启动按钮样式

## 个人见解

- 更改后减少割裂感，视觉效果会更好。
- 小箭头更容易点击。
- 与左侧菜单栏分界线统一。

## 实况

|更改前|更改后|
|---|---|
|<img width="1227" height="762" alt="1" src="https://github.com/user-attachments/assets/b14b3818-3114-4693-96e2-b87a549e8169" />|<img width="1227" height="762" alt="2" src="https://github.com/user-attachments/assets/09d58145-4f0d-4b1c-8f40-64f8bf1f592f" />|
|<img width="366" height="110" alt="3" src="https://github.com/user-attachments/assets/e09c8dcf-6258-4576-b568-2573a193c194" />|<img width="360" height="106" alt="4" src="https://github.com/user-attachments/assets/6b0a8a2b-822c-41b5-b34b-d5e9048ec60a" />|