### PR TITLE
更新时 日志输出新进程命令行时 打码敏感信息

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateHandler.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateHandler.java
@@ -231,15 +231,18 @@ public final class UpdateHandler {
     private static String maskCommandline(List<String> commandline) {
         return commandline.stream().map(str -> {
             if (str.startsWith("-D")) {
-                String key = str.split("=")[0].replace("-D", "");
-                String value = str.split("=")[1];
-                if (key.contains("http.proxy") ||
-                        key.startsWith("https.proxy") ||
-                        key.startsWith("socksProxy") ||
-                        key.equals("hmcl.microsoft.auth.id") ||
-                        key.equals("hmcl.curseforge.apikey")
-                ) {
-                    return "-D" + key + "=" + value.charAt(0) + "*".repeat(value.length() - 1);
+                int eqIdx = str.indexOf('=');
+                if (eqIdx != -1) {
+                    String key = str.substring(2, eqIdx);
+                    String value = str.substring(eqIdx + 1);
+                    if (key.contains("http.proxy") ||
+                            key.startsWith("https.proxy") ||
+                            key.startsWith("socksProxy") ||
+                            key.equals("hmcl.microsoft.auth.id") ||
+                            key.equals("hmcl.curseforge.apikey")
+                    ) {
+                        return "-D" + key + "=" + (value.isEmpty() ? "" : value.charAt(0) + "*".repeat(value.length() - 1));
+                    }
                 }
             }
             return str;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateHandler.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateHandler.java
@@ -47,6 +47,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.jackhuang.hmcl.ui.FXUtils.checkFxUserThread;
 import static org.jackhuang.hmcl.util.Lang.thread;
@@ -220,11 +221,29 @@ public final class UpdateHandler {
         commandline.add("-jar");
         commandline.add(jar.toAbsolutePath().toString());
         commandline.addAll(Arrays.asList(appArgs));
-        LOG.info("Starting process: " + commandline);
+        LOG.info("Starting process: " + maskCommandline(commandline));
         new ProcessBuilder(commandline)
                 .directory(Paths.get("").toAbsolutePath().toFile())
                 .inheritIO()
                 .start();
+    }
+
+    private static String maskCommandline(List<String> commandline) {
+        return commandline.stream().map(str -> {
+            if (str.startsWith("-D")) {
+                String key = str.split("=")[0].replace("-D", "");
+                String value = str.split("=")[1];
+                if (key.contains("http.proxy") ||
+                        key.startsWith("https.proxy") ||
+                        key.startsWith("socksProxy") ||
+                        key.equals("hmcl.microsoft.auth.id") ||
+                        key.equals("hmcl.curseforge.apikey")
+                ) {
+                    return "-D" + key + "=" + value.charAt(0) + "*".repeat(value.length() - 1);
+                }
+            }
+            return str;
+        }).collect(Collectors.joining(" "));
     }
 
     private static Optional<Path> tryRename(Path path, String newVersion) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateHandler.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateHandler.java
@@ -245,6 +245,7 @@ public final class UpdateHandler {
                     }
                 }
             }
+
             return str;
         }).collect(Collectors.joining(" "));
     }


### PR DESCRIPTION
如果玩家通过设置 JVM 参数使用了自己的 curseforge apikey / microsoft auth uuid 或配置了自己的代理服务器，那么更新时这些信息会被明文保存在日志中，玩家发送启动器日志时可能会泄露这些信息。