### PR TITLE
Fix: 删除实例过程中修改实例设置导致实例目录残留文件

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java
@@ -67,6 +67,7 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -109,6 +110,8 @@ public final class HMCLGameRepository extends DefaultGameRepository {
     private final Set<GameInstanceID> loadedInstanceGameSettings = new HashSet<>();
     private final Set<GameInstanceID> readOnlyInstanceGameSettings = new HashSet<>();
     private final Set<GameInstanceID> beingModpackInstances = new HashSet<>();
+    /// Instance IDs whose instance game settings must not be written back to disk
+    private final Set<GameInstanceID> beingRemovedInstances = ConcurrentHashMap.newKeySet();
 
     public final EventManager<Event> onInstanceIconChanged = new EventManager<>();
 
@@ -243,17 +246,43 @@ public final class HMCLGameRepository extends DefaultGameRepository {
         clean(getRunDirectory(instanceId));
     }
 
+    /// Marks the instance as being removed so that instance game settings changes
+    /// are not written back to disk
+    public void markInstanceBeingRemoved(GameInstanceID instanceId) {
+        beingRemovedInstances.add(instanceId);
+    }
+
+    /// Unmarks the instance so that instance game settings can be saved again,
+    /// e.g. when the removal failed.
+    public void unmarkInstanceBeingRemoved(GameInstanceID instanceId) {
+        beingRemovedInstances.remove(instanceId);
+    }
+
     /// Removes an instance from disk and clears its cached HMCL settings state.
     @Override
     public boolean removeInstanceFromDisk(GameInstanceID instanceId) {
-        boolean removed = super.removeInstanceFromDisk(instanceId);
-        if (removed) {
-            instanceGameSettings.remove(instanceId);
-            loadedInstanceGameSettings.remove(instanceId);
-            readOnlyInstanceGameSettings.remove(instanceId);
-            beingModpackInstances.remove(instanceId);
+        beingRemovedInstances.add(instanceId);
+        try {
+            // Flush settings saves that were enqueued before the removal started, so that they
+            // cannot recreate the instance directory after it has been moved
+            try {
+                FileSaver.waitForAllSaves();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                LOG.warning("Interrupted while waiting for pending file saves", e);
+            }
+
+            boolean removed = super.removeInstanceFromDisk(instanceId);
+            if (removed) {
+                instanceGameSettings.remove(instanceId);
+                loadedInstanceGameSettings.remove(instanceId);
+                readOnlyInstanceGameSettings.remove(instanceId);
+                beingModpackInstances.remove(instanceId);
+            }
+            return removed;
+        } finally {
+            beingRemovedInstances.remove(instanceId);
         }
-        return removed;
     }
 
     public void duplicateInstance(GameInstanceID srcId, GameInstanceID dstId, boolean copySaves) throws IOException {
@@ -680,7 +709,9 @@ public final class HMCLGameRepository extends DefaultGameRepository {
     }
 
     public void saveGameSettings(GameInstanceID instanceId) {
-        if (!instanceGameSettings.containsKey(instanceId) || readOnlyInstanceGameSettings.contains(instanceId))
+        if (beingRemovedInstances.contains(instanceId)
+                || !instanceGameSettings.containsKey(instanceId)
+                || readOnlyInstanceGameSettings.contains(instanceId))
             return;
         GameSettings.Instance setting = instanceGameSettings.get(instanceId);
         if (setting == null) {
@@ -705,7 +736,9 @@ public final class HMCLGameRepository extends DefaultGameRepository {
     /// @param instanceId the instance ID
     /// @throws IOException if saving the file fails
     private void saveGameSettingsSync(GameInstanceID instanceId) throws IOException {
-        if (!instanceGameSettings.containsKey(instanceId) || readOnlyInstanceGameSettings.contains(instanceId)) {
+        if (beingRemovedInstances.contains(instanceId)
+                || !instanceGameSettings.containsKey(instanceId)
+                || readOnlyInstanceGameSettings.contains(instanceId)) {
             return;
         }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/instances/Instances.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/instances/Instances.java
@@ -128,8 +128,13 @@ public final class Instances {
         JFXButton deleteButton = new JFXButton(i18n("button.delete"));
         deleteButton.getStyleClass().add("dialog-error");
         deleteButton.setOnAction(e -> {
+            // Block instance game settings from being written back to disk while the deletion
+            // task is running, otherwise a settings change during the deletion may recreate
+            // the instance directory after it has been moved to the trash
+            repository.markInstanceBeingRemoved(instanceId);
             Task.supplyAsync(Schedulers.io(), () -> repository.removeInstanceFromDisk(instanceId))
                     .whenComplete(Schedulers.javafx(), (result, exception) -> {
+                        repository.unmarkInstanceBeingRemoved(instanceId);
                         if (exception != null || !Boolean.TRUE.equals(result)) {
                             Controllers.dialog(i18n("instance.manage.remove.failed"), i18n("message.error"), MessageDialogPane.MessageType.ERROR);
                         }


### PR DESCRIPTION
## 问题：
在任意实例的实例管理页面点击`删除实例->删除`、且删除任务未完成时，修改某一项实例配置，会导致版本文件夹中出现该实例的残留配置文件（如图）
<img width="1315" height="445" alt="b36407229a16a26e4a2bac135c1ce5a1" src="https://github.com/user-attachments/assets/bce95347-23ed-4c75-9797-549dacab848b" />

## 复现方法：
（最好将用于测试的`.minecraft`文件夹放在机械硬盘或者响应速度较慢的老旧SATA固态硬盘中）
打开某个实例的实例管理界面，点击`删除实例->删除`后迅速点击“版本隔离”的开关（不一定非得是这个，只是比较容易）
然后到实例文件夹就可以看到残留的文件和文件夹了。
由于我的电脑性能不算很差，因此窗口期很短，但如果电脑性能较差，那么非常可能因为误触导致文件残留。

## 修复措施：
删除实例时将实例ID添加到一个即将被删除的实例的名单中，保存游戏设置的时候会检查当前更改配置的实例是否处于这个名单中，如果是，那么就不将配置写入磁盘。

## 其他问题：
测试的时候发现：
如果电脑配置很差或者系统卡顿的时候，点击`删除实例->删除`后在页面没有跳转时，点击`修改游戏图标->（随便选一个其他的图标）->确定`会引发HMCL崩溃。
<img width="916" height="249" alt="image" src="https://github.com/user-attachments/assets/c3976439-99e8-401e-afde-c9866b6214fe" />
<img width="1194" height="754" alt="image" src="https://github.com/user-attachments/assets/54d00eaf-7c2f-4387-9592-48edd4dd854a" />
<details>
  <summary>完整报错信息</summary>

---- Hello Minecraft! Crash Report ----
  Version: 3.17.SNAPSHOT
  Time: 2026-08-04 13:33:22
  Thread: Thread[#44,JavaFX Application Thread,5,main]

  Content: 
    org.jackhuang.hmcl.game.NoSuchGameInstanceException: 26.2
	at org.jackhuang.hmcl.game.DefaultGameRepository.getResolvedInstanceManifest(DefaultGameRepository.java:284)
	at org.jackhuang.hmcl.game.HMCLGameRepository.getInstanceIconImage(HMCLGameRepository.java:665)
	at org.jackhuang.hmcl.ui.game.GameSettingsPage.loadIcon(GameSettingsPage.java:2728)
	at org.jackhuang.hmcl.ui.instances.GameInstanceIconDialog.onAccept(GameInstanceIconDialog.java:123)
	at org.jackhuang.hmcl.ui.construct.DialogPane.lambda$new$0(DialogPane.java:55)
	at javafx.base@25/com.sun.javafx.event.CompositeEventHandler.dispatchBubblingEvent(CompositeEventHandler.java:86)
	at javafx.base@25/com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:232)
	at javafx.base@25/com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:189)
	at javafx.base@25/com.sun.javafx.event.CompositeEventDispatcher.dispatchBubblingEvent(CompositeEventDispatcher.java:59)
	at javafx.base@25/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:58)
	at javafx.base@25/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base@25/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base@25/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base@25/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base@25/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base@25/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base@25/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base@25/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base@25/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base@25/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base@25/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base@25/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base@25/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base@25/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base@25/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base@25/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base@25/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base@25/com.sun.javafx.event.EventUtil.fireEventImpl(EventUtil.java:74)
	at javafx.base@25/com.sun.javafx.event.EventUtil.fireEvent(EventUtil.java:49)
	at javafx.base@25/javafx.event.Event.fireEvent(Event.java:199)
	at javafx.graphics@25/javafx.scene.Node.fireEvent(Node.java:9026)
	at javafx.controls@25/javafx.scene.control.Button.fire(Button.java:203)
	at javafx.controls@25/com.sun.javafx.scene.control.behavior.ButtonBehavior.mouseReleased(ButtonBehavior.java:207)
	at javafx.controls@25/com.sun.javafx.scene.control.inputmap.InputMap.handle(InputMap.java:274)
	at javafx.base@25/com.sun.javafx.event.CompositeEventHandler$NormalEventHandlerRecord.handleBubblingEvent(CompositeEventHandler.java:247)
	at javafx.base@25/com.sun.javafx.event.CompositeEventHandler.dispatchBubblingEvent(CompositeEventHandler.java:80)
	at javafx.base@25/com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:232)
	at javafx.base@25/com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:189)
	at javafx.base@25/com.sun.javafx.event.CompositeEventDispatcher.dispatchBubblingEvent(CompositeEventDispatcher.java:59)
	at javafx.base@25/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:58)
	at javafx.base@25/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base@25/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base@25/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base@25/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base@25/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base@25/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base@25/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base@25/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base@25/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base@25/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base@25/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base@25/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base@25/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base@25/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base@25/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base@25/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base@25/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base@25/com.sun.javafx.event.EventUtil.fireEventImpl(EventUtil.java:74)
	at javafx.base@25/com.sun.javafx.event.EventUtil.fireEvent(EventUtil.java:54)
	at javafx.base@25/javafx.event.Event.fireEvent(Event.java:199)
	at javafx.graphics@25/javafx.scene.Scene$MouseHandler.process(Scene.java:4061)
	at javafx.graphics@25/javafx.scene.Scene.processMouseEvent(Scene.java:1947)
	at javafx.graphics@25/javafx.scene.Scene$ScenePeerListener.mouseEvent(Scene.java:2784)
	at javafx.graphics@25/com.sun.javafx.tk.quantum.GlassViewEventHandler$MouseEventNotification.get(GlassViewEventHandler.java:353)
	at javafx.graphics@25/com.sun.javafx.tk.quantum.GlassViewEventHandler$MouseEventNotification.get(GlassViewEventHandler.java:255)
	at javafx.graphics@25/com.sun.javafx.tk.quantum.QuantumToolkit.runWithoutRenderLock(QuantumToolkit.java:424)
	at javafx.graphics@25/com.sun.javafx.tk.quantum.GlassViewEventHandler.handleMouseEvent(GlassViewEventHandler.java:387)
	at javafx.graphics@25/com.sun.glass.ui.View.handleMouseEvent(View.java:573)
	at javafx.graphics@25/com.sun.glass.ui.View.notifyMouse(View.java:975)
	at javafx.graphics@25/com.sun.glass.ui.win.WinApplication._runLoop(Native Method)
	at javafx.graphics@25/com.sun.glass.ui.win.WinApplication.lambda$runLoop$0(WinApplication.java:168)
	at java.base/java.lang.Thread.run(Thread.java:1474)


-- System Details --
  Operating System: Windows 11 25H2 10.0.26200.8875
  System Architecture: x86-64
  Java Architecture: x86-64
  Java Version: 25.0.4, Azul Systems, Inc.
  Java VM Version: OpenJDK 64-Bit Server VM (mixed mode, sharing), Azul Systems, Inc.
  JVM Max Memory: 1073741824
  JVM Total Memory: 110100480
  JVM Free Memory: 12749856


</details>
额不过不在这次修复范围内而且我也不会修，嗯。