### PR TITLE
Fix: Resolve ModLoaderType.LEGACY_FABRIC for Modrinth

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
@@ -472,6 +472,9 @@ public class DownloadPage extends Control implements DecoratorPage {
                             case QUILT:
                                 content.addTag(i18n("install.installer.quilt"));
                                 break;
+                            case LEGACY_FABRIC:
+                                content.addTag(i18n("install.installer.legacyfabric"));
+                                break;
                         }
                     }
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/addon/repository/ModrinthRemoteAddonRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/addon/repository/ModrinthRemoteAddonRepository.java
@@ -420,6 +420,7 @@ public final class ModrinthRemoteAddonRepository implements RemoteAddonRepositor
                     loaders.stream().flatMap(loader -> {
                         if ("fabric".equalsIgnoreCase(loader)) return Stream.of(ModLoaderType.FABRIC);
                         else if ("forge".equalsIgnoreCase(loader)) return Stream.of(ModLoaderType.FORGE);
+                        else if ("legacy-fabric".equalsIgnoreCase(loader)) return Stream.of(ModLoaderType.LEGACY_FABRIC);
                         else if ("neoforge".equalsIgnoreCase(loader)) return Stream.of(ModLoaderType.NEO_FORGE);
                         else if ("quilt".equalsIgnoreCase(loader)) return Stream.of(ModLoaderType.QUILT);
                         else if ("liteloader".equalsIgnoreCase(loader)) return Stream.of(ModLoaderType.LITE_LOADER);


### PR DESCRIPTION
# 补充 `Modrinth` 数据源的 `Legacy Fabric` 标签解析

## 实况

|更改前|更改后|
|---|---|
|<img width="1227" height="762" alt="1" src="https://github.com/user-attachments/assets/f4221d05-4cb6-4428-bdd9-599733139858" />|<img width="1227" height="762" alt="2" src="https://github.com/user-attachments/assets/7f24b278-88a8-4f96-9ecf-ebf5dd88f7cc" />|