### PR TITLE
Fix: Adjusted the size of the ModInfoListCell ResourcePackListCell icon

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
@@ -522,7 +522,7 @@ final class ModListPageSkin extends SkinBase<ModListPage> {
         private static final PseudoClass WARNING = PseudoClass.getPseudoClass("warning");
 
         JFXCheckBox checkBox = new JFXCheckBox();
-        ImageContainer imageContainer = new ImageContainer(24);
+        ImageContainer imageContainer = new ImageContainer(32);
         TwoLineListItem content = new TwoLineListItem();
         JFXButton restoreButton = FXUtils.newToggleButton4(SVG.RESTORE);
         JFXButton infoButton = FXUtils.newToggleButton4(SVG.INFO);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ResourcePackListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ResourcePackListPage.java
@@ -471,7 +471,7 @@ public final class ResourcePackListPage extends ListPageBase<ResourcePackListPag
         private final ResourcePackListPage page;
 
         private final JFXCheckBox checkBox;
-        private final ImageContainer imageContainer = new ImageContainer(24);
+        private final ImageContainer imageContainer = new ImageContainer(32);
         private final TwoLineListItem content = new TwoLineListItem();
         private final JFXButton btnReveal = FXUtils.newToggleButton4(SVG.FOLDER);
         private final JFXButton btnInfo = FXUtils.newToggleButton4(SVG.INFO);


### PR DESCRIPTION
# 调整了`ModInfoListCell`和`ResourcePackListCell`的图标大小

- `ModInfoListCell`和`ResourcePackListCell`的图标与`WorldListCell`图标大小不一致。

```
> WorldListCell
this.imageView = new ImageContainer(24);

> ModInfoListCell
ImageContainer imageContainer = new ImageContainer(24);

> ResourcePackListCell
private final ImageContainer imageContainer = new ImageContainer(32);
```

## 实况

|更改前|更改后|WorldListCell（未更改）|
|---|---|---|
|<img width="883" height="647" alt="A1" src="https://github.com/user-attachments/assets/6ab3c40c-dbe4-45db-8fc8-9a895fad2da0" />|<img width="895" height="656" alt="B1" src="https://github.com/user-attachments/assets/12e35113-c2b2-4e6e-ae4c-4cf842e040c2" />|<img width="879" height="660" alt="0" src="https://github.com/user-attachments/assets/12828aa5-4c62-45c0-ab52-536ae3023276" />|
|<img width="875" height="446" alt="A2" src="https://github.com/user-attachments/assets/24f49d93-35cb-41dd-8118-1027f1ec9e6c" />|<img width="894" height="446" alt="B2" src="https://github.com/user-attachments/assets/f2f340b4-f807-47a5-b7a4-42b52b0316d8" />|<img width="879" height="660" alt="0" src="https://github.com/user-attachments/assets/be9f2605-c646-40f3-91aa-3f04aa71daa7" />|