### PR TITLE
清理模组管理页面冗余 “实例无模组加载器” 提示

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPage.java
@@ -17,17 +17,15 @@
  */
 package org.jackhuang.hmcl.ui.versions;
 
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.ObservableList;
 import javafx.scene.control.Skin;
 import javafx.stage.FileChooser;
-import org.jackhuang.hmcl.download.LibraryAnalyzer;
-import org.jackhuang.hmcl.game.HMCLGameRepository;
-import org.jackhuang.hmcl.game.Version;
 import org.jackhuang.hmcl.addon.mod.LocalModFile;
 import org.jackhuang.hmcl.addon.mod.ModLoaderType;
 import org.jackhuang.hmcl.addon.mod.ModManager;
+import org.jackhuang.hmcl.download.LibraryAnalyzer;
+import org.jackhuang.hmcl.game.HMCLGameRepository;
+import org.jackhuang.hmcl.game.Version;
 import org.jackhuang.hmcl.setting.DownloadProviders;
 import org.jackhuang.hmcl.setting.GameDirectory;
 import org.jackhuang.hmcl.task.Schedulers;
@@ -52,8 +50,6 @@ import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 import static org.jackhuang.hmcl.util.logging.Logger.LOG;
 
 public final class ModListPage extends ListPageBase<ModListPageSkin.ModInfoObject> implements VersionPage.GameInstanceLoadable, PageAware {
-    private final BooleanProperty modded = new SimpleBooleanProperty(this, "modded", false);
-
     private final ReentrantLock lock = new ReentrantLock();
 
     private ModManager modManager;
@@ -92,8 +88,7 @@ public final class ModListPage extends ListPageBase<ModListPageSkin.ModInfoObjec
 
         Version resolved = repository.getResolvedPreservingPatchesVersion(instanceId);
         this.gameVersion = repository.getGameVersion(resolved).orElse(null);
-        LibraryAnalyzer analyzer = LibraryAnalyzer.analyze(resolved, gameVersion);
-        modded.set(analyzer.hasModLoader());
+
         loadMods(repository.getModManager(instanceId));
     }
 
@@ -287,18 +282,6 @@ public final class ModListPage extends ListPageBase<ModListPageSkin.ModInfoObjec
         } catch (IOException ex) {
             Controllers.showToast(i18n("message.failed"));
         }
-    }
-
-    public boolean isModded() {
-        return modded.get();
-    }
-
-    public BooleanProperty moddedProperty() {
-        return modded;
-    }
-
-    public void setModded(boolean modded) {
-        this.modded.set(modded);
     }
 
     public GameDirectory getGameDirectory() {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
@@ -109,6 +109,7 @@ final class ModListPageSkin extends SkinBase<ModListPage> {
         pane.getStyleClass().addAll("notice-pane");
 
         ComponentList root = new ComponentList();
+        pane.getChildren().setAll(root);
         root.getStyleClass().add("no-padding");
         listView = new JFXListView<>();
         listView.getStyleClass().add("no-horizontal-scrollbar");

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPageSkin.java
@@ -38,10 +38,11 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
 import javafx.util.Duration;
-import org.jackhuang.hmcl.addon.*;
-import org.jackhuang.hmcl.addon.repository.CurseForgeRemoteAddonRepository;
+import org.jackhuang.hmcl.addon.RemoteAddon;
+import org.jackhuang.hmcl.addon.RemoteAddonRepository;
 import org.jackhuang.hmcl.addon.mod.LocalModFile;
 import org.jackhuang.hmcl.addon.mod.ModLoaderType;
+import org.jackhuang.hmcl.addon.repository.CurseForgeRemoteAddonRepository;
 import org.jackhuang.hmcl.addon.repository.ModrinthRemoteAddonRepository;
 import org.jackhuang.hmcl.game.HMCLGameRepository;
 import org.jackhuang.hmcl.setting.DownloadProviders;
@@ -268,14 +269,6 @@ final class ModListPageSkin extends SkinBase<ModListPage> {
             center.setContent(listView);
             root.getContent().add(center);
         }
-
-        Label label = new Label(i18n("mods.not_modded"));
-        label.prefWidthProperty().bind(pane.widthProperty().add(-100));
-
-        FXUtils.onChangeAndOperate(skinnable.moddedProperty(), modded -> {
-            if (modded) pane.getChildren().setAll(root);
-            else pane.getChildren().setAll(label);
-        });
 
         getChildren().setAll(pane);
     }


### PR DESCRIPTION
1. 这个机制已经很久没有正常工作过了，因为 `LibraryType` 中 `MINECRAFT` 的 `modLoader`字段为 `true`，所以无论如何 `ModListPage` 中的 `modded` 属性的值都为 `true`
2.如果修复这个机制，会导致无法管理通过文件覆盖安装模组加载器（如旧版本 Forge）的 Minecraft 实例的模组。