### PR TITLE
Fix: 修复 ModDownloadListPage 末尾项 Padding

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/instances/DownloadListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/instances/DownloadListPage.java
@@ -542,6 +542,7 @@ public class DownloadListPage extends Control implements DecoratorPage, GameInst
                 ignoreEvent(listView, KeyEvent.KEY_PRESSED, e -> e.getCode() == KeyCode.ESCAPE);
                 listView.setCellFactory(x -> new ListCell<>() {
                     private static final Insets PADDING = new Insets(9, 9, 0, 9);
+                    private static final Insets LAST_PADDING = new Insets(9, 9, 9, 9);
 
                     private final RipplerContainer graphic;
                     private final StackPane wrapper = new StackPane();
@@ -584,6 +585,12 @@ public class DownloadListPage extends Control implements DecoratorPage, GameInst
                         if (empty || item == null) {
                             setGraphic(null);
                         } else {
+                            setPadding(
+                                getIndex() == getListView().getItems().size() - 1
+                                    ? LAST_PADDING
+                                    : PADDING
+                            );
+
                             ModTranslations.Mod mod = ModTranslations.getTranslationsByRepositoryType(getSkinnable().repository.getType()).getModByCurseForgeId(item.slug());
                             content.setTitle(mod != null && I18n.isUseChinese() ? mod.getDisplayName() : item.title());
                             String description = item.description();


### PR DESCRIPTION
# 修复 `ModDownloadListPage` 末尾项 `Padding`

- 在此之前，末尾项底部几乎贴边了。

## 对比
|更改前|更改后|
|---|---|
|<img width="1227" height="762" alt="1" src="https://github.com/user-attachments/assets/53e2b66b-1f2d-437e-b244-fe7b9b25c21e" />|<img width="1227" height="762" alt="2" src="https://github.com/user-attachments/assets/a269b7b1-ded9-4ce1-98f5-ad3a579d59a1" />|