### PR TITLE
Fix/兼容从hmcl旧版本安装的整合包升级

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLModpackInstallTask.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLModpackInstallTask.java
@@ -17,7 +17,6 @@
  */
 package org.jackhuang.hmcl.game;
 
-import com.google.gson.JsonParseException;
 import org.jackhuang.hmcl.download.DefaultDependencyManager;
 import org.jackhuang.hmcl.download.LibraryAnalyzer;
 import org.jackhuang.hmcl.modpack.MinecraftInstanceTask;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLModpackInstallTask.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLModpackInstallTask.java
@@ -67,7 +67,7 @@ public final class HMCLModpackInstallTask extends Task<Void> {
             if (Files.exists(json)) {
                 config = JsonUtils.fromJsonFile(json, ModpackConfiguration.typeOf(Modpack.class));
 
-                if (!HMCLModpackProvider.INSTANCE.getName().equals(config.getType()))
+                if (config.getType() != null && !HMCLModpackProvider.INSTANCE.getName().equals(config.getType()))
                     throw new IllegalArgumentException("Instance " + instanceId + " is not a HMCL modpack. Cannot update this instance.");
             }
         } catch (JsonParseException | IOException ignore) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLModpackInstallTask.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLModpackInstallTask.java
@@ -62,15 +62,15 @@ public final class HMCLModpackInstallTask extends Task<Void> {
             if (event.isFailed()) repository.removeInstanceFromDisk(this.instanceId);
         });
 
-        ModpackConfiguration<Modpack> config = null;
+        ModpackConfiguration<?> config = null;
         try {
             if (Files.exists(json)) {
-                config = JsonUtils.fromJsonFile(json, ModpackConfiguration.typeOf(Modpack.class));
+                config = ModpackHelper.readModpackConfiguration(json);
 
                 if (config.getType() != null && !HMCLModpackProvider.INSTANCE.getName().equals(config.getType()))
                     throw new IllegalArgumentException("Instance " + instanceId + " is not a HMCL modpack. Cannot update this instance.");
             }
-        } catch (JsonParseException | IOException ignore) {
+        } catch (IOException ignore) {
         }
         dependents.add(new ModpackInstallTask<>(zipFile, run, modpack.getEncoding(), Collections.singletonList("/minecraft"), it -> !"pack.json".equals(it), config));
         dependents.add(new MinecraftInstanceTask<>(zipFile, modpack.getEncoding(), Collections.singletonList("/minecraft"), modpack, HMCLModpackProvider.INSTANCE, modpack.getName(), modpack.getVersion(), repository.getModpackConfiguration(this.instanceId)).withStage("hmcl.modpack"));

