### PR TITLE
fix: 修复展开状态下再次点击切换实例按钮时重新展开的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/MainPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/MainPage.java
@@ -104,6 +104,7 @@ public final class MainPage extends StackPane implements DecoratorPage {
     private TransitionPane announcementPane;
     private final StackPane updatePane;
     private final JFXButton menuButton;
+    private long lastHideTime = 0;
 
     private RemoteVersion lastShownVersion;
 
@@ -259,6 +260,10 @@ public final class MainPage extends StackPane implements DecoratorPage {
             menuButton = new JFXButton();
             menuButton.getStyleClass().add("menu-button");
             menuButton.setOnAction(e -> {
+                if(System.currentTimeMillis() - lastHideTime < 200) {
+                    return;
+                }
+
                 JFXPopup popup = GameListPopupMenu.showAndGetPopup(
                         menuButton,
                         JFXPopup.PopupVPosition.BOTTOM,
@@ -277,13 +282,19 @@ public final class MainPage extends StackPane implements DecoratorPage {
                         FXUtils.playAnimation(graphic, "arrow-rotation", rotateOpen);
 
                         popup.setOnHidden(windowEvent -> {
+                            lastHideTime = System.currentTimeMillis();
+                            System.out.println(lastHideTime);
                             RotateTransition rotateClose = new RotateTransition(duration, graphic);
                             rotateClose.setToAngle(0);
                             FXUtils.playAnimation(graphic, "arrow-rotation", rotateClose);
                         });
                     } else {
                         graphic.setRotate(-180);
-                        popup.setOnHidden(windowEvent -> graphic.setRotate(0));
+                        popup.setOnHidden(windowEvent -> {
+                            lastHideTime = System.currentTimeMillis();
+                            System.out.println(lastHideTime);
+                            graphic.setRotate(0);
+                        });
                     }
                 }
             });

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/MainPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/MainPage.java
@@ -283,7 +283,6 @@ public final class MainPage extends StackPane implements DecoratorPage {
 
                         popup.setOnHidden(windowEvent -> {
                             lastHideTime = System.currentTimeMillis();
-                            System.out.println(lastHideTime);
                             RotateTransition rotateClose = new RotateTransition(duration, graphic);
                             rotateClose.setToAngle(0);
                             FXUtils.playAnimation(graphic, "arrow-rotation", rotateClose);
@@ -292,7 +291,6 @@ public final class MainPage extends StackPane implements DecoratorPage {
                         graphic.setRotate(-180);
                         popup.setOnHidden(windowEvent -> {
                             lastHideTime = System.currentTimeMillis();
-                            System.out.println(lastHideTime);
                             graphic.setRotate(0);
                         });
                     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/MainPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/MainPage.java
@@ -260,7 +260,7 @@ public final class MainPage extends StackPane implements DecoratorPage {
             menuButton = new JFXButton();
             menuButton.getStyleClass().add("menu-button");
             menuButton.setOnAction(e -> {
-                if(System.currentTimeMillis() - lastHideTime < 200) {
+                if (System.currentTimeMillis() - lastHideTime < 200) {
                     return;
                 }
 


### PR DESCRIPTION
### 修复内容
修复了主界面在实例选择列表已展开时，再次点击切换按钮不会收起列表而是重新展开的问题。

### 修复思路
在 `MainPage` 中记录 JFXPopup 关闭的时间戳，在 `menuButton` 点击事件中加入防抖判断，避免 Auto-Hide 触发后紧接着又重新展开列表