### PR TITLE
Refactor: Replace deprecated URL constructor

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/UpgradeDialog.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/UpgradeDialog.java
@@ -34,7 +34,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Node;
 
-import java.net.URL;
+import java.net.URI;
 
 import static org.jackhuang.hmcl.Metadata.CHANGELOG_URL;
 import static org.jackhuang.hmcl.ui.FXUtils.onEscPressed;
@@ -59,7 +59,7 @@ public final class UpgradeDialog extends JFXDialogLayout {
                 // Downgrade update, no need to display changelog
                 return null;
 
-            Document document = Jsoup.parse(new URL(url), 30 * 1000);
+            Document document = Jsoup.parse(URI.create(url).toURL(), 30 * 1000);
             Node node = document.selectFirst("h1[data-version=\"%s\"]".formatted(targetVersion));
 
             if (node == null || !"h1".equals(node.nodeName())) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/UpgradeDialog.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/UpgradeDialog.java
@@ -22,6 +22,8 @@ import com.jfoenix.controls.JFXDialogLayout;
 import com.jfoenix.controls.JFXSpinner;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
+
+import org.glavo.url.WebURL;
 import org.jackhuang.hmcl.Metadata;
 import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.task.Task;
@@ -33,8 +35,6 @@ import org.jackhuang.hmcl.util.versioning.VersionNumber;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Node;
-
-import java.net.URI;
 
 import static org.jackhuang.hmcl.Metadata.CHANGELOG_URL;
 import static org.jackhuang.hmcl.ui.FXUtils.onEscPressed;
@@ -59,7 +59,7 @@ public final class UpgradeDialog extends JFXDialogLayout {
                 // Downgrade update, no need to display changelog
                 return null;
 
-            Document document = Jsoup.parse(URI.create(url).toURL(), 30 * 1000);
+            Document document = Jsoup.parse(WebURL.toURL(url), 30 * 1000);
             Node node = document.selectFirst("h1[data-version=\"%s\"]".formatted(targetVersion));
 
             if (node == null || !"h1".equals(node.nodeName())) {


### PR DESCRIPTION
# 替换废弃的`URL`构造函数

- `URL`已被标记为`Deprecated`。