### PR TITLE
移除对 JavaFX 14 的兼容性

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/StyleSheets.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/StyleSheets.java
@@ -28,18 +28,11 @@ import org.glavo.monetfx.ColorScheme;
 import org.jackhuang.hmcl.theme.ResolvedTheme;
 import org.jackhuang.hmcl.theme.ThemeColor;
 import org.jackhuang.hmcl.theme.Themes;
-import org.jackhuang.hmcl.ui.FXUtils;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Locale;
-
-import static org.jackhuang.hmcl.util.logging.Logger.LOG;
 
 /**
  * @author Glavo
@@ -68,22 +61,7 @@ public final class StyleSheets {
     }
 
     private static String toStyleSheetUri(String styleSheet, String fallback) {
-        if (FXUtils.JAVAFX_MAJOR_VERSION >= 17)
-            // JavaFX 17+ support loading stylesheets from data URIs
-            // https://bugs.openjdk.org/browse/JDK-8267554
-            return "data:text/css;charset=UTF-8;base64," + Base64.getEncoder().encodeToString(styleSheet.getBytes(StandardCharsets.UTF_8));
-        else
-            try {
-                Path temp = Files.createTempFile("hmcl", ".css");
-                // For JavaFX 17 or earlier, CssParser uses the default charset
-                // https://bugs.openjdk.org/browse/JDK-8279328
-                Files.writeString(temp, styleSheet, Charset.defaultCharset());
-                temp.toFile().deleteOnExit();
-                return temp.toUri().toString();
-            } catch (IOException | NullPointerException e) {
-                LOG.error("Unable to create stylesheet, fallback to " + fallback, e);
-                return fallback;
-            }
+        return "data:text/css;charset=UTF-8;base64," + Base64.getEncoder().encodeToString(styleSheet.getBytes(StandardCharsets.UTF_8));
     }
 
     private static String getFontStyleSheet() {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/StyleSheets.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/StyleSheets.java
@@ -60,7 +60,7 @@ public final class StyleSheets {
         });
     }
 
-    private static String toStyleSheetUri(String styleSheet, String fallback) {
+    private static String toStyleSheetUri(String styleSheet) {
         return "data:text/css;charset=UTF-8;base64," + Base64.getEncoder().encodeToString(styleSheet.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -111,7 +111,7 @@ public final class StyleSheets {
 
         builder.append('}');
 
-        return toStyleSheetUri(builder.toString(), defaultCss);
+        return toStyleSheetUri(builder.toString());
     }
 
     private static String getBrightnessStyleSheet() {
@@ -162,7 +162,7 @@ public final class StyleSheets {
         addColor(builder, scheme, ColorRole.INVERSE_SURFACE, 0.8);
 
         builder.append("}\n");
-        return toStyleSheetUri(builder.toString(), blueCss);
+        return toStyleSheetUri(builder.toString());
     }
 
     public static void init(Scene scene) {


### PR DESCRIPTION
现在我们在 FreeBSD x86-64 平台不再依赖官方的 openjfx14 包，而是使用自行移植的 [JavaFX 21](https://github.com/Glavo/jfx21-freebsd)。所以我们不再需要兼容 JavaFX 14~16，将 JavaFX 基线提升至 17。