### PR TITLE
Refactor: Style of JavaManagementPage

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaManagementPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaManagementPage.java
@@ -306,7 +306,7 @@ public final class JavaManagementPage extends ListPageBase<JavaRuntime> {
 
                 String vendor = JavaInfo.normalizeVendor(item.getVendor());
 
-                content.setTitle((vendor != null ? vendor : "Unknown") + " " + (item.isJDK() ? "JDK" : "JRE") + " " + item.getVersion());
+                content.setTitle((vendor != null ? vendor : i18n("message.unknown")) + " " + (item.isJDK() ? "JDK" : "JRE") + " " + item.getVersion());
                 content.setSubtitle(item.getBinary().toString());
 
                 if (oldItem != item) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaManagementPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaManagementPage.java
@@ -244,10 +244,10 @@ public final class JavaManagementPage extends ListPageBase<JavaRuntime> {
             center.setAlignment(Pos.CENTER_LEFT);
 
             label.setAlignment(Pos.CENTER);
-            label.setMinSize(24, 24);
-            label.setMaxSize(24, 24);
-            label.setPrefSize(24, 24);
-            label.setStyle("-fx-background-color: -monet-secondary-container; -fx-background-radius: 2; -fx-padding: 2; -fx-font-weight: normal; -fx-font-size: 12px;");
+            FXUtils.setLimitWidth(label, 32);
+            FXUtils.setLimitHeight(label, 32);
+
+            label.setStyle("-fx-background-color: -monet-secondary-container; -fx-background-radius: 2; -fx-padding: 2; -fx-font-weight: normal; -fx-font-size: 16px;");
 
             this.content = new TwoLineListItem();
             HBox.setHgrow(content, Priority.ALWAYS);
@@ -304,15 +304,14 @@ public final class JavaManagementPage extends ListPageBase<JavaRuntime> {
                 int parsedVersion = item.getParsedVersion();
                 label.setText(parsedVersion >= 0 ? String.valueOf(parsedVersion) : "?");
 
-                content.setTitle((item.isJDK() ? "JDK" : "JRE") + " " + item.getVersion());
+                String vendor = JavaInfo.normalizeVendor(item.getVendor());
+
+                content.setTitle((vendor != null ? vendor : "Unknown") + " " + (item.isJDK() ? "JDK" : "JRE") + " " + item.getVersion());
                 content.setSubtitle(item.getBinary().toString());
 
                 if (oldItem != item) {
                     content.getTags().clear();
-                    content.addTag(i18n("java.info.architecture") + ": " + item.getArchitecture().getDisplayName());
-                    String vendor = JavaInfo.normalizeVendor(item.getVendor());
-                    if (vendor != null)
-                        content.addTag(i18n("java.info.vendor") + ": " + vendor);
+                    content.addTag(item.getArchitecture().getDisplayName());                    
                 }
 
                 SVG newRemoveIcon = item.isManaged() ? SVG.DELETE_FOREVER : SVG.DELETE;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaManagementPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaManagementPage.java
@@ -52,6 +52,7 @@ import org.jackhuang.hmcl.util.TaskCancellationAction;
 import org.jackhuang.hmcl.util.io.FileUtils;
 import org.jackhuang.hmcl.util.platform.UnsupportedPlatformException;
 import org.jackhuang.hmcl.util.tree.ArchiveFileTree;
+import org.jetbrains.annotations.Nullable;
 import org.jackhuang.hmcl.util.platform.Architecture;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 import org.jackhuang.hmcl.util.platform.Platform;
@@ -304,7 +305,7 @@ public final class JavaManagementPage extends ListPageBase<JavaRuntime> {
                 int parsedVersion = item.getParsedVersion();
                 label.setText(parsedVersion >= 0 ? String.valueOf(parsedVersion) : "?");
 
-                String vendor = JavaInfo.normalizeVendor(item.getVendor());
+                @Nullable String vendor = JavaInfo.normalizeVendor(item.getVendor());
 
                 content.setTitle((vendor != null ? vendor : i18n("message.unknown")) + " " + (item.isJDK() ? "JDK" : "JRE") + " " + item.getVersion());
                 content.setSubtitle(item.getBinary().toString());


### PR DESCRIPTION
# 调整了`JavaManagementPage`样式

## 实况

|更改前|更改后|
|---|---|
|<img width="1227" height="762" alt="1" src="https://github.com/user-attachments/assets/098bc03e-10fb-410c-92cc-4c57f0c7c526" />|<img width="1227" height="762" alt="2" src="https://github.com/user-attachments/assets/d94110e2-a93d-4567-94ee-9f798401f279" />|