### PR TITLE
固定默认游戏文件夹和官方启动器游戏文件夹的 ID

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/GameDirectoryManager.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/GameDirectoryManager.java
@@ -39,6 +39,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.function.Consumer;
 
 import static org.jackhuang.hmcl.setting.SettingsManager.*;
@@ -53,6 +54,14 @@ import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 /// [LauncherSettings] directly.
 @NotNullByDefault
 public final class GameDirectoryManager {
+
+    /// The stable ID shared by newly created and migrated current-workspace game directories.
+    static final GameDirectoryID DEFAULT_GAME_DIRECTORY_ID =
+            new GameDirectoryID(new UUID(0x7105bc1f490e5e8cL, 0x878cf5844c3d4bc3L));
+
+    /// The stable ID shared by newly created and migrated user-home game directories.
+    static final GameDirectoryID HOME_GAME_DIRECTORY_ID =
+            new GameDirectoryID(new UUID(0xf3eafde8506e5a77L, 0xbc88f24b4728dfb2L));
 
     /// The default current-workspace game directory path.
     private static final PortablePath CURRENT_GAME_DIRECTORY_PATH = PortablePath.of(".minecraft");
@@ -154,12 +163,14 @@ public final class GameDirectoryManager {
         if (localGameDirectories().isNewlyCreated() && localGameDirectories().getGameDirectories().isEmpty()) {
             needRebuildGameDirectories = true;
             GameDirectories gameDirectories = localGameDirectories();
-            gameDirectories.getGameDirectories().add(new GameDirectory(newGameDirectoryId(), null, CURRENT_GAME_DIRECTORY_PATH));
+            gameDirectories.getGameDirectories().add(new GameDirectory(
+                    DEFAULT_GAME_DIRECTORY_ID, null, CURRENT_GAME_DIRECTORY_PATH));
         }
         if (userGameDirectories().isNewlyCreated() && userGameDirectories().getGameDirectories().isEmpty()) {
             needRebuildGameDirectories = true;
             GameDirectories gameDirectories = userGameDirectories();
-            gameDirectories.getGameDirectories().add(new GameDirectory(newGameDirectoryId(), null, HOME_GAME_DIRECTORY_PATH));
+            gameDirectories.getGameDirectories().add(new GameDirectory(
+                    HOME_GAME_DIRECTORY_ID, null, HOME_GAME_DIRECTORY_PATH));
         }
 
         needRebuildGameDirectories |= createDefaultGameDirectoriesIfEmpty();
@@ -216,9 +227,11 @@ public final class GameDirectoryManager {
         if (localGameDirectories().getGameDirectories().isEmpty()
                 && userGameDirectories().getGameDirectories().isEmpty()) {
             localGameDirectories().getGameDirectories()
-                    .add(new GameDirectory(newGameDirectoryId(), null, CURRENT_GAME_DIRECTORY_PATH));
+                    .add(new GameDirectory(
+                            DEFAULT_GAME_DIRECTORY_ID, null, CURRENT_GAME_DIRECTORY_PATH));
             userGameDirectories().getGameDirectories()
-                    .add(new GameDirectory(newGameDirectoryId(), null, HOME_GAME_DIRECTORY_PATH));
+                    .add(new GameDirectory(
+                            HOME_GAME_DIRECTORY_ID, null, HOME_GAME_DIRECTORY_PATH));
             return true;
         } else {
             return false;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/LegacyConfigMigrator.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/LegacyConfigMigrator.java
@@ -81,12 +81,6 @@ public final class LegacyConfigMigrator {
     /// The legacy built-in profile name for the user-home game directory.
     private static final String LEGACY_HOME_PROFILE = "Home";
 
-    /// The legacy built-in current-workspace profile ID.
-    private static final GameDirectoryID LEGACY_DEFAULT_PROFILE_ID = getLegacyProfileID(LEGACY_DEFAULT_PROFILE);
-
-    /// The legacy built-in user-home profile ID.
-    private static final GameDirectoryID LEGACY_HOME_PROFILE_ID = getLegacyProfileID(LEGACY_HOME_PROFILE);
-
     /// The legacy Windows and portable configuration file name used before HMCL 3.16.
     private static final String LEGACY_CONFIG_FILENAME = "hmcl.json";
 
@@ -1359,10 +1353,10 @@ public final class LegacyConfigMigrator {
 
     /// Returns the legacy profile name used in `configurations`.
     private static @Nullable String getLegacyProfileName(GameDirectory gameDirectory) {
-        if (LEGACY_DEFAULT_PROFILE_ID.equals(gameDirectory.getId())) {
+        if (GameDirectoryManager.DEFAULT_GAME_DIRECTORY_ID.equals(gameDirectory.getId())) {
             return LEGACY_DEFAULT_PROFILE;
         }
-        if (LEGACY_HOME_PROFILE_ID.equals(gameDirectory.getId())) {
+        if (GameDirectoryManager.HOME_GAME_DIRECTORY_ID.equals(gameDirectory.getId())) {
             return LEGACY_HOME_PROFILE;
         }
         return GameDirectoryManager.getGameDirectoryCustomName(gameDirectory);

--- a/HMCL/src/test/java/org/jackhuang/hmcl/setting/GameDirectoriesTest.java
+++ b/HMCL/src/test/java/org/jackhuang/hmcl/setting/GameDirectoriesTest.java
@@ -96,8 +96,8 @@ public final class GameDirectoriesTest {
 
         GameDirectories gameDirectories = Objects.requireNonNull(LegacyConfigMigrator.extractGameDirectoriesFromConfigJson(settings));
 
-        GameDirectoryID defaultGameDirectoryId = LegacyConfigMigrator.getLegacyProfileID("Default");
-        GameDirectoryID homeGameDirectoryId = LegacyConfigMigrator.getLegacyProfileID("Home");
+        GameDirectoryID defaultGameDirectoryId = GameDirectoryManager.DEFAULT_GAME_DIRECTORY_ID;
+        GameDirectoryID homeGameDirectoryId = GameDirectoryManager.HOME_GAME_DIRECTORY_ID;
         GameDirectory defaultGameDirectory = gameDirectories.getGameDirectories().stream()
                 .filter(gameDirectory -> defaultGameDirectoryId.equals(gameDirectory.getId()))
                 .findFirst()
@@ -357,9 +357,33 @@ public final class GameDirectoriesTest {
             GameDirectory userGameDirectory = assertSingleDefaultGameDirectory(
                     userDirectories,
                     PortablePath.fromPath(Metadata.MINECRAFT_DIRECTORY));
+            assertEquals(GameDirectoryManager.DEFAULT_GAME_DIRECTORY_ID, localGameDirectory.getId());
+            assertEquals(GameDirectoryManager.HOME_GAME_DIRECTORY_ID, userGameDirectory.getId());
             assertEquals(2, GameDirectoryManager.getGameDirectories().size());
             assertTrue(GameDirectoryManager.getGameDirectories().contains(localGameDirectory));
             assertTrue(GameDirectoryManager.getGameDirectories().contains(userGameDirectory));
+        }
+    }
+
+    /// Tests that newly created stores use the stable IDs for their built-in game directories.
+    @Test
+    public void createsBuiltInGameDirectoriesWithStableIdsForNewStores() throws ReflectiveOperationException {
+        GameDirectories userDirectories = new GameDirectories();
+        userDirectories.setUserFile(true);
+        userDirectories.setNewlyCreated(true);
+        GameDirectories localDirectories = new GameDirectories();
+        localDirectories.setUserFile(false);
+        localDirectories.setNewlyCreated(true);
+
+        try (GameDirectoryEnvironment ignored = new GameDirectoryEnvironment(localDirectories, userDirectories)) {
+            GameDirectoryManager.init();
+
+            GameDirectory localGameDirectory = assertSingleDefaultGameDirectory(localDirectories, PortablePath.of(".minecraft"));
+            GameDirectory userGameDirectory = assertSingleDefaultGameDirectory(
+                    userDirectories,
+                    PortablePath.fromPath(Metadata.MINECRAFT_DIRECTORY));
+            assertEquals(GameDirectoryManager.DEFAULT_GAME_DIRECTORY_ID, localGameDirectory.getId());
+            assertEquals(GameDirectoryManager.HOME_GAME_DIRECTORY_ID, userGameDirectory.getId());
         }
     }
 


### PR DESCRIPTION
这样迁移后位于 `game-directories.json` 的官方启动器游戏文件夹可以遮蔽 `user-game-directories.json` 中的游戏文件夹。