### PR TITLE
Refactor: ModpackSelectionPage 文件选择器关闭后不清空页面栈

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/ModpackSelectionPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/ModpackSelectionPage.java
@@ -114,7 +114,6 @@ public final class ModpackSelectionPage extends VBox implements WizardPage {
         chooser.getExtensionFilters().add(new FileChooser.ExtensionFilter(i18n("modpack"), "*.zip", "*.mrpack"));
         Path selectedFile = Controllers.showOpenDialog(chooser);
         if (selectedFile == null) {
-            Platform.runLater(controller::onEnd);
             return;
         }
 


### PR DESCRIPTION
# `ModpackSelectionPage` 文件选择器关闭后不清空页面栈

- 用户不需要重新打开该页面。
- 在视觉上，这将与 `从互联网下载整合包` 的取消操作类似。

## 实况

### 更改前

https://github.com/user-attachments/assets/b900a0ed-1643-4682-bbbd-6d5e24d8c546

### 更改后

https://github.com/user-attachments/assets/c4163bbe-1d53-47bb-b34b-5d2871fd5f40