### PR TITLE
Fix: Limit max download threads to 256 in text field

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
@@ -150,7 +150,7 @@ public class DownloadSettingsPage extends StackPane {
                                 JFXTextField threadsField = new JFXTextField();
                                 FXUtils.setLimitWidth(threadsField, 60);
                                 FXUtils.bind(threadsField, settings().downloadThreadsProperty(), SafeStringConverter.fromInteger()
-                                        .restrict(it -> it > 0)
+                                        .restrict(it -> it > 0 && it < 257)
                                         .fallbackTo(FetchTask.DEFAULT_CONCURRENCY)
                                         .asPredicate(Validator.addTo(threadsField)));
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
@@ -150,7 +150,7 @@ public class DownloadSettingsPage extends StackPane {
                                 JFXTextField threadsField = new JFXTextField();
                                 FXUtils.setLimitWidth(threadsField, 60);
                                 FXUtils.bind(threadsField, settings().downloadThreadsProperty(), SafeStringConverter.fromInteger()
-                                        .restrict(it -> it > 0 && it < 257)
+                                        .restrict(it -> it > 0 && it <= 256)
                                         .fallbackTo(FetchTask.DEFAULT_CONCURRENCY)
                                         .asPredicate(Validator.addTo(threadsField)));
 


### PR DESCRIPTION
# 限制下载线程输入范围

- 以下语句期望线程数量范围为 **1 - 256**。

```
JFXSlider slider = new JFXSlider(1, 256, 64);
```

## 实况

### 更改前

<img width="874" height="218" alt="1" src="https://github.com/user-attachments/assets/6ce334a7-11ce-4250-af02-616caf5d4d0d" />

### 更改后

<img width="883" height="215" alt="2" src="https://github.com/user-attachments/assets/450dc034-595e-45d3-8885-6b26b1a51efc" />