### PR TITLE
Fix: control.txtName width of InstallersPage

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/AbstractInstallersPage.java
@@ -130,7 +130,7 @@ public abstract class AbstractInstallersPage extends Control implements WizardPa
                 versionNamePane.setStyle("-fx-padding: 20 8 20 16");
                 versionNamePane.setAlignment(Pos.CENTER_LEFT);
 
-                control.txtName.setMaxWidth(300);
+                control.txtName.setPrefWidth(300);
                 versionNamePane.getChildren().setAll(new Label(i18n("version.name")), control.txtName);
                 root.setTop(versionNamePane);
             }


### PR DESCRIPTION
# 修复 `InstallersPage` 中 `control.txtName` 的宽度问题

- Fix: #6461

## 实况

|更改前|更改后|更改后（英语）|
|---|---|---|
|<img width="1227" height="762" alt="1" src="https://github.com/user-attachments/assets/ce08ad75-1994-4f67-ac13-f9c442e597fa" />|<img width="1227" height="762" alt="2" src="https://github.com/user-attachments/assets/328769ef-fab2-4f59-b459-5d2d9fc01a1d" />|<img width="1227" height="762" alt="3" src="https://github.com/user-attachments/assets/7abab284-b953-4a16-83e1-d0b1622a784a" />|