### PR TITLE
fix(launch): fix no-sound when natives directory path contains non-ASCII characters

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
@@ -556,7 +556,15 @@ public class DefaultLauncher extends Launcher {
     /// Returns the native library directory selected by the launch options.
     private Path getNativeFolder() {
         if (StringUtils.isBlank(options.getNativesDir())) {
-            return repository.getNativeDirectory(manifest.id(), options.getJava().getPlatform());
+            Path defaultPath = repository.getNativeDirectory(manifest.id(), options.getJava().getPlatform());
+            // JDK 17+ uses the ANSI-native LoadLibraryA internally,
+            // which cannot resolve native libraries from non-ASCII paths.
+            // Use a temp directory with ASCII-only path as a workaround.
+            if (!StringUtils.isASCII(defaultPath.toString())) {
+                return Paths.get(System.getProperty("java.io.tmpdir"),
+                        "hmcl-natives-" + Math.abs(manifest.id().id().hashCode()) + "-" + options.getJava().getPlatform());
+            }
+            return defaultPath;
         }
 
         return Path.of(options.getNativesDir());


### PR DESCRIPTION
When the instance folder name contains non-ASCII characters (e.g. Chinese),
the java.library.path is set to a path with those characters. JDK 17+ uses
the ANSI-native API (LoadLibraryA) internally to resolve native libraries,
which cannot handle non-ASCII paths — native libraries such as OpenAL32.dll
fail to load, resulting in games launching with video but no audio.

This is triggered when running 1.6.4 with FishModLoader, which depends on
LWJGL 2.9.4, under JDK 17 with a Chinese-character instance folder name.

Redirect getNativeFolder() to an ASCII-only temp path under java.io.tmpdir
when the default path contains non-ASCII characters. This is the Windows
equivalent of the existing Linux/macOS symlink workaround introduced in #1141.

Fixes #1141 for Windows.