### PR TITLE
Fix: 修复 macOS 下主题模式「跟随系统设置」失效

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/theme/Themes.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/theme/Themes.java
@@ -466,6 +466,16 @@ public final class Themes {
 
     /// Returns the brightness requested by the current system or platform settings.
     private static Brightness getAutomaticBrightness() {
+        // On macOS the launcher pins the application appearance (see #applyNativeDarkMode), and JavaFX derives its
+        // color scheme from NSApp.effectiveAppearance. Reading FXUtils.DARK_MODE here would therefore read back the
+        // brightness this launcher itself applied, so the system setting is read directly instead.
+        if (OperatingSystem.CURRENT_OS == OperatingSystem.MACOS && MacOSNativeUtils.isSupported()) {
+            @Nullable Boolean systemDarkMode = MacOSNativeUtils.isSystemInDarkMode();
+            if (systemDarkMode != null) {
+                return systemDarkMode ? Brightness.DARK : Brightness.LIGHT;
+            }
+        }
+
         if (FXUtils.DARK_MODE != null) {
             return FXUtils.DARK_MODE.get() ? Brightness.DARK : Brightness.LIGHT;
         }
@@ -1151,10 +1161,29 @@ public final class Themes {
                 });
             }
         } else if (OperatingSystem.CURRENT_OS == OperatingSystem.MACOS && MacOSNativeUtils.isSupported()) {
-            MacOSNativeUtils.setAppearance(darkModeProperty().get());
+            applyMacOSAppearance(darkModeProperty().get());
 
-            ChangeListener<Boolean> listener = FXUtils.onWeakChange(Themes.darkModeProperty(), MacOSNativeUtils::setAppearance);
+            ChangeListener<Boolean> listener = FXUtils.onWeakChange(Themes.darkModeProperty(), Themes::applyMacOSAppearance);
             stage.getProperties().put("Themes.applyNativeDarkMode.listener", listener);
+        }
+    }
+
+    /// Applies the launcher brightness to the macOS application appearance.
+    ///
+    /// Setting an explicit appearance is what makes native windows owned by the application - notably the file
+    /// chooser - follow the launcher brightness instead of the system one. It has a cost: while an appearance is
+    /// pinned, `NSApp.effectiveAppearance` no longer reports the system appearance, so JavaFX stops reporting
+    /// system color scheme changes.
+    ///
+    /// The appearance is therefore only pinned while the launcher brightness actually differs from the system
+    /// brightness. When they agree - which is the case whenever the brightness mode follows the system - the
+    /// appearance is cleared, so the system appearance is inherited and JavaFX keeps observing system changes.
+    private static void applyMacOSAppearance(boolean dark) {
+        @Nullable Boolean systemDarkMode = MacOSNativeUtils.isSystemInDarkMode();
+        if (systemDarkMode != null && systemDarkMode == dark) {
+            MacOSNativeUtils.clearAppearance();
+        } else {
+            MacOSNativeUtils.setAppearance(dark);
         }
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/MacOSNativeUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/MacOSNativeUtils.java
@@ -96,6 +96,63 @@ public final class MacOSNativeUtils {
         }
     }
 
