### PR TITLE
[release/3.16] fix: `切换版本隔离设置后自动刷新其他子页面` 功能失效

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/game/GameSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/game/GameSettingsPage.java
@@ -22,7 +22,10 @@ import com.jfoenix.controls.JFXComboBox;
 import com.jfoenix.controls.JFXSlider;
 import com.jfoenix.controls.JFXTextField;
 import javafx.beans.InvalidationListener;
-import javafx.beans.property.*;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.Property;
+import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -32,11 +35,7 @@ import javafx.geometry.Pos;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Node;
 import javafx.scene.Scene;
-import javafx.scene.control.ContentDisplay;
-import javafx.scene.control.Label;
-import javafx.scene.control.ScrollPane;
-import javafx.scene.control.TextFormatter;
-import javafx.scene.control.Tooltip;
+import javafx.scene.control.*;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.*;
 import javafx.stage.FileChooser;
@@ -1721,6 +1720,8 @@ public final class GameSettingsPage<S extends GameSettings> extends StackPane
                 updating.value = false;
             }
             refresh.invalidated(instance);
+
+            fireEvent(new VersionPage.WorkingDirChangedEvent());
         });
 
         currentSetting.addListener((observable, oldValue, newValue) -> {
@@ -1809,6 +1810,9 @@ public final class GameSettingsPage<S extends GameSettings> extends StackPane
                 updating.value = false;
             }
             refresh.invalidated(instance);
+
+            fireEvent(new VersionPage.WorkingDirChangedEvent());
+
             event.consume();
         });
 
@@ -1828,6 +1832,8 @@ public final class GameSettingsPage<S extends GameSettings> extends StackPane
             } finally {
                 updating.value = false;
             }
+
+            fireEvent(new VersionPage.WorkingDirChangedEvent());
         });
 
         currentSetting.addListener((observable, oldValue, newValue) -> {


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/pull/6468