### PR TITLE
[release/3.16] 修复 1.21.1 安装信雅互联仍显示不支持 Fabric 模组的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPage.java
@@ -163,7 +163,7 @@ public final class ModListPage extends ListPageBase<ModListPageSkin.ModInfoObjec
         }
 
         // Sinytra Connector
-        if (analyzer.has(LibraryAnalyzer.LibraryType.NEO_FORGE) && modManager.hasMod("connectormod", ModLoaderType.NEO_FORGE)
+        if (analyzer.has(LibraryAnalyzer.LibraryType.NEO_FORGE) && (modManager.hasMod("connector", ModLoaderType.NEO_FORGE) || modManager.hasMod("connectormod", ModLoaderType.NEO_FORGE))
                 || "1.20.1".equals(gameVersion) && analyzer.has(LibraryAnalyzer.LibraryType.FORGE) && modManager.hasMod("connectormod", ModLoaderType.FORGE)) {
             supportedLoaders.add(ModLoaderType.FABRIC);
         }


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/pull/6404