### PR TITLE
[release/3.16] 修复 `GameAdvancedListItem#loadVersion` UI 操作可能不会  JavaFX 线程运行的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/ModpackHelper.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/ModpackHelper.java
@@ -176,7 +176,7 @@ public final class ModpackHelper {
         };
 
         return new ServerModpackRemoteInstallTask(repository.getDependency(), manifest, name)
-                .whenComplete(Schedulers.defaultScheduler(), success, failure)
+                .whenComplete(Schedulers.javafx(), success, failure)
                 .withStagesHints(new Task.StagesHint("hmcl.modpack"), new Task.StagesHint("hmcl.modpack.download", List.of("hmcl.install.assets", "hmcl.install.libraries")));
     }
 
@@ -221,12 +221,12 @@ public final class ModpackHelper {
 
         if (modpack.getManifest() instanceof MultiMCInstanceConfiguration)
             return modpack.getInstallTask(repository.getDependency(), zipFile, name, iconUrl)
-                    .whenComplete(Schedulers.defaultScheduler(), success, failure)
+                    .whenComplete(Schedulers.javafx(), success, failure)
                     .thenComposeAsync(createMultiMCPostInstallTask(repository, (MultiMCInstanceConfiguration) modpack.getManifest(), name))
                     .withStagesHints(new Task.StagesHint("hmcl.modpack"), new Task.StagesHint("hmcl.modpack.download", List.of("hmcl.install.assets", "hmcl.install.libraries")));
         else if (modpack.getManifest() instanceof McbbsModpackManifest)
             return modpack.getInstallTask(repository.getDependency(), zipFile, name, iconUrl)
-                    .whenComplete(Schedulers.defaultScheduler(), success, failure)
+                    .whenComplete(Schedulers.javafx(), success, failure)
                     .thenComposeAsync(createMcbbsPostInstallTask(repository, (McbbsModpackManifest) modpack.getManifest(), name))
                     .withStagesHints(new Task.StagesHint("hmcl.modpack"), new Task.StagesHint("hmcl.modpack.download", List.of("hmcl.install.assets", "hmcl.install.libraries")));
         else

--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/ModpackHelper.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/ModpackHelper.java
@@ -176,7 +176,7 @@ public final class ModpackHelper {
         };
 
         return new ServerModpackRemoteInstallTask(repository.getDependency(), manifest, name)
-                .whenComplete(Schedulers.javafx(), success, failure)
+                .whenComplete(Schedulers.defaultScheduler(), success, failure)
                 .withStagesHints(new Task.StagesHint("hmcl.modpack"), new Task.StagesHint("hmcl.modpack.download", List.of("hmcl.install.assets", "hmcl.install.libraries")));
     }
 
@@ -221,12 +221,12 @@ public final class ModpackHelper {
 
         if (modpack.getManifest() instanceof MultiMCInstanceConfiguration)
             return modpack.getInstallTask(repository.getDependency(), zipFile, name, iconUrl)
-                    .whenComplete(Schedulers.javafx(), success, failure)
+                    .whenComplete(Schedulers.defaultScheduler(), success, failure)
                     .thenComposeAsync(createMultiMCPostInstallTask(repository, (MultiMCInstanceConfiguration) modpack.getManifest(), name))
                     .withStagesHints(new Task.StagesHint("hmcl.modpack"), new Task.StagesHint("hmcl.modpack.download", List.of("hmcl.install.assets", "hmcl.install.libraries")));
         else if (modpack.getManifest() instanceof McbbsModpackManifest)
             return modpack.getInstallTask(repository.getDependency(), zipFile, name, iconUrl)
-                    .whenComplete(Schedulers.javafx(), success, failure)
+                    .whenComplete(Schedulers.defaultScheduler(), success, failure)
                     .thenComposeAsync(createMcbbsPostInstallTask(repository, (McbbsModpackManifest) modpack.getManifest(), name))
                     .withStagesHints(new Task.StagesHint("hmcl.modpack"), new Task.StagesHint("hmcl.modpack.download", List.of("hmcl.install.assets", "hmcl.install.libraries")));
         else

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/GameAdvancedListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/GameAdvancedListItem.java
@@ -53,8 +53,6 @@ public class GameAdvancedListItem extends AdvancedListItem {
     }
 
     private void loadVersion() {
-        System.err.println(Thread.currentThread().getName());
-
         String version = GameDirectoryManager.getSelectedInstance();
 
         boolean repositoryChanged = GameDirectoryManager.getSelectedRepository() != repository;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/GameAdvancedListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/GameAdvancedListItem.java
@@ -68,14 +68,17 @@ public class GameAdvancedListItem extends AdvancedListItem {
                 return;
             }
         }
-        if (version != null && repository != null && repository.hasVersion(version)) {
-            setTitle(i18n("version.manage.manage"));
-            setSubtitle(version);
-            imageContainer.setImage(repository.getVersionIconImage(version));
-        } else {
-            setTitle(i18n("version.empty"));
-            setSubtitle(i18n("version.empty.add"));
-            imageContainer.setImage(VersionIconType.DEFAULT.getIcon());
-        }
+
+        FXUtils.runInFX(() -> {
+            if (version != null && repository != null && repository.hasVersion(version)) {
+                setTitle(i18n("version.manage.manage"));
+                setSubtitle(version);
+                imageContainer.setImage(repository.getVersionIconImage(version));
+            } else {
+                setTitle(i18n("version.empty"));
+                setSubtitle(i18n("version.empty.add"));
+                imageContainer.setImage(VersionIconType.DEFAULT.getIcon());
+            }
+        });
     }
 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/GameAdvancedListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/GameAdvancedListItem.java
