### PR TITLE
调换 “预设” 与 “版本隔离” 位置

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/game/GameSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/game/GameSettingsPage.java
@@ -162,13 +162,14 @@ public final class GameSettingsPage<S extends GameSettings> extends StackPane
         {
             if (isPresetSetting) {
                 var presetSettings = new ComponentList();
-                rootPane.getChildren().addAll(ComponentList.createComponentListTitle(i18n("settings.game.section.basic")),
-                        basicSettings,
+                rootPane.getChildren().addAll(
                         ComponentList.createComponentListTitle(
                                 i18n("settings.type.global.preset"),
                                 i18n("settings.type.global.preset.help")
                         ),
                         presetSettings,
+                        ComponentList.createComponentListTitle(i18n("settings.game.section.basic")),
+                        basicSettings,
                         ComponentList.createComponentListTitle(i18n("settings.game.section.game")),
                         gameSettings,
                         ComponentList.createComponentListTitle(i18n("settings.launcher")),


### PR DESCRIPTION
<img width="1227" height="762" alt="image" src="https://github.com/user-attachments/assets/cfd7ab2f-bc8f-4db7-ad81-92bb77e8bdc9" />
第一次看的时候我还以为 “版本隔离” 设置 不受 “预设” 选项管理，并且在实例独立设置中 “版本隔离” 也是 在 “预设” 下面的
<img width="895" height="364" alt="image" src="https://github.com/user-attachments/assets/cb5015bb-f91b-4f10-bee0-767fe9f4b3da" />
