### PR TITLE
Refactor: "more" button of DownloadMojangJava

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaDownloadDialog.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaDownloadDialog.java
@@ -47,6 +47,7 @@ import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.ui.Controllers;
 import org.jackhuang.hmcl.ui.FXUtils;
+import org.jackhuang.hmcl.ui.SVG;
 import org.jackhuang.hmcl.ui.construct.DialogCloseEvent;
 import org.jackhuang.hmcl.ui.construct.DialogPane;
 import org.jackhuang.hmcl.ui.construct.JFXHyperlink;
@@ -152,8 +153,11 @@ public final class JavaDownloadDialog extends StackPane {
             setBody(vbox);
 
             if (!distributions.isEmpty()) {
-                JFXHyperlink more = new JFXHyperlink(i18n("java.download.more"));
+                JFXButton more = new JFXButton(i18n("java.download.more"));
+                more.setGraphic(SVG.FORMAT_LIST_BULLETED.createIcon());
+                more.getStyleClass().add("dialog-cancel");
                 more.setOnAction(event -> JavaDownloadDialog.this.getChildren().setAll(new DownloadDiscoJava()));
+
                 setActions(warningLabel, more, acceptPane, cancelButton);
             } else
                 setActions(warningLabel, acceptPane, cancelButton);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaDownloadDialog.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaDownloadDialog.java
@@ -155,7 +155,7 @@ public final class JavaDownloadDialog extends StackPane {
             if (!distributions.isEmpty()) {
                 JFXButton more = new JFXButton(i18n("java.download.more"));
                 more.setGraphic(SVG.FORMAT_LIST_BULLETED.createIcon());
-                more.getStyleClass().add("dialog-cancel");
+                more.getStyleClass().add("dialog-accept");
                 more.setOnAction(event -> JavaDownloadDialog.this.getChildren().setAll(new DownloadDiscoJava()));
 
                 setActions(warningLabel, more, acceptPane, cancelButton);


### PR DESCRIPTION
# 更改了 `DownloadMojangJava` 中的 `更多发行版` 按钮样式

- 此处的超链接标志应表示 **离开** HMCL 页面的链接，跳转到 **独立** 于 HMCL 的页面。（例如`购买 Minecraft`）
- 建议改为 **按钮** 样式。

## 实况

|更改前|更改后|
|---|---|
|<img width="709" height="535" alt="1" src="https://github.com/user-attachments/assets/356e5fb0-291b-48c7-b8c1-d0c8a0918240" />|<img width="692" height="519" alt="2" src="https://github.com/user-attachments/assets/17d1c270-6e3c-4dcb-ac14-3df36062c688" />|