### PR TITLE
Refactor: Remove redundant downloadSourceComboBox from ModDownloadListPageSkin

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadListPage.java
@@ -273,30 +273,18 @@ public class DownloadListPage extends Control implements DecoratorPage, VersionP
             {
                 int rowIndex = 0;
 
-                if (control.versionSelection || !control.downloadSources.isEmpty()) {
+                if (control.versionSelection) {
                     searchPane.addRow(rowIndex);
                     int columns = 0;
                     Node lastNode = null;
-                    if (control.versionSelection) {
-                        JFXComboBox<String> versionsComboBox = new JFXComboBox<>();
-                        versionsComboBox.setMaxWidth(Double.MAX_VALUE);
-                        Bindings.bindContent(versionsComboBox.getItems(), control.versions);
-                        selectedItemPropertyFor(versionsComboBox).bindBidirectional(control.selectedVersion);
 
-                        searchPane.add(new Label(i18n("version")), columns++, rowIndex);
-                        searchPane.add(lastNode = versionsComboBox, columns++, rowIndex);
-                    }
+                    JFXComboBox<String> versionsComboBox = new JFXComboBox<>();
+                    versionsComboBox.setMaxWidth(Double.MAX_VALUE);
+                    Bindings.bindContent(versionsComboBox.getItems(), control.versions);
+                    selectedItemPropertyFor(versionsComboBox).bindBidirectional(control.selectedVersion);
 
-                    if (control.downloadSources.getSize() > 1) {
-                        JFXComboBox<String> downloadSourceComboBox = new JFXComboBox<>();
-                        downloadSourceComboBox.setMaxWidth(Double.MAX_VALUE);
-                        downloadSourceComboBox.getItems().setAll(control.downloadSources.get());
-                        downloadSourceComboBox.setConverter(stringConverter(I18n::i18n));
-                        selectedItemPropertyFor(downloadSourceComboBox).bindBidirectional(control.downloadSource);
-
-                        searchPane.add(new Label(i18n("settings.launcher.download_source")), columns++, rowIndex);
-                        searchPane.add(lastNode = downloadSourceComboBox, columns++, rowIndex);
-                    }
+                    searchPane.add(new Label(i18n("version")), columns++, rowIndex);
+                    searchPane.add(lastNode = versionsComboBox, columns++, rowIndex);
 
                     if (columns == 2) {
                         GridPane.setColumnSpan(lastNode, 3);


### PR DESCRIPTION
# 为`ModDownloadListPageSkin`移除了多余的下载源 ComboBox

- 在#6122 后，`control.downloadSources.getSize() > 1`的条件不应该成立，并且实际上也没有成立。

```
> HMCL/src/main/java/org/jackhuang/hmcl/setting/LauncherSettings.java

    /// The selected default add-on source ID.
    @SerializedName("defaultAddonSource")
    private final StringProperty defaultAddonSource = new SimpleStringProperty("modrinth");

    /// Returns the selected default add-on source ID property.
    public StringProperty defaultAddonSourceProperty() {
        return defaultAddonSource;
    }
```

```
> HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java

var defaultAddonSourcePane = new LineSelectButton<String>();
defaultAddonSourcePane.setTitle(i18n("settings.launcher.default_addon_source"));
defaultAddonSourcePane.setNullSafeConverter(key -> I18n.i18n("addon." + key));
defaultAddonSourcePane.setItems("modrinth", "curseforge");
defaultAddonSourcePane.valueProperty().bindBidirectional(settings().defaultAddonSourceProperty());
```