### PR TITLE
Chore: Clean up duplicate key-value pairs for No results found

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadListPage.java
@@ -519,7 +519,7 @@ public class DownloadListPage extends Control implements DecoratorPage, VersionP
                         if (getSkinnable().isFailed()) {
                             return i18n("download.failed.refresh");
                         } else if (!getSkinnable().isLoading() && getSkinnable().pageCount.get() >= 0 && getSkinnable().items.isEmpty()) {
-                            return i18n("download.failed.no_results_found"); 
+                            return i18n("search.no_results_found"); 
                         } else {
                             return null;
                         }

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -399,7 +399,6 @@ download.external_link=Visit Download Website
 download.failed=Failed to download "%1$s", response code: %2$d.
 download.failed.empty=No versions are available. Please click here to go back.
 download.failed.no_code=Failed to download
-download.failed.no_results_found=No results found
 download.failed.refresh=Failed to fetch version list. Please click here to retry.
 download.game=New Game
 download.provider.bmclapi=BMCLAPI & MCIM

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -397,7 +397,6 @@ download.external_link=開啟下載網站
 download.failed=下載失敗：%1$s\n錯誤碼：%2$d
 download.failed.empty=沒有可供安裝的版本，按一下此處返回。
 download.failed.no_code=下載失敗
-download.failed.no_results_found=搜尋無結果
 download.failed.refresh=載入版本清單失敗，按一下此處重試。
 download.game=新遊戲
 download.provider.bmclapi=BMCLAPI & MCIM

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -399,7 +399,6 @@ download.external_link=打开下载网站
 download.failed=下载失败: %1$s，\n错误码：%2$d\n你可以点击右上角帮助按钮进行求助。
 download.failed.empty=[没有可供安装的版本，点击此处返回]\n(你可以点击右上角帮助按钮进行求助)
 download.failed.no_code=下载失败
-download.failed.no_results_found=搜索无结果
 download.failed.refresh=[加载版本列表失败，点击此处重试]\n(你可以点击右上角帮助按钮进行求助)
 download.game=新游戏
 download.provider.bmclapi=BMCLAPI & MCIM


### PR DESCRIPTION
# 清理重复的 `搜索无结果` 键值

- #6426 中已经统一使用了 `search.no_results_found`，故先前 #6368 中的 `download.failed.no_results_found` 已是重复的。