### PR TITLE
chore(workflow): add pr-size-label workflow file

### DIFF
--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -1,0 +1,133 @@
+name: PR Size Label
+
+on:
+  pull_request_target:
+    types:
+    - opened
+    - reopened
+    - synchronize
+  workflow_dispatch:
+
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  Label:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Label PR by filtered changed lines
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const owner = context.repo.owner
+          const repo = context.repo.repo
+          const ignoredFilePatterns = [
+            /(?:^|\/)gradlew(?:\.bat)?$/i,
+            /(?:^|\/)gradle\/wrapper\/gradle-wrapper\.properties$/i,
+            /(?:^|\/)\.idea\/.+\.xml$/i,
+            /(?:^|\/)lang\/.+\.properties$/i,
+            /(?:^|\/)l10n\/.+\.properties$/i
+          ]
+
+          async function processPR(issue_number) {
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: issue_number,
+              per_page: 100,
+            })
+
+            const countedFiles = []
+            const ignoredFiles = []
+            let totalChanges = 0
+
+            for (const file of files) {
+              const ignored = ignoredFilePatterns.some(pattern => pattern.test(file.filename))
+              if (ignored) {
+                ignoredFiles.push(file.filename)
+                continue
+              }
+
+              const fileChanges = file.changes ?? ((file.additions || 0) + (file.deletions || 0))
+              totalChanges += fileChanges
+              countedFiles.push(`${file.filename} (${fileChanges})`)
+            }
+
+            let targetLabel
+            if (totalChanges <= 9) targetLabel = 'size/XS'
+            else if (totalChanges <= 29) targetLabel = 'size/S'
+            else if (totalChanges <= 99) targetLabel = 'size/M'
+            else if (totalChanges <= 499) targetLabel = 'size/L'
+            else if (totalChanges <= 999) targetLabel = 'size/XL'
+            else targetLabel = 'size/XXL'
+
+            const currentLabels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            })
+
+            const sizeLabels = currentLabels
+              .map(label => label.name)
+              .filter(name => /^size\//.test(name))
+
+            for (const name of sizeLabels) {
+              if (name !== targetLabel) {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number,
+                  name,
+                }).catch(() => {})
+              }
+            }
+
+            if (!currentLabels.some(label => label.name === targetLabel)) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number,
+                labels: [targetLabel],
+              })
+            }
+
+            core.info(`Pull request #${issue_number} has ${totalChanges} counted changed lines, applied ${targetLabel}.`)
+            core.info(`Ignored files: ${ignoredFiles.length ? ignoredFiles.join(', ') : 'none'}`)
+            core.info(`Counted files: ${countedFiles.length ? countedFiles.join(', ') : 'none'}`)
+          }
+
+          if (context.eventName === 'workflow_dispatch') {
+            core.info('Manual trigger detected. Fetching all open pull requests...')
+            
+            const openPRs = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            })
+
+            const unlabelledPRs = openPRs.filter(pr => {
+              return !pr.labels.some(label => /^size\//.test(label.name))
+            })
+
+            core.info(`Found ${openPRs.length} open pull request(s), ${unlabelledPRs.length} of them lack a size label.`)
+
+            for (const pr of unlabelledPRs) {
+              core.info(`----------------------------------------`)
+              core.info(`Processing unlabelled pull request #${pr.number}: ${pr.title}`)
+              await processPR(pr.number)
+            }
+          } else {
+            const pr = context.payload.pull_request
+            if (!pr) {
+              core.info('No pull request found in payload, skipping.')
+              return
+            }
+            await processPR(pr.number)
+          }

