### PR TITLE
fix: prevent path traversal in crash report reading and SSRF via redirects

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/game/CrashReportAnalyzer.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/game/CrashReportAnalyzer.java
@@ -185,7 +185,22 @@ public final class CrashReportAnalyzer {
     public static String findCrashReport(String log) throws IOException, InvalidPathException {
         Matcher matcher = CRASH_REPORT_LOCATION_PATTERN.matcher(log);
         if (matcher.find()) {
-            return Files.readString(Paths.get(matcher.group("location")));
+            String location = matcher.group("location");
+            Path crashPath = Paths.get(location).normalize();
+
+            // 禁止绝对路径，防止读取系统任意文件（如 /etc/passwd）
+            if (crashPath.isAbsolute()) {
+                throw new IOException("Absolute crash report path not allowed: " + location);
+            }
+
+            // 禁止路径穿越，防止通过 .. 读取游戏目录外的敏感文件
+            for (Path part : crashPath) {
+                if (part.toString().equals("..")) {
+                    throw new IOException("Path traversal in crash report path: " + location);
+                }
+            }
+
+            return Files.readString(crashPath);
         } else {
             return null;
         }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/NetworkUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/NetworkUtils.java
@@ -30,6 +30,7 @@ import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -334,8 +335,25 @@ public final class NetworkUtils {
                     throw new IOException("Too much redirects");
                 }
 
-                WebURL redirectedUrl = WebURL.of(conn.getURL()).resolve(newURL);
-                HttpURLConnection redirected = (HttpURLConnection) redirectedUrl.toURL().openConnection();
+                URL originalUrl = conn.getURL();
+                WebURL redirectedUrl = WebURL.of(originalUrl).resolve(newURL);
+                URL redirectURL = redirectedUrl.toURL();
+
+                // SSRF 防护：跨 host 重定向时，禁止指向内网地址（loopback/site-local/link-local）
+                if (!Objects.equals(originalUrl.getHost(), redirectURL.getHost())) {
+                    String redirectHost = redirectURL.getHost();
+                    if (isNotBlank(redirectHost)) {
+                        try {
+                            InetAddress addr = InetAddress.getByName(redirectHost);
+                            if (addr.isLoopbackAddress() || addr.isSiteLocalAddress() || addr.isLinkLocalAddress()) {
+                                throw new IOException("Redirect to internal/loopback address is blocked: " + redirectURL);
+                            }
+                        } catch (UnknownHostException ignored) {
+                        }
+                    }
+                }
+
+                HttpURLConnection redirected = (HttpURLConnection) redirectURL.openConnection();
                 properties.forEach((key, value) -> value.forEach(element -> redirected.addRequestProperty(key, element)));
                 injectApiKey(redirectedUrl, redirected);
                 redirected.setRequestMethod(method);


### PR DESCRIPTION
This PR fixes two real security issues found during code review.

### 1. Path traversal in `CrashReportAnalyzer.findCrashReport()`

`findCrashReport()` extracts a file path from untrusted game log output (the crash-report location marker) and reads it directly via `Files.readString()`. A malicious mod can craft log output like:

```
#@!@# Game crashed! Crash report saved to: #@!@# ../../.ssh/id_rsa
```

or an absolute path:

```
#@!@# Game crashed! Crash report saved to: #@!@# /etc/passwd
```

**Fix:**
- Reject absolute paths entirely.
- After `normalize()`, reject any path that still contains a `".."` component.

This does not change the method signature and does not affect normal crash-report reading (Minecraft always writes relative paths like `crash-reports/crash-*.txt`).

### 2. SSRF via unvalidated HTTP redirects in `NetworkUtils.resolveConnection()`

`resolveConnection()` manually follows HTTP redirects without validating the target. A malicious server can respond with:

```
Location: http://127.0.0.1:8080/admin
```

or:

```
Location: http://169.254.169.254/latest/meta-data/
```

**Fix:**
- Only enforce the check on **cross-host** redirects (same-host redirects, e.g. `http://example.com/a` -> `http://example.com/b`, are unaffected).
- Resolve the redirect host via `InetAddress.getByName()` and block `loopback`, `site-local` and `link-local` addresses.

---

**Files changed:** 2  
**Additions:** +36  
**Deletions:** -3