### PR TITLE
解决导出 MCBBS 整合包因文件过多导致的 Out Of Memory

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/mcbbs/McbbsModpackExportTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/mcbbs/McbbsModpackExportTask.java
@@ -35,6 +35,9 @@ import org.jackhuang.hmcl.util.io.Zipper;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -67,6 +70,9 @@ public class McbbsModpackExportTask extends Task<Void> {
         });
     }
 
+    /// Exports the selected game files and manifests to the target archive.
+    ///
+    /// @throws Exception if the instance cannot be analyzed or the archive cannot be written
     @Override
     public void execute() throws Exception {
         ArrayList<String> blackList = new ArrayList<>(ModAdviser.MODPACK_BLACK_LIST);
@@ -123,7 +129,9 @@ public class McbbsModpackExportTask extends Task<Void> {
             McbbsModpackManifest.LaunchInfo launchInfo = new McbbsModpackManifest.LaunchInfo(info.getMinMemory(), info.getSupportedJavaVersions(), StringUtils.tokenize(info.getLaunchArguments()), StringUtils.tokenize(info.getJavaArguments()));
 
             McbbsModpackManifest mcbbsManifest = new McbbsModpackManifest(McbbsModpackManifest.MANIFEST_TYPE, 2, info.getName(), info.getVersion(), info.getAuthor(), info.getDescription(), info.getFileApi() == null ? null : StringUtils.removeSuffix(info.getFileApi(), "/"), info.getUrl(), info.isForceUpdate(), origins, addons, libraries, files, settings, launchInfo);
-            zip.putTextFile(JsonUtils.GSON.toJson(mcbbsManifest), "mcbbs.packmeta");
+            try (Writer writer = new OutputStreamWriter(zip.putStream("mcbbs.packmeta"), StandardCharsets.UTF_8)) {
+                JsonUtils.GSON.toJson(mcbbsManifest, writer);
+            }
 
             // CurseForge manifest
             List<CurseManifestModLoader> modLoaders = new ArrayList<>();

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/mcbbs/McbbsModpackExportTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/mcbbs/McbbsModpackExportTask.java
@@ -70,9 +70,8 @@ public class McbbsModpackExportTask extends Task<Void> {
         });
     }
 
-    /// Exports the selected game files and manifests to the target archive.
-    ///
-    /// @throws Exception if the instance cannot be analyzed or the archive cannot be written
+/// Exports the selected game files and manifests to the target archive.
+    
     @Override
     public void execute() throws Exception {
         ArrayList<String> blackList = new ArrayList<>(ModAdviser.MODPACK_BLACK_LIST);


### PR DESCRIPTION
#6086 #6173

导出 MCBBS 整合包时，`mcbbs.packmeta` 会记录整合包中的文件信息。原实现会先将整个 `McbbsModpackManifest` 序列化为 JSON 字符串，再由 `Zipper.putTextFile` 将该字符串转换为完整的 UTF-8 字节数组，导致内存中同时存在完整的 JSON 字符串和字节数组。文件数量较多时，生成的清单 JSON 会过大，并可能导致 OOM。

此 PR 将 `mcbbs.packmeta` 直接序列化并写入 ZIP，避免创建完整的中间 JSON 字符串和 UTF-8 字节数组，降低导出过程的内存峰值。