+    /// Clears the explicit application appearance, so that the application inherits the system appearance again.
+    ///
+    /// While an explicit appearance is set, `NSApp.effectiveAppearance` reports that appearance rather than the
+    /// system one. JavaFX derives [javafx.application.Platform.Preferences#colorSchemeProperty()] from
+    /// `effectiveAppearance`, so leaving an appearance pinned makes the reported color scheme follow the launcher
+    /// instead of the system.
+    public static void clearAppearance() {
+        if (nsApp == null) return;
+
+        try {
+            var objc = ObjectiveCRuntime.INSTANCE;
+            // A null Pointer maps to Objective-C nil, which resets the appearance to inherited.
+            objc.objc_msgSend(nsApp, objc.sel_registerName("setAppearance:"), (Pointer) null);
+        } catch (Throwable t) {
+            LOG.warning("Failed to clear macOS appearance", t);
+        }
+    }
+
+    /// Reads whether the system is currently using dark mode, independently of the application appearance.
+    ///
+    /// This reads the `AppleInterfaceStyle` user default, which reflects the system setting and is unaffected by
+    /// [#setAppearance(boolean)]. It must not be derived from `effectiveAppearance` or from the JavaFX color
+    /// scheme, because both report the pinned application appearance once one has been set.
+    ///
+    /// @return whether the system is in dark mode, or `null` if it could not be determined
+    public static @Nullable Boolean isSystemInDarkMode() {
+        if (nsApp == null) return null;
+
+        try {
+            var objc = ObjectiveCRuntime.INSTANCE;
+
+            @Nullable Pointer userDefaults = objc.objc_getClass("NSUserDefaults");
+            if (isNull(userDefaults)) return null;
+
+            @Nullable Pointer defaults = objc.objc_msgSend(userDefaults, objc.sel_registerName("standardUserDefaults"));
+            if (isNull(defaults)) return null;
+
+            @Nullable Pointer nsString = objc.objc_getClass("NSString");
+            if (isNull(nsString)) return null;
+
+            @Nullable Pointer key = objc.objc_msgSend(nsString, objc.sel_registerName("stringWithUTF8String:"), "AppleInterfaceStyle");
+            if (isNull(key)) return null;
+
+            @Nullable Pointer value = objc.objc_msgSend(defaults, objc.sel_registerName("stringForKey:"), key);
+            // The key is absent in light mode.
+            if (isNull(value)) return Boolean.FALSE;
+
+            @Nullable Pointer utf8 = objc.objc_msgSend(value, objc.sel_registerName("UTF8String"));
+            if (isNull(utf8)) return null;
+
+            return "Dark".equalsIgnoreCase(utf8.getString(0));
+        } catch (Throwable t) {
+            LOG.warning("Failed to read macOS system appearance", t);
+            return null;
+        }
+    }
+
     private MacOSNativeUtils() {
     }
 }


### PR DESCRIPTION
Closes #6526

## 问题是什么

在 macOS 上，主题的「跟随系统设置」是坏的：

- 从「浅色」或「深色」切换到「跟随系统设置」，界面没有任何变化
- 就算一开始就设成「跟随系统设置」，之后去系统设置里切换明暗模式，HMCL 也不会跟着变

## 为什么会坏

说起来有点绕，但根子上是一个「自己读自己」的循环。

HMCL 想知道「系统现在是浅色还是深色」，读的是 JavaFX 提供的 `Platform.Preferences.colorScheme`。

而 JavaFX 这个值不是凭空来的，它是这么算出来的（`PlatformSupport.m` / `PreferenceProperties.java`）：

1. 对 `NSApp.effectiveAppearance` 注册 KVO 监听
2. 外观变化时，用当前外观去解析系统颜色（窗口背景色、文字色等）
3. 比较背景色和前景色的亮度，得出是深色还是浅色

问题就在这里：HMCL 自己会去改 `NSApp.effectiveAppearance`。

#5778 为了让文件选择器这类原生窗口的配色跟着启动器走，加了 `NSApplication setAppearance:` 调用。而 `setAppearance:` 改的正是 `effectiveAppearance` —— JavaFX 拿来算明暗的那个属性。

于是就成了这样：

```
HMCL 想知道系统是深还是浅
  └─ 读 JavaFX colorScheme
       └─ 它由 NSApp.effectiveAppearance 推导
            └─ 而这个值是 HMCL 自己刚写进去的
```

HMCL 读到的「系统外观」，其实是它自己设定的外观。系统真正是深还是浅，它再也看不见了。

`FXUtils.DARK_MODE` 同时承担了两个角色 —— 既是「值的来源」，又是「变化的通知源」。被污染的是前者，后者仍然正常。

## 怎么改的

**第一处：换一个不会被污染的信息源**

改成读 `AppleInterfaceStyle` 用户默认项。这个值只反映系统设置，`setAppearance:` 影响不到它。

`FXUtils.DARK_MODE` 作为「变化通知源」保留不动 —— 没有它就收不到变化通知。只是不再从它取值。这样重算时得到的是同一个值，`Objects.equals` 会短路掉，循环收敛。

