### PR TITLE
删除 Gemini 审查配置文件

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,3 +1,0 @@
-code_review:
-  pull_request_opened:
-    code_review: false


### PR DESCRIPTION
Gemini 现在不再提供相关的代码审查功能。