@@ -53,23 +53,23 @@ public class GameAdvancedListItem extends AdvancedListItem {
     }
 
     private void loadVersion() {
-        String version = GameDirectoryManager.getSelectedInstance();
-
-        boolean repositoryChanged = GameDirectoryManager.getSelectedRepository() != repository;
-        if (repositoryChanged) {
-            repository = GameDirectoryManager.getSelectedRepository();
-            onVersionIconChangedListener = repository.onVersionIconChanged.registerWeak(event -> {
-                this.loadVersion();
-            });
-
-            if (!repository.isLoaded()) {
-                onRefreshedVersionsListener = EventBus.EVENT_BUS.channel(RefreshedVersionsEvent.class)
-                        .registerWeak(event -> loadVersion());
-                return;
-            }
-        }
-
         FXUtils.runInFX(() -> {
+            String version = GameDirectoryManager.getSelectedInstance();
+
+            boolean repositoryChanged = GameDirectoryManager.getSelectedRepository() != repository;
+            if (repositoryChanged) {
+                repository = GameDirectoryManager.getSelectedRepository();
+                onVersionIconChangedListener = repository.onVersionIconChanged.registerWeak(event -> {
+                    this.loadVersion();
+                });
+
+                if (!repository.isLoaded()) {
+                    onRefreshedVersionsListener = EventBus.EVENT_BUS.channel(RefreshedVersionsEvent.class)
+                            .registerWeak(event -> loadVersion());
+                    return;
+                }
+            }
+
             if (version != null && repository != null && repository.hasVersion(version)) {
                 setTitle(i18n("version.manage.manage"));
                 setSubtitle(version);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/GameAdvancedListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/GameAdvancedListItem.java
@@ -53,6 +53,8 @@ public class GameAdvancedListItem extends AdvancedListItem {
     }
 
     private void loadVersion() {
+        System.err.println(Thread.currentThread().getName());
+
         String version = GameDirectoryManager.getSelectedInstance();
 
         boolean repositoryChanged = GameDirectoryManager.getSelectedRepository() != repository;


### PR DESCRIPTION
resolves #6443
附来自崩溃群 & 用户群的完整报告
```
---- Hello Minecraft! Crash Report ----
  Version: 3.16.2
  Time: 2026-07-20 16:08:24
  Thread: Thread[#47,ForkJoinPool.commonPool-worker-3,5,InnocuousForkJoinWorkerThreadGroup]

  Content: 
    java.lang.IllegalStateException: Not on FX application thread; currentThread = ForkJoinPool.commonPool-worker-3
	at javafx.graphics@25/com.sun.javafx.tk.Toolkit.checkFxUserThread(Toolkit.java:282)
	at javafx.graphics@25/com.sun.javafx.tk.quantum.QuantumToolkit.checkFxUserThread(QuantumToolkit.java:475)
	at javafx.graphics@25/javafx.scene.Parent$3.onProposedChange(Parent.java:539)
	at javafx.base@25/com.sun.javafx.collections.VetoableListDecorator.setAllImpl(VetoableListDecorator.java:127)
	at javafx.base@25/com.sun.javafx.collections.VetoableListDecorator.setAll(VetoableListDecorator.java:118)
	at javafx.controls@25/javafx.scene.control.skin.LabeledSkinBase.updateChildren(LabeledSkinBase.java:285)
	at javafx.controls@25/javafx.scene.control.skin.LabeledSkinBase.lambda$new$11(LabeledSkinBase.java:222)
	at javafx.controls@25/com.sun.javafx.scene.control.LambdaMultiplePropertyChangeListenerHandler.lambda$new$0(LambdaMultiplePropertyChangeListenerHandler.java:88)
	at javafx.base@25/javafx.beans.value.WeakChangeListener.changed(WeakChangeListener.java:86)
	at javafx.base@25/com.sun.javafx.binding.ExpressionHelper$SingleChange.fireValueChangedEvent(ExpressionHelper.java:192)
	at javafx.base@25/com.sun.javafx.binding.ExpressionHelper.fireValueChangedEvent(ExpressionHelper.java:91)
	at javafx.base@25/javafx.beans.property.StringPropertyBase.fireValueChangedEvent(StringPropertyBase.java:104)
	at javafx.base@25/javafx.beans.property.StringPropertyBase.markInvalid(StringPropertyBase.java:111)
	at javafx.base@25/javafx.beans.property.StringPropertyBase.set(StringPropertyBase.java:145)
	at javafx.base@25/javafx.beans.property.StringPropertyBase.set(StringPropertyBase.java:50)
	at javafx.base@25/javafx.beans.property.StringProperty.setValue(StringProperty.java:71)
	at javafx.controls@25/javafx.scene.control.Labeled.setText(Labeled.java:157)
	at org.jackhuang.hmcl.ui.construct.TwoLineListItem$1.invalidated(TwoLineListItem.java:85)
	at javafx.base@25/javafx.beans.property.StringPropertyBase.markInvalid(StringPropertyBase.java:110)
	at javafx.base@25/javafx.beans.property.StringPropertyBase$Listener.invalidated(StringPropertyBase.java:231)
	at javafx.base@25/com.sun.javafx.binding.ExpressionHelper$SingleInvalidation.fireValueChangedEvent(ExpressionHelper.java:147)
	at javafx.base@25/com.sun.javafx.binding.ExpressionHelper.fireValueChangedEvent(ExpressionHelper.java:91)
	at javafx.base@25/javafx.beans.property.StringPropertyBase.fireValueChangedEvent(StringPropertyBase.java:104)
	at javafx.base@25/javafx.beans.property.StringPropertyBase.markInvalid(StringPropertyBase.java:111)
	at javafx.base@25/javafx.beans.property.StringPropertyBase.set(StringPropertyBase.java:145)
	at javafx.base@25/javafx.beans.property.StringPropertyBase.set(StringPropertyBase.java:50)
	at org.jackhuang.hmcl.ui.construct.AdvancedListItem.setTitle(AdvancedListItem.java:107)
	at org.jackhuang.hmcl.ui.versions.GameAdvancedListItem.loadVersion(GameAdvancedListItem.java:72)
	at org.jackhuang.hmcl.ui.versions.GameAdvancedListItem.lambda$loadVersion$2(GameAdvancedListItem.java:67)
	at org.jackhuang.hmcl.event.EventManager.fireEvent(EventManager.java:83)
	at org.jackhuang.hmcl.event.EventBus.fireEvent(EventBus.java:46)
	at org.jackhuang.hmcl.game.DefaultGameRepository.refreshVersions(DefaultGameRepository.java:401)
	at org.jackhuang.hmcl.util.function.ExceptionalRunnable.lambda$toCallable$0(ExceptionalRunnable.java:32)
	at org.jackhuang.hmcl.task.Task$SimpleTask.execute(Task.java:1110)
	at org.jackhuang.hmcl.task.AsyncTaskExecutor.lambda$executeNormalTask$22(AsyncTaskExecutor.java:241)
	at org.jackhuang.hmcl.util.Lang.lambda$wrap$2(Lang.java:303)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1825)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1817)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)


-- System Details --
  Operating System: Windows NT (unknown) 6.1.7601
  System Architecture: x86-64
  Java Architecture: x86-64
  Java Version: 25.0.3, Microsoft
  Java VM Version: OpenJDK 64-Bit Server VM (mixed mode, sharing), Microsoft
  JVM Max Memory: 1073741824
  JVM Total Memory: 76546048
  JVM Free Memory: 43667776
```

```
---- Hello Minecraft! Crash Report ----
  Version: 3.17.0.351
  Time: 2026-07-19 09:53:47
  Thread: Thread[#67,ForkJoinPool.commonPool-worker-4,5,InnocuousForkJoinWorkerThreadGroup]

  Content: 
    java.lang.IllegalStateException: Not on FX application thread; currentThread = ForkJoinPool.commonPool-worker-4
    at javafx.graphics@25/com.sun.javafx.tk.Toolkit.checkFxUserThread(Toolkit.java:282)
    at javafx.graphics@25/com.sun.javafx.tk.quantum.QuantumToolkit.checkFxUserThread(QuantumToolkit.java:475)
    at javafx.graphics@25/javafx.scene.Parent$3.onProposedChange(Parent.java:539)
    at javafx.base@25/com.sun.javafx.collections.VetoableListDecorator.add(VetoableListDecorator.java:221)
    at org.jackhuang.hmcl.ui.construct.TwoLineListItem$2.invalidated(TwoLineListItem.java:125)
    at javafx.base@25/javafx.beans.property.StringPropertyBase.markInvalid(StringPropertyBase.java:110)
    at javafx.base@25/javafx.beans.property.StringPropertyBase$Listener.invalidated(StringPropertyBase.java:231)
    at javafx.base@25/com.sun.javafx.binding.ExpressionHelper$SingleInvalidation.fireValueChangedEvent(ExpressionHelper.java:147)
    at javafx.base@25/com.sun.javafx.binding.ExpressionHelper.fireValueChangedEvent(ExpressionHelper.java:91)
    at javafx.base@25/javafx.beans.property.StringPropertyBase.fireValueChangedEvent(StringPropertyBase.java:104)
    at javafx.base@25/javafx.beans.property.StringPropertyBase.markInvalid(StringPropertyBase.java:111)
    at javafx.base@25/javafx.beans.property.StringPropertyBase.set(StringPropertyBase.java:145)
    at javafx.base@25/javafx.beans.property.StringPropertyBase.set(StringPropertyBase.java:50)
    at org.jackhuang.hmcl.ui.construct.AdvancedListItem.setSubtitle(AdvancedListItem.java:121)
    at org.jackhuang.hmcl.ui.versions.GameAdvancedListItem.loadVersion(GameAdvancedListItem.java:73)
    at org.jackhuang.hmcl.ui.versions.GameAdvancedListItem.lambda$loadVersion$2(GameAdvancedListItem.java:67)
    at org.jackhuang.hmcl.event.EventManager.fireEvent(EventManager.java:83)
    at org.jackhuang.hmcl.event.EventBus.fireEvent(EventBus.java:46)
    at org.jackhuang.hmcl.game.DefaultGameRepository.refreshVersions(DefaultGameRepository.java:401)
    at org.jackhuang.hmcl.util.function.ExceptionalRunnable.lambda$toCallable$0(ExceptionalRunnable.java:32)
    at org.jackhuang.hmcl.task.Task$SimpleTask.execute(Task.java:1110)
    at org.jackhuang.hmcl.task.AsyncTaskExecutor.lambda$executeNormalTask$22(AsyncTaskExecutor.java:241)
    at org.jackhuang.hmcl.util.Lang.lambda$wrap$2(Lang.java:303)
    at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1825)
    at java.base/java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1817)
    at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
    at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
    at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
    at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)


-- System Details --
  Operating System: Windows 11 25H2 10.0.26200.8875
  System Architecture: x86-64
  Java Architecture: x86-64
  Java Version: 25.0.3, Microsoft
  Java VM Version: OpenJDK 64-Bit Server VM (mixed mode, sharing), Microsoft
  JVM Max Memory: 1073741824
  JVM Total Memory: 286261248
  JVM Free Memory: 128702656这是怎么回事？
```