### PR TITLE
增大预设管理 右侧按钮大小

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/game/PresetManagementPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/game/PresetManagementPane.java
@@ -287,14 +287,14 @@ final class PresetManagementPane extends ComponentSublist {
         /// Creates the remove button shown on the right side of the option.
         @Override
         protected Node createRightNode() {
-            JFXButton renameButton = FXUtils.newToggleButton4(SVG.EDIT, 14);
+            JFXButton renameButton = FXUtils.newToggleButton4(SVG.EDIT, 18);
             renameButton.setOnAction(event -> {
                 renamePreset(getValue());
                 event.consume();
             });
             FXUtils.installFastTooltip(renameButton, i18n("settings.type.global.preset.rename"));
 
-            JFXButton removeButton = FXUtils.newToggleButton4(SVG.DELETE_FOREVER, 14);
+            JFXButton removeButton = FXUtils.newToggleButton4(SVG.DELETE_FOREVER, 18);
             removeButton.disableProperty().bind(Bindings.createBooleanBinding(
                     () -> SettingsManager.getGameSettings().size() <= 1,
                     SettingsManager.getGameSettings()));


### PR DESCRIPTION
<img width="961" height="300" alt="image" src="https://github.com/user-attachments/assets/631bff7d-4864-4ada-8ac7-b3472e4c383a" />
与左侧复选框等大看着更平衡