--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -27,11 +27,19 @@ jobs:
           const owner = context.repo.owner
           const repo = context.repo.repo
           const ignoredFilePatterns = [
+            /(?:^|\/)\.github\/.+\.ya?ml$/i,
+            /(?:^|\/)\.idea\/.+\.xml$/i,
+            /(?:^|\/)\.editorconfig$/i,
+            /(?:^|\/)\.gitignore$/i,
+            /(?:^|\/).+\.md$/i,
+            /(?:^|\/)LICENSE(?:_.*)?$/i,
             /(?:^|\/)gradlew(?:\.bat)?$/i,
             /(?:^|\/)gradle\/wrapper\/gradle-wrapper\.properties$/i,
-            /(?:^|\/)\.idea\/.+\.xml$/i,
             /(?:^|\/)lang\/.+\.properties$/i,
-            /(?:^|\/)l10n\/.+\.properties$/i
+            /(?:^|\/)l10n\/.+\.properties$/i,
+            /(?:^|\/)checkstyle\.xml$/i,
+            /(?:^|\/)org\/jackhuang\/hmcl\/ui\/SVG\.java$/i,
+            /(?:^|\/).+\.(?:png|jpe?g|gif|ico|svg|json|ttf|ttc|woff2?|webp|avif|jxl|heic|mp4|webm|mp3|ogg|wav)$/i
           ]
 
           async function processPR(issue_number) {

--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -27,10 +27,15 @@ jobs:
           const owner = context.repo.owner
           const repo = context.repo.repo
           const ignoredFilePatterns = [
+            /(?:^|\/)\.cnb\/.+\.ya?ml$/i,
+            /(?:^|\/)\.gemini\/.+\.ya?ml$/i,
+            /(?:^|\/)\.gitee\/.+\.ya?ml$/i,
             /(?:^|\/)\.github\/.+\.ya?ml$/i,
             /(?:^|\/)\.idea\/.+\.xml$/i,
             /(?:^|\/)\.editorconfig$/i,
+            /(?:^|\/)\.gitattributes$/i,
             /(?:^|\/)\.gitignore$/i,
+            /(?:^|\/).+\.kts$/i
             /(?:^|\/).+\.md$/i,
             /(?:^|\/)LICENSE(?:_.*)?$/i,
             /(?:^|\/)gradlew(?:\.bat)?$/i,
@@ -39,7 +44,7 @@ jobs:
             /(?:^|\/)l10n\/.+\.properties$/i,
             /(?:^|\/)checkstyle\.xml$/i,
             /(?:^|\/)org\/jackhuang\/hmcl\/ui\/SVG\.java$/i,
-            /(?:^|\/).+\.(?:png|jpe?g|gif|ico|svg|json|ttf|ttc|woff2?|webp|avif|jxl|heic|mp4|webm|mp3|ogg|wav)$/i
+            /(?:^|\/).+\.(?:png|jpe?g|gif|ico|svg|json|ttf|woff2?|webp|avif|jxl|heic|mp4|webm|mp3|ogg|wav|txt|toml)$/i
           ]
 
           async function processPR(issue_number) {

--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -59,12 +59,14 @@ jobs:
             }
 
             let targetLabel
-            if (totalChanges <= 9) targetLabel = 'size/XS'
-            else if (totalChanges <= 29) targetLabel = 'size/S'
-            else if (totalChanges <= 99) targetLabel = 'size/M'
-            else if (totalChanges <= 499) targetLabel = 'size/L'
-            else if (totalChanges <= 999) targetLabel = 'size/XL'
-            else targetLabel = 'size/XXL'
+            if (totalChanges <= 9) targetLabel = '1+'
+            else if (totalChanges <= 39) targetLabel = '10+'
+            else if (totalChanges <= 99) targetLabel = '40+'
+            else if (totalChanges <= 499) targetLabel = '100+'
+            else if (totalChanges <= 999) targetLabel = '500+'
+            else if (totalChanges <= 1999) targetLabel = '1000+'
+            else if (totalChanges <= 4999) targetLabel = '2000+'
+            else targetLabel = '5000+'
 
             const currentLabels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
               owner,

--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -77,7 +77,7 @@ jobs:
 
             const sizeLabels = currentLabels
               .map(label => label.name)
-              .filter(name => /^size\//.test(name))
+              .filter(name => /^\d+\+$/.test(name))
 
             for (const name of sizeLabels) {
               if (name !== targetLabel) {
@@ -115,7 +115,7 @@ jobs:
             })
 
             const unlabelledPRs = openPRs.filter(pr => {
-              return !pr.labels.some(label => /^size\//.test(label.name))
+              return !pr.labels.some(label => /^\d+\+$/.test(label.name))
             })
 
             core.info(`Found ${openPRs.length} open pull request(s), ${unlabelledPRs.length} of them lack a size label.`)

--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -38,12 +38,11 @@ jobs:
             /(?:^|\/).+\.kts$/i,
             /(?:^|\/).+\.md$/i,
             /(?:^|\/)LICENSE(?:_.*)?$/i,
-            /(?:^|\/)gradlew(?:\.bat)?$/i,
+            /(?:^|\/)gradlew(?:\.bat|\.ps1)?$/i,
             /(?:^|\/)gradle\/wrapper\/gradle-wrapper\.properties$/i,
             /(?:^|\/)lang\/.+\.properties$/i,
             /(?:^|\/)l10n\/.+\.properties$/i,
             /(?:^|\/)checkstyle\.xml$/i,
-            /(?:^|\/)org\/jackhuang\/hmcl\/ui\/SVG\.java$/i,
             /(?:^|\/).+\.(?:png|jpe?g|gif|ico|svg|json|ttf|woff2?|webp|avif|jxl|heic|mp4|webm|mp3|ogg|wav|txt|toml)$/i
           ]
 

--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -35,7 +35,7 @@ jobs:
             /(?:^|\/)\.editorconfig$/i,
             /(?:^|\/)\.gitattributes$/i,
             /(?:^|\/)\.gitignore$/i,
-            /(?:^|\/).+\.kts$/i
+            /(?:^|\/).+\.kts$/i,
             /(?:^|\/).+\.md$/i,
             /(?:^|\/)LICENSE(?:_.*)?$/i,
             /(?:^|\/)gradlew(?:\.bat)?$/i,


### PR DESCRIPTION
前段时间我在 https://github.com/HMCL-dev/HMCL/discussions/4921 写了篇评论。由于没看到明确的反对、疑问等，我先整理了这个 PR 作为一个尝试。

这个 PR 添加了一个为各 PR 标注代码规模 label 的 workflow。在 https://github.com/UNIkeEN/SJMCL/blob/4b511c8a5adb99de34a123ccf08def036ad29735/.github/workflows/pr-size-label.yml 的基础上改进而来。

在 SJMCL workflow 的基础上，

- 修改了忽略的目标文件，现在会排除各类非业务文件
- 添加了一个手动触发机制，为所有无 label PR 自动添加表示 PR 更改规模的 label

合并后，在 Actions 页面点击左侧的「PR Size Label」，然后点击页面中的「Run workflow」按钮，在 `main` 分支上运行即可为所有无 label 的 PR 标注 label。

如果要采纳这个 PR，需要先在 https://github.com/HMCL-dev/HMCL/labels 页面添加以下 label：

| Name | Description | Color |
|--------|--------|--------|
| 1+ | 0-9 code lines changed. | `#cfd8dc` |
| 10+ | 10-39 code lines changed. | `#aed6f1` |
| 40+ | 40-99 code lines changed. | `#5dade2` |
| 100+ | 100-499 code lines changed. | `#f5b041` |
| 500+ | 500-999 code lines changed. | `#dc7633` | 
| 1000+ | 1000-1999 code lines changed. | `#cb4335` | 
| 2000+ | 2000-4999 code lines changed. | `#884ea0` | 
| 5000+ | 5000+ code lines changed. | `#1b2631` | 

我在自己的 fork 里测试了下，目前整理了一批 PR 作为展示：https://github.com/3gf8jv4dv/HMCL/pulls

也可以看看 SJMCL 的实际运作效果：https://github.com/UNIkeEN/SJMCL/pulls