### PR TITLE
Refactor: InstallersPageSkin versionNamePane

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
@@ -115,7 +115,7 @@ public abstract class AbstractInstallersPage extends Control implements WizardPa
         return new InstallersPageSkin(this);
     }
 
-    protected abstract boolean showExpendPane();
+    protected abstract boolean showExtendPane();
     protected abstract void resetDefaultName();
 
     protected static class InstallersPageSkin extends SkinBase<AbstractInstallersPage> {
@@ -140,7 +140,7 @@ public abstract class AbstractInstallersPage extends Control implements WizardPa
 
                 versionNamePane.getChildren().addAll(new Label(i18n("version.name")), control.txtName);
                 
-                if (control.showExpendPane()) {
+                if (control.showExtendPane()) {
                     JFXButton clearButton = FXUtils.newToggleButton4(SVG.CLOSE);
                     FXUtils.installFastTooltip(clearButton, i18n("button.clear"));
                     clearButton.disableProperty().bind(control.txtName.textProperty().isEmpty());

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
@@ -40,7 +40,6 @@ import org.jackhuang.hmcl.ui.wizard.Navigation;
 import org.jackhuang.hmcl.ui.wizard.WizardController;
 import org.jackhuang.hmcl.ui.wizard.WizardPage;
 import org.jackhuang.hmcl.util.SettingsMap;
-import org.jackhuang.hmcl.util.i18n.I18n;
 
 import static org.jackhuang.hmcl.setting.SettingsManager.state;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
@@ -138,19 +137,19 @@ public abstract class AbstractInstallersPage extends Control implements WizardPa
 
                 JFXButton clearButton = FXUtils.newToggleButton4(SVG.CLOSE);
                 FXUtils.installFastTooltip(clearButton, i18n("button.clear"));
-                clearButton.setOnAction(e -> {
-                    control.txtName.clear();
-                });
+                clearButton.disableProperty().bind(control.txtName.textProperty().isEmpty());
+                clearButton.setOnAction(e -> control.txtName.clear());
 
-                JFXButton resetButton = FXUtils.newToggleButton4(SVG.RESTORE);
-                FXUtils.installFastTooltip(resetButton, i18n("button.reset"));
-                resetButton.setOnAction(e -> {
-                    if (control instanceof InstallersPage page) {
-                        page.resetDefaultName();
-                    }
-                });
+                versionNamePane.getChildren().addAll(new Label(i18n("version.name")), control.txtName, clearButton);
+                
+                if (control instanceof InstallersPage page) {
+                    JFXButton resetButton = FXUtils.newToggleButton4(SVG.RESTORE);
+                    FXUtils.installFastTooltip(resetButton, i18n("button.reset"));
+                    resetButton.setOnAction(e -> page.resetDefaultName());
+                    
+                    versionNamePane.getChildren().add(resetButton);
+                }
 
-                versionNamePane.getChildren().setAll(new Label(i18n("version.name")), control.txtName, clearButton, resetButton);
                 root.setTop(versionNamePane);
             }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
@@ -115,6 +115,9 @@ public abstract class AbstractInstallersPage extends Control implements WizardPa
         return new InstallersPageSkin(this);
     }
 
+    protected abstract boolean showExpendPane();
+    protected abstract void resetDefaultName();
+
     protected static class InstallersPageSkin extends SkinBase<AbstractInstallersPage> {
         /**
          * Constructor for all SkinBase instances.
@@ -135,19 +138,19 @@ public abstract class AbstractInstallersPage extends Control implements WizardPa
 
                 HBox.setHgrow(control.txtName, Priority.ALWAYS);
 
-                JFXButton clearButton = FXUtils.newToggleButton4(SVG.CLOSE);
-                FXUtils.installFastTooltip(clearButton, i18n("button.clear"));
-                clearButton.disableProperty().bind(control.txtName.textProperty().isEmpty());
-                clearButton.setOnAction(e -> control.txtName.clear());
-
-                versionNamePane.getChildren().addAll(new Label(i18n("version.name")), control.txtName, clearButton);
+                versionNamePane.getChildren().addAll(new Label(i18n("version.name")), control.txtName);
                 
-                if (control instanceof InstallersPage page) {
+                if (control.showExpendPane()) {
+                    JFXButton clearButton = FXUtils.newToggleButton4(SVG.CLOSE);
+                    FXUtils.installFastTooltip(clearButton, i18n("button.clear"));
+                    clearButton.disableProperty().bind(control.txtName.textProperty().isEmpty());
+                    clearButton.setOnAction(e -> control.txtName.clear());
+
                     JFXButton resetButton = FXUtils.newToggleButton4(SVG.RESTORE);
                     FXUtils.installFastTooltip(resetButton, i18n("button.reset"));
-                    resetButton.setOnAction(e -> page.resetDefaultName());
+                    resetButton.setOnAction(e -> control.resetDefaultName());
                     
-                    versionNamePane.getChildren().add(resetButton);
+                    versionNamePane.getChildren().addAll(clearButton, resetButton);
                 }
 
                 root.setTop(versionNamePane);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
@@ -116,7 +116,7 @@ public abstract class AbstractInstallersPage extends Control implements WizardPa
     }
 
     protected abstract boolean showExtendPane();
-    
+
     protected abstract void resetDefaultName();
 
     protected static class InstallersPageSkin extends SkinBase<AbstractInstallersPage> {
@@ -144,11 +144,12 @@ public abstract class AbstractInstallersPage extends Control implements WizardPa
                 if (control.showExtendPane()) {
                     JFXButton clearButton = FXUtils.newToggleButton4(SVG.CLOSE);
                     FXUtils.installFastTooltip(clearButton, i18n("button.clear"));
-                    clearButton.disableProperty().bind(control.txtName.textProperty().isEmpty());
+                    clearButton.disableProperty().bind(control.txtName.textProperty().isEmpty().or(control.txtName.disableProperty()));
                     clearButton.setOnAction(e -> control.txtName.clear());
 
                     JFXButton resetButton = FXUtils.newToggleButton4(SVG.RESTORE);
                     FXUtils.installFastTooltip(resetButton, i18n("button.reset"));
+                    resetButton.disableProperty().bind(control.txtName.disableProperty());
                     resetButton.setOnAction(e -> control.resetDefaultName());
                     
                     versionNamePane.getChildren().addAll(clearButton, resetButton);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
@@ -27,16 +27,20 @@ import javafx.scene.control.*;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+
 import org.jackhuang.hmcl.download.DownloadProvider;
 import org.jackhuang.hmcl.download.LibraryAnalyzer;
 import org.jackhuang.hmcl.ui.Controllers;
 import org.jackhuang.hmcl.ui.FXUtils;
 import org.jackhuang.hmcl.ui.InstallerItem;
+import org.jackhuang.hmcl.ui.SVG;
 import org.jackhuang.hmcl.ui.construct.MessageDialogPane;
 import org.jackhuang.hmcl.ui.wizard.Navigation;
 import org.jackhuang.hmcl.ui.wizard.WizardController;
 import org.jackhuang.hmcl.ui.wizard.WizardPage;
 import org.jackhuang.hmcl.util.SettingsMap;
+import org.jackhuang.hmcl.util.i18n.I18n;
 
 import static org.jackhuang.hmcl.setting.SettingsManager.state;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
@@ -127,11 +131,26 @@ public abstract class AbstractInstallersPage extends Control implements WizardPa
             {
                 HBox versionNamePane = new HBox(8);
                 versionNamePane.getStyleClass().add("card-non-transparent");
-                versionNamePane.setStyle("-fx-padding: 20 8 20 16");
+                versionNamePane.setStyle("-fx-padding: 20 16 20 16");
                 versionNamePane.setAlignment(Pos.CENTER_LEFT);
 
-                control.txtName.setMaxWidth(300);
-                versionNamePane.getChildren().setAll(new Label(i18n("version.name")), control.txtName);
+                HBox.setHgrow(control.txtName, Priority.ALWAYS);
+
+                JFXButton clearButton = FXUtils.newToggleButton4(SVG.CLOSE);
+                FXUtils.installFastTooltip(clearButton, i18n("button.clear"));
+                clearButton.setOnAction(e -> {
+                    control.txtName.clear();
+                });
+
+                JFXButton resetButton = FXUtils.newToggleButton4(SVG.RESTORE);
+                FXUtils.installFastTooltip(resetButton, i18n("button.reset"));
+                resetButton.setOnAction(e -> {
+                    if (control instanceof InstallersPage page) {
+                        page.resetDefaultName();
+                    }
+                });
+
+                versionNamePane.getChildren().setAll(new Label(i18n("version.name")), control.txtName, clearButton, resetButton);
                 root.setTop(versionNamePane);
             }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
@@ -116,6 +116,7 @@ public abstract class AbstractInstallersPage extends Control implements WizardPa
     }
 
     protected abstract boolean showExtendPane();
+    
     protected abstract void resetDefaultName();
 
     protected static class InstallersPageSkin extends SkinBase<AbstractInstallersPage> {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
@@ -115,8 +115,28 @@ public abstract class AbstractInstallersPage extends Control implements WizardPa
         return new InstallersPageSkin(this);
     }
 
+    /**
+     * Determines whether to display the extension pane.
+     * <p>
+     * This method controls the visibility of the extension pane in the UI.
+     * When this method returns {@code true} and the pane is visible, users can 
+     * interact with the features inside it, which includes triggering the 
+     * "Reset to Default Name" button handled by {@link #resetDefaultName()}.
+     * </p>
+     *
+     * @return {@code true} if the extension pane should be displayed; {@code false} otherwise.
+     */
     protected abstract boolean showExtendPane();
 
+    /**
+     * Resets the name to its default value.
+     * <p>
+     * This method contains the business logic for the "Reset to Default Name" button 
+     * located within the extension pane. This logic can only be triggered by the user 
+     * clicking the corresponding button after {@link #showExtendPane()} returns 
+     * {@code true} and the extension pane is successfully displayed.
+     * </p>
+     */
     protected abstract void resetDefaultName();
 
     protected static class InstallersPageSkin extends SkinBase<AbstractInstallersPage> {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AdditionalInstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AdditionalInstallersPage.java
@@ -111,4 +111,13 @@ class AdditionalInstallersPage extends AbstractInstallersPage {
     @Override
     public void cleanup(SettingsMap settings) {
     }
+
+    @Override
+    protected boolean showExpendPane() {
+        return false;
+    }
+
+    @Override
+    public void resetDefaultName() {
+    }
 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AdditionalInstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AdditionalInstallersPage.java
@@ -113,11 +113,11 @@ class AdditionalInstallersPage extends AbstractInstallersPage {
     }
 
     @Override
-    protected boolean showExpendPane() {
+    protected boolean showExtendPane() {
         return false;
     }
 
     @Override
-    public void resetDefaultName() {
+    protected void resetDefaultName() {
     }
 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java
@@ -144,6 +144,12 @@ public class InstallersPage extends AbstractInstallersPage {
         isNameModifiedByUser = false;
     }
 
+    @Override
+    public boolean showExpendPane() {
+        return true;
+    }
+
+    @Override
     public void resetDefaultName() {
         isNameModifiedByUser = false;
         setTxtNameWithLoaders();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java
@@ -145,12 +145,12 @@ public class InstallersPage extends AbstractInstallersPage {
     }
 
     @Override
-    public boolean showExpendPane() {
+    protected boolean showExtendPane() {
         return true;
     }
 
     @Override
-    public void resetDefaultName() {
+    protected void resetDefaultName() {
         isNameModifiedByUser = false;
         setTxtNameWithLoaders();
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java
@@ -111,7 +111,7 @@ public class InstallersPage extends AbstractInstallersPage {
         }
     }
 
-    private void setTxtNameWithLoaders() {
+    public void setTxtNameWithLoaders() {
         StringBuilder nameBuilder = new StringBuilder(getTitle());
 
         for (InstallerItem library : group.getLibraries()) {
@@ -142,5 +142,10 @@ public class InstallersPage extends AbstractInstallersPage {
 
         txtName.setText(nameBuilder.toString());
         isNameModifiedByUser = false;
+    }
+
+    public void resetDefaultName() {
+        isNameModifiedByUser = false;
+        setTxtNameWithLoaders();
     }
 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/InstallersPage.java
@@ -111,7 +111,7 @@ public class InstallersPage extends AbstractInstallersPage {
         }
     }
 
-    public void setTxtNameWithLoaders() {
+    private void setTxtNameWithLoaders() {
         StringBuilder nameBuilder = new StringBuilder(getTitle());
 
         for (InstallerItem library : group.getLibraries()) {


### PR DESCRIPTION
# 重构`InstallersPageSkin.versionNamePane`

- 修复了`control.txtName`被截断的问题。
- 更改了输入框长度。
- 为输入框添加了`清空`和`重置`的按钮。

## 实况

|更改前|更改后|
|---|---|
|<img width="1227" height="762" alt="1" src="https://github.com/user-attachments/assets/64985c7f-f135-4fba-8d39-3c9d3b89d418" />|<img width="1227" height="762" alt="2" src="https://github.com/user-attachments/assets/5b6c5e58-76a3-4b3d-8ea9-fcc073d8c3d2" />|