### PR TITLE
Fix: 在 ModpackSelectionPage 中非 IOException 的异常导致崩溃

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/ModpackSelectionPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/ModpackSelectionPage.java
@@ -44,7 +44,6 @@ import org.jackhuang.hmcl.util.SettingsMap;
 import org.jackhuang.hmcl.util.TaskCancellationAction;
 import org.jackhuang.hmcl.util.gson.JsonUtils;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -158,8 +157,8 @@ public final class ModpackSelectionPage extends VBox implements WizardPage {
                             TaskCancellationAction.NORMAL
                     );
                 }
-            } catch (IOException e) {
-                handler.reject(e.getMessage());
+            } catch (Exception e) {
+                handler.reject(i18n("message.failed"));
             }
         }, "", new URLValidator());
     }


### PR DESCRIPTION
# 修复在 `ModpackSelectionPage` 中非 `IOException` 的异常导致崩溃

- 此前，在 `安装整合包 - 导入整合包` > `从互联网下载整合包` 中输入 **无法解析的地址** 并且尝试下载后，无法捕获非 `IOException` 的异常，导致启动器 **崩溃** 。