--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/ModpackHelper.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/ModpackHelper.java
@@ -236,13 +236,13 @@ public final class ModpackHelper {
     }
 
     public static Task<Void> getUpdateTask(HMCLGameRepository repository, ServerModpackManifest manifest, Charset charset, GameInstanceID instanceId, ModpackConfiguration<?> configuration) throws UnsupportedModpackException {
-        switch (configuration.getType()) {
-            case ServerModpackRemoteInstallTask.MODPACK_TYPE:
-                return new ModpackUpdateTask(repository, instanceId, new ServerModpackRemoteInstallTask(repository.getDependency(), manifest, instanceId))
-                        .thenComposeAsync(repository.refreshAsync())
-                        .withStagesHints(new Task.StagesHint("hmcl.modpack"), new Task.StagesHint("hmcl.modpack.download", List.of("hmcl.install.assets", "hmcl.install.libraries")));
-            default:
-                throw new UnsupportedModpackException();
+        String type = configuration.getType();
+        if (ServerModpackRemoteInstallTask.MODPACK_TYPE.equals(type)) {
+            return new ModpackUpdateTask(repository, instanceId, new ServerModpackRemoteInstallTask(repository.getDependency(), manifest, instanceId))
+                    .thenComposeAsync(repository.refreshAsync())
+                    .withStagesHints(new Task.StagesHint("hmcl.modpack"), new Task.StagesHint("hmcl.modpack.download", List.of("hmcl.install.assets", "hmcl.install.libraries")));
+        } else {
+            throw new UnsupportedModpackException();
         }
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/ModpackHelper.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/ModpackHelper.java
@@ -236,19 +236,23 @@ public final class ModpackHelper {
     }
 
     public static Task<Void> getUpdateTask(HMCLGameRepository repository, ServerModpackManifest manifest, Charset charset, GameInstanceID instanceId, ModpackConfiguration<?> configuration) throws UnsupportedModpackException {
-        switch (configuration.getType()) {
-            case ServerModpackRemoteInstallTask.MODPACK_TYPE:
-                return new ModpackUpdateTask(repository, instanceId, new ServerModpackRemoteInstallTask(repository.getDependency(), manifest, instanceId))
-                        .thenComposeAsync(repository.refreshAsync())
-                        .withStagesHints(new Task.StagesHint("hmcl.modpack"), new Task.StagesHint("hmcl.modpack.download", List.of("hmcl.install.assets", "hmcl.install.libraries")));
-            default:
-                throw new UnsupportedModpackException();
+        String type = configuration.getType();
+        if (type == null || ServerModpackRemoteInstallTask.MODPACK_TYPE.equals(type)) {
+            return new ModpackUpdateTask(repository, instanceId, new ServerModpackRemoteInstallTask(repository.getDependency(), manifest, instanceId))
+                    .thenComposeAsync(repository.refreshAsync())
+                    .withStagesHints(new Task.StagesHint("hmcl.modpack"), new Task.StagesHint("hmcl.modpack.download", List.of("hmcl.install.assets", "hmcl.install.libraries")));
+        } else {
+            throw new UnsupportedModpackException();
         }
     }
 
     public static Task<?> getUpdateTask(HMCLGameRepository repository, Path zipFile, Charset charset, GameInstanceID instanceId, ModpackConfiguration<?> configuration) throws UnsupportedModpackException, ManuallyCreatedModpackException, MismatchedModpackTypeException {
         Modpack modpack = ModpackHelper.readModpackManifest(zipFile, charset);
-        ModpackProvider provider = getProviderByType(configuration.getType());
+        String type = configuration.getType();
+        if (type == null) {
+            type = modpack.getManifest().getProvider().getName();
+        }
+        ModpackProvider provider = getProviderByType(type);
         if (provider == null) {
             throw new UnsupportedModpackException();
         }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/ModpackConfiguration.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/ModpackConfiguration.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @Immutable
 public final class ModpackConfiguration<T> implements Validation {
@@ -36,7 +37,7 @@ public final class ModpackConfiguration<T> implements Validation {
     }
 
     private final T manifest;
-    private final String type;
+    private final @Nullable String type;
     private final String name;
     private final String version;
     private final List<FileInformation> overrides;
@@ -45,7 +46,7 @@ public final class ModpackConfiguration<T> implements Validation {
         this(null, null, "", null, Collections.emptyList());
     }
 
-    public ModpackConfiguration(T manifest, String type, String name, String version, List<FileInformation> overrides) {
+    public ModpackConfiguration(T manifest, @Nullable String type, String name, String version, List<FileInformation> overrides) {
         this.manifest = manifest;
         this.type = type;
         this.name = name;
@@ -57,8 +58,35 @@ public final class ModpackConfiguration<T> implements Validation {
         return manifest;
     }
 
+    @Nullable
     public String getType() {
-        return type;
+        if (type != null) {
+            return type;
+        }
+        if (manifest instanceof ModpackManifest modpackManifest) {
+            return modpackManifest.getProvider().getName();
+        }
+        if (manifest instanceof Modpack modpack && modpack.getManifest() != null) {
+            return modpack.getManifest().getProvider().getName();
+        }
+        if (manifest instanceof Map<?, ?> map) {
+            if (map.containsKey("instanceType") || map.containsKey("components") || map.containsKey("mmcPack")) {
+                return "MultiMC";
+            }
+            if (map.containsKey("formatVersion") && map.containsKey("game")) {
+                return "Modrinth";
+            }
+            if (map.containsKey("files") && map.containsKey("minecraft")) {
+                return "Curse";
+            }
+            if (map.containsKey("fileApi") && !map.containsKey("manifestType")) {
+                return "Server";
+            }
+            if (map.containsKey("addons") || map.containsKey("manifestType")) {
+                return "Mcbbs";
+            }
+        }
+        return null;
     }
 
     public String getName() {
@@ -90,8 +118,6 @@ public final class ModpackConfiguration<T> implements Validation {
     public void validate() throws JsonParseException {
         if (manifest == null)
             throw new JsonParseException("MinecraftInstanceConfiguration missing `manifest`");
-        if (type == null)
-            throw new JsonParseException("MinecraftInstanceConfiguration missing `type`");
     }
 
     @Immutable

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/ModpackConfiguration.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/ModpackConfiguration.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @Immutable
 public final class ModpackConfiguration<T> implements Validation {
@@ -36,7 +37,7 @@ public final class ModpackConfiguration<T> implements Validation {
     }
 
     private final T manifest;
-    private final String type;
+    private final @Nullable String type;
     private final String name;
     private final String version;
     private final List<FileInformation> overrides;
@@ -45,7 +46,7 @@ public final class ModpackConfiguration<T> implements Validation {
         this(null, null, "", null, Collections.emptyList());
     }
 
-    public ModpackConfiguration(T manifest, String type, String name, String version, List<FileInformation> overrides) {
+    public ModpackConfiguration(T manifest, @Nullable String type, String name, String version, List<FileInformation> overrides) {
         this.manifest = manifest;
         this.type = type;
         this.name = name;
@@ -57,8 +58,41 @@ public final class ModpackConfiguration<T> implements Validation {
         return manifest;
     }
 
+    @Nullable
     public String getType() {
-        return type;
+        if (type != null) {
+            return type;
+        }
+        if (manifest instanceof ModpackManifest modpackManifest) {
+            return modpackManifest.getProvider().getName();
+        }
+        if (manifest instanceof Modpack modpack) {
+            if (modpack.getManifest() != null) {
+                return modpack.getManifest().getProvider().getName();
+            }
+            return "HMCL";
+        }
+        if (manifest instanceof Map<?, ?> map) {
+            if (map.containsKey("instanceType") || map.containsKey("components") || map.containsKey("mmcPack")) {
+                return "MultiMC";
+            }
+            if (map.containsKey("formatVersion") && map.containsKey("game")) {
+                return "Modrinth";
+            }
+            if (map.containsKey("files") && map.containsKey("minecraft")) {
+                return "Curse";
+            }
+            if (map.containsKey("fileApi") && !map.containsKey("manifestType")) {
+                return "Server";
+            }
+            if (map.containsKey("addons") || map.containsKey("manifestType")) {
+                return "Mcbbs";
+            }
+            if (map.containsKey("manifest") || map.containsKey("gameVersion") || map.containsKey("description")) {
+                return "HMCL";
+            }
+        }
+        return null;
     }
 
     public String getName() {
@@ -90,8 +124,6 @@ public final class ModpackConfiguration<T> implements Validation {
     public void validate() throws JsonParseException {
         if (manifest == null)
             throw new JsonParseException("MinecraftInstanceConfiguration missing `manifest`");
-        if (type == null)
-            throw new JsonParseException("MinecraftInstanceConfiguration missing `type`");
     }
 
     @Immutable

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/curse/CurseInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/curse/CurseInstallTask.java
@@ -109,8 +109,8 @@ public final class CurseInstallTask extends Task<Void> {
             if (Files.exists(json)) {
                 config = JsonUtils.fromJsonFile(json, ModpackConfiguration.typeOf(CurseManifest.class));
 
-                if (!CurseModpackProvider.INSTANCE.getName().equals(config.getType()))
-                    throw new IllegalArgumentException("Instance " + instanceId + " is not a Curse modpack. Cannot update this instance.");
+                if (config.getType() != null && !CurseModpackProvider.INSTANCE.getName().equals(config.getType()))
+                    throw new IllegalArgumentException("Instance " + instanceId + " is not a CurseForge modpack. Cannot update this instance.");
             }
         } catch (JsonParseException | IOException ignore) {
         }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/mcbbs/McbbsModpackLocalInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/mcbbs/McbbsModpackLocalInstallTask.java
@@ -83,8 +83,8 @@ public final class McbbsModpackLocalInstallTask extends Task<Void> {
             if (Files.exists(json)) {
                 config = JsonUtils.fromJsonFile(json, ModpackConfiguration.typeOf(McbbsModpackManifest.class));
 
-                if (!McbbsModpackProvider.INSTANCE.getName().equals(config.getType()))
-                    throw new IllegalArgumentException("Instance " + instanceId + " is not a Mcbbs modpack. Cannot update this instance.");
+                if (config.getType() != null && !McbbsModpackProvider.INSTANCE.getName().equals(config.getType()))
+                    throw new IllegalArgumentException("Instance " + instanceId + " is not a MCBBS modpack. Cannot update this instance.");
             }
         } catch (JsonParseException | IOException ignore) {
         }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/mcbbs/McbbsModpackRemoteInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/mcbbs/McbbsModpackRemoteInstallTask.java
@@ -68,8 +68,8 @@ public class McbbsModpackRemoteInstallTask extends Task<Void> {
             if (Files.exists(json)) {
                 config = JsonUtils.fromJsonFile(json, ModpackConfiguration.typeOf(McbbsModpackManifest.class));
 
-                if (!MODPACK_TYPE.equals(config.getType()))
-                    throw new IllegalArgumentException("Instance " + instanceId + " is not a Mcbbs modpack. Cannot update this instance.");
+                if (config.getType() != null && !McbbsModpackProvider.INSTANCE.getName().equals(config.getType()))
+                    throw new IllegalArgumentException("Instance " + instanceId + " is not a MCBBS modpack. Cannot update this instance.");
             }
         } catch (JsonParseException | IOException ignore) {
         }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/mcbbs/McbbsModpackRemoteInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/mcbbs/McbbsModpackRemoteInstallTask.java
@@ -68,7 +68,7 @@ public class McbbsModpackRemoteInstallTask extends Task<Void> {
             if (Files.exists(json)) {
                 config = JsonUtils.fromJsonFile(json, ModpackConfiguration.typeOf(McbbsModpackManifest.class));
 
-                if (!MODPACK_TYPE.equals(config.getType()))
+                if (config.getType() != null && !MODPACK_TYPE.equals(config.getType()))
                     throw new IllegalArgumentException("Instance " + instanceId + " is not a Mcbbs modpack. Cannot update this instance.");
             }
         } catch (JsonParseException | IOException ignore) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/modrinth/ModrinthInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/modrinth/ModrinthInstallTask.java
@@ -107,7 +107,7 @@ public class ModrinthInstallTask extends Task<Void> {
             if (Files.exists(json)) {
                 config = JsonUtils.fromJsonFile(json, ModpackConfiguration.typeOf(ModrinthManifest.class));
 
-                if (!ModrinthModpackProvider.INSTANCE.getName().equals(config.getType()))
+                if (config.getType() != null && !ModrinthModpackProvider.INSTANCE.getName().equals(config.getType()))
                     throw new IllegalArgumentException("Instance " + instanceId + " is not a Modrinth modpack. Cannot update this instance.");
             }
         } catch (JsonParseException | IOException ignore) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/multimc/MultiMCModpackInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/multimc/MultiMCModpackInstallTask.java
@@ -117,7 +117,7 @@ public final class MultiMCModpackInstallTask extends Task<MultiMCInstancePatch.R
                 if (Files.exists(json)) {
                     config = JsonUtils.fromJsonFile(json, ModpackConfiguration.typeOf(MultiMCInstanceConfiguration.class));
 
-                    if (!MultiMCModpackProvider.INSTANCE.getName().equals(config.getType()))
+                    if (config.getType() != null && !MultiMCModpackProvider.INSTANCE.getName().equals(config.getType()))
                         throw new IllegalArgumentException("Instance " + instanceId + " is not a MultiMC modpack. Cannot update this instance.");
                 }
             } catch (JsonParseException | IOException ignore) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/server/ServerModpackLocalInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/server/ServerModpackLocalInstallTask.java
@@ -74,7 +74,7 @@ public class ServerModpackLocalInstallTask extends Task<Void> {
             if (Files.exists(json)) {
                 config = JsonUtils.fromJsonFile(json, ModpackConfiguration.typeOf(ServerModpackManifest.class));
 
-                if (!ServerModpackProvider.INSTANCE.getName().equals(config.getType()))
+                if (config.getType() != null && !ServerModpackProvider.INSTANCE.getName().equals(config.getType()))
                     throw new IllegalArgumentException("Instance " + instanceId + " is not a Server modpack. Cannot update this instance.");
             }
         } catch (JsonParseException | IOException ignore) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/server/ServerModpackRemoteInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/server/ServerModpackRemoteInstallTask.java
@@ -68,7 +68,7 @@ public class ServerModpackRemoteInstallTask extends Task<Void> {
             if (Files.exists(json)) {
                 config = JsonUtils.fromJsonFile(json, ModpackConfiguration.typeOf(ServerModpackManifest.class));
 
-                if (!MODPACK_TYPE.equals(config.getType()))
+                if (config.getType() != null && !MODPACK_TYPE.equals(config.getType()))
                     throw new IllegalArgumentException("Instance " + instanceId + " is not a Server modpack. Cannot update this instance.");
             }
         } catch (JsonParseException | IOException ignore) {


### PR DESCRIPTION
### 概述

修复了由于旧版本 HMCL 或第三方工具导出的整合包配置文件 `modpack.cfg` 中缺失 `type` 字段，导致在最新版本 HMCL 中更新整合包时抛出 `IllegalArgumentException` 或 `JsonParseException` 并中断更新的问题。

---

### 根本原因

1. **JSON 反序列化校验限制**：先前 `ModpackConfiguration.validate()` 强制要求 `type` 字段不能为 `null`。在解析缺乏 `"type"` 键的旧版 `modpack.cfg` 时，校验失败导致反序列化抛出异常并落空。
2. **未判空的类型断言拦截**：`CurseInstallTask` 及其他整合包安装任务在比对提供商类型时没有检查 `type` 是否为 `null`。在旧配置中 `type` 为 `null` 时，`!"Curse".equals(null)` 被计算为 `true`，从而误判并抛出 `IllegalArgumentException`（“Instance is not a CurseForge modpack. Cannot update this instance.”）。

---

### 主要修改

1. **放宽 `ModpackConfiguration.validate()`**：移除了 `ModpackConfiguration.validate()` 中对 `type == null` 的强行抛错限制，允许旧版本整合包配置成功反序列化。
2. **安全的提供商类型校验**：在所有整合包 installer 任务（包括 `CurseInstallTask`、`ModrinthInstallTask`、`McbbsModpackLocalInstallTask`、`McbbsModpackRemoteInstallTask`、`MultiMCModpackInstallTask`、`ServerModpackLocalInstallTask`、`ServerModpackRemoteInstallTask`）中增加了 `config.getType() != null` 的前置检查。只有当 `type` 存在且明确与当前提供商不匹配时才抛出异常拦截；老整合包（`type == null`）将顺畅放行并在更新完成后自动写回包含 `type` 的规范新配置。