**第二处：只在需要的时候才固定外观**

原来是无条件调用 `setAppearance:`。改成：

| 启动器明暗模式 | 处理 | 原因 |
|---|---|---|
| 与系统**一致** | 清除外观（传 nil） | 让应用重新继承系统外观，JavaFX 得以继续观察系统变化 |
| 与系统**不一致** | 固定外观 | 用户显式选了浅色/深色，本来就不该跟随系统 |

这一步是打破循环的关键。

有一个容易踩的坑：主题包可以通过 `resolveCurrentThemeBrightness` 覆盖明暗模式，也就是说**即使用户没有显式选择浅色/深色，启动器的实际明暗也可能与系统不同**。所以这里比较的是**已经解析出来的** `darkModeProperty()`，而不是「明暗模式设置项是否等于 auto」。如果按后者判断，主题包指定的外观会被错误地清除，文件选择器就会跟着系统而不是启动器走。

## #5778 的行为有没有丢

没有。用户显式选择浅色或深色时，外观照旧会被固定，文件选择器仍然跟启动器配色一致。

只有在「启动器明暗与系统本来就相同」时才清除 —— 那种情况下继承系统外观和固定外观的视觉结果是一样的，但前者保住了系统变化的通知。

## 影响范围

两个文件，只在 macOS 分支内：

- `MacOSNativeUtils.java` — 新增 `isSystemInDarkMode()` 读系统真实明暗、`clearAppearance()` 清除外观
- `Themes.java` — `getAutomaticBrightness()` 在 macOS 上改用系统真实值；新增 `applyMacOSAppearance()` 做上面那个判断

Windows 的检测路径（注册表 `AppsUseLightTheme` + `DWMWA_USE_IMMERSIVE_DARK_MODE`）和 Linux 的检测路径（`dbus-send` 查 xdg portal）都没有改动。

在 `-Dhmcl.native.backend=none` 下 `MacOSNativeUtils.isSupported()` 返回 false，会退回原有逻辑，不影响禁用 JNA 的场景。

## 测试

环境与 #6526 报告者一致：macOS 26.5.2 / Apple Silicon (arm64) / JDK 21.0.11。

用 JNA 直连 Objective-C 运行时，验证了四项行为：

```
system dark mode = true

[PASS] 启动器明暗与系统一致      appearance = nil（继承系统）
[PASS] 启动器明暗与系统不一致    appearance = NSAppearanceNameAqua
[PASS] 固定后切回一致            appearance = nil（继承系统）    ← #6526 的路径
[PASS] 固定期间读取系统明暗      isSystemInDarkMode() = true     ← 信息源独立性
```

最后一项是整个修复的前提 —— 确认外观被固定时，`AppleInterfaceStyle` 仍然返回系统真实值。

另外验证了 `setAppearance:` 传 nil 确实能把 `NSApp.appearance` 恢复成继承状态：

```
                     appearance
初始                 nil
固定为 Aqua          NSAppearanceNameAqua
固定为 DarkAqua      NSAppearanceNameDarkAqua
传 nil               nil          ← 恢复继承
```

构建与检查：

- `./gradlew :HMCL:compileJava` 通过
- `./gradlew checkstyle checkTranslations` 通过（与 Check Codes 工作流一致）

另外说明一下，`./gradlew test` 在我的 macOS 机器上有一个失败项 `GameDirectoriesTest.newIsolatedInstallingInstanceUsesVersionRootBeforeVersionExists`，与本 PR 无关 —— 我在未修改的 c8929c8 上复跑过，同样失败。那是一个独立的问题，我会另开 issue 说明。

## 尚未验证的部分

上面的验证覆盖了 Objective-C 层的行为和构建检查，但**我没有在完整 GUI 中做端到端点击验证**（在启动器里切换「跟随系统设置」、再去系统设置里切换明暗模式，观察界面实际跟随）。JavaFX 绑定链在真实事件循环下的收敛我只做了代码层面的推导。如果需要，我可以补上这部分验证结果。
