### PR TITLE
Fix: Lock AccountListItemSkin.btnRefresh width to prevent layout shifting

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItemSkin.java
@@ -121,6 +121,7 @@ public final class AccountListItemSkin extends SkinBase<AccountListItem> {
         JFXButton btnRefresh = FXUtils.newToggleButton4(SVG.REFRESH);
         SpinnerPane spinnerRefresh = new SpinnerPane();
         spinnerRefresh.getStyleClass().setAll("small-spinner-pane");
+        spinnerRefresh.setPrefSize(30.0, 30.0);
         if (skinnable.getAccount() instanceof MicrosoftAccount && Accounts.OAUTH_CALLBACK.getClientId().isEmpty()) {
             btnRefresh.setDisable(true);
             FXUtils.installFastTooltip(spinnerRefresh, i18n("account.methods.microsoft.snapshot.tooltip"));


### PR DESCRIPTION
# 修复了`AccountListItemSkin`中刷新按钮在showSpinner后大小更改的问题

## 问题复现

https://github.com/user-attachments/assets/616dc99c-1f61-46e2-833b-4dc1bc578709