### PR TITLE
Fix: Alignment for background opacity percentage label

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
@@ -1007,6 +1007,7 @@ public class PersonalizationPage extends StackPane {
 
                 Label textOpacity = new Label();
                 FXUtils.setLimitWidth(textOpacity, 50);
+                textOpacity.setAlignment(Pos.CENTER);
 
                 StringBinding valueBinding = Bindings.createStringBinding(() -> ((int) slider.getValue()) + "%", slider.valueProperty());
                 textOpacity.textProperty().bind(valueBinding);


### PR DESCRIPTION
# 对齐了 `不透明度` 设置中的 `textOpacity`

|更改前|更改后|
|---|---|
|<img width="890" height="598" alt="1" src="https://github.com/user-attachments/assets/2fe2c5ab-90c2-4ac8-af17-24cd317fa617" />|<img width="899" height="596" alt="2" src="https://github.com/user-attachments/assets/5826ba72-d064-437e-b1e0-40c0d892f592" />|