### PR TITLE
Feat: DisplayName for JavaPackageType

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaDownloadDialog.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaDownloadDialog.java
@@ -232,6 +232,7 @@ public final class JavaDownloadDialog extends StackPane {
             this.remoteVersionBox.setConverter(FXUtils.stringConverter(JavaRemoteVersion::getDistributionVersion));
 
             this.packageTypeBox = new JFXComboBox<>(FXCollections.observableArrayList());
+            this.packageTypeBox.setConverter(FXUtils.stringConverter(JavaPackageType::getDisplayName));
 
             this.downloadButton = new JFXButton(i18n("download"));
             downloadButton.setOnAction(e -> onDownload());

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/JavaPackageType.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/JavaPackageType.java
@@ -21,15 +21,17 @@ package org.jackhuang.hmcl.download.java;
  * @author Glavo
  */
 public enum JavaPackageType {
-    JRE(false, false),
-    JDK(true, false),
-    JREFX(false, true),
-    JDKFX(true, true);
+    JRE("JRE", false, false),
+    JDK("JDK", true, false),
+    JREFX("JRE FX", false, true),
+    JDKFX("JDK FX", true, true);
 
+    private final String displayName;
     private final boolean jdk;
     private final boolean javafx;
 
-    JavaPackageType(boolean jdk, boolean javafx) {
+    JavaPackageType(String displayName, boolean jdk, boolean javafx) {
+        this.displayName = displayName;
         this.jdk = jdk;
         this.javafx = javafx;
     }
@@ -39,6 +41,10 @@ public enum JavaPackageType {
             return javafx ? JDKFX : JDK;
         else
             return javafx ? JREFX : JRE;
+    }
+
+    public String getDisplayName() {
+        return displayName;
     }
 
     public boolean isJDK() {


### PR DESCRIPTION
# 为`JavaPackageType`增加了显示名称

- 使用 **显示名称** 而不是直接枚举。
- 类似 Azul Zulu 网站中加入 **空格** 视觉上可能会更好。（如 `JDKFX` -> `JDK FX` ）

## 样式来源

- [Azul Zulu](https://www.azul.com/downloads)

<img width="1449" height="492" alt="A1" src="https://github.com/user-attachments/assets/890151b7-66e5-43f5-b417-bd46e7be804e" />

## 实况

|更改前|更改后|
|---|---|
|<img width="706" height="534" alt="B1" src="https://github.com/user-attachments/assets/421b53ec-d8a1-4bab-b9cb-1d8b57b88467" />|<img width="691" height="533" alt="B2" src="https://github.com/user-attachments/assets/aeaf94ea-98dc-43f8-9c64-22d2c8b72048" />|