### PR TITLE
Set up Cursor Cloud dev environment for HMCL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,14 @@ Apply the following requirements when writing or modifying code. Do not use them
 - Documentation must use `///` Markdown-style Javadoc comments.
 - Keep documentation accurate and specific to the actual behavior, constraints, and side effects.
 - Add concise implementation comments inside complex logic whenever they materially improve readability or explain non-obvious behavior.
+
+## Cursor Cloud specific instructions
+
+HMCL is a single JavaFX desktop application built with a Gradle multi-module setup (no backend/database services). Standard build/test/run commands live in `docs/Contributing.md` and the module `build.gradle.kts` files; the notes below only cover non-obvious cloud caveats.
+
+- JDK: `docs/Contributing.md` asks for JDK 17+. The VM ships JDK 21 (no `JAVA_HOME` set), which works fine — do not downgrade or install a separate JDK.
+- JavaFX is fetched automatically by the Gradle build (`buildSrc` `JavaFXUtils`), so no manual OpenJFX install is needed; the build just needs network access to Maven Central / JitPack / `libraries.minecraft.net`.
+- Lint (matches `.github/workflows/check-codes.yml`): `./gradlew checkstyle checkTranslations`. Note `checkstyle` here is a custom aggregate task, not the default `check`.
+- Run the GUI: a VNC X server is available at `DISPLAY=:1`. Launch with `DISPLAY=:1 ./gradlew run --no-daemon` (blocks while the app runs). The app writes its data folder to `./.hmcl` under the repo root by default.
+- Expected harmless warnings when running an unofficial local build: `IntegrityChecker ... Signature is missing` / `Self verification failed` (the jar isn't signed), and a `getDefaultBrightness` stack trace when `fastfetch` is absent. Neither blocks startup.
+- `MICROSOFT_AUTH_ID` and `CURSEFORGE_API_KEY` are only needed to bake real API keys into a build; blank defaults are fine for building, testing, and offline-account usage.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Cursor Cloud development environment for HMCL (Hello Minecraft! Launcher), a JavaFX desktop app built with Gradle. No application code was changed.

- Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting durable, non-obvious caveats (JDK 21 works, JavaFX auto-downloaded by Gradle, lint via the custom `checkstyle` task, GUI run via `DISPLAY=:1`, expected harmless unsigned-build/fastfetch warnings, optional API-key env vars).

## Environment verification

All commands run from repo root with the bundled Gradle wrapper (Gradle 9.6.1) on the VM's JDK 21.

| Action | Command | Result |
|---|---|---|
| Build (+tests) | `./gradlew build --no-daemon --parallel` | BUILD SUCCESSFUL; produced `HMCL-3.17.SNAPSHOT.{jar,exe,sh,deb}` |
| Lint | `./gradlew checkstyle checkTranslations --no-daemon --parallel` | BUILD SUCCESSFUL |
| Tests | run as part of `build` (JUnit 5 in `HMCLCore`) | passed |
| Run GUI | `DISPLAY=:1 ./gradlew run --no-daemon` | App launched; created an offline account |

## Hello-world task

Launched the GUI, accepted the ToS/EULA, and created an offline Minecraft account named **Steve**, which now appears in the ACCOUNTS sidebar.

[hmcl_add_offline_account.mp4](https://cursor.com/agents/bc-3dd9ce39-51b6-44da-8b64-c66539f5cfbe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhmcl_add_offline_account.mp4)

[HMCL with offline account Steve](https://cursor.com/agents/bc-3dd9ce39-51b6-44da-8b64-c66539f5cfbe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhmcl_account_steve_created.webp)

## Update script

`./gradlew --no-daemon help` — minimal, idempotent warm-up of the Gradle wrapper distribution and `buildSrc`. Build/test/run are intentionally excluded.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3dd9ce39-51b6-44da-8b64-c66539f5cfbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3dd9ce39-51b6-44da-8b64-c66539f5cfbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

