### PR TITLE
Fix: 防止 DisabledJavaItem 的 Label 响应鼠标事件

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaRestorePage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/JavaRestorePage.java
@@ -151,6 +151,7 @@ public final class JavaRestorePage extends ListPageBase<JavaRestorePage.Disabled
             BorderPane root = new BorderPane();
 
             Label label = new Label(skinnable.path);
+            label.setMouseTransparent(true);
             BorderPane.setAlignment(label, Pos.CENTER_LEFT);
             root.setCenter(label);
 


### PR DESCRIPTION
# 防止 `DisabledJavaItem` 的 `Label` 响应鼠标事件

- 在此之前，`管理已禁用的 Java` 页面中条目的 `Label` 会响应鼠标事件，导致点击 `Label` **无法被穿透**，也 **不会** 触发水波纹。

## 更改前

https://github.com/user-attachments/assets/cfe590b7-9efb-4bce-80a4-abc1e491f09a

## 更改后

https://github.com/user-attachments/assets/33d63a0f-da16-4465-95c3-264c68fbec0e