### PR TITLE
修复异步任务 OOM 后界面假死并显示错误信息

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/wizard/TaskExecutorDialogWizardDisplayer.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/wizard/TaskExecutorDialogWizardDisplayer.java
@@ -76,6 +76,15 @@ public abstract class TaskExecutorDialogWizardDisplayer extends AbstractWizardDi
                                 return;
                             }
 
+                            if (executor.getException().getCause() instanceof OutOfMemoryError outOfMemoryError) {
+                                try {
+                                    Controllers.dialog(StringUtils.getStackTrace(outOfMemoryError), null, MessageType.ERROR, () -> onEnd());
+                                } catch (OutOfMemoryError ignored) {
+                                    onEnd();
+                                }
+                                return;
+                            }
+
                             String appendix = StringUtils.getStackTrace(executor.getException());
                             if (settings.get(WizardProvider.FailureCallback.KEY) != null)
                                 settings.get(WizardProvider.FailureCallback.KEY).onFail(settings, executor.getException(), () -> onEnd());

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/wizard/TaskExecutorDialogWizardDisplayer.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/wizard/TaskExecutorDialogWizardDisplayer.java
@@ -68,8 +68,10 @@ public abstract class TaskExecutorDialogWizardDisplayer extends AbstractWizardDi
                             else if (!settings.containsKey("forbid_success_message"))
                                 Controllers.dialog(i18n("message.success"), null, MessageType.SUCCESS, () -> onEnd());
                         } else {
-                            if (executor.getException() == null)
+                            if (executor.getException() == null) {
+                                onEnd();
                                 return;
+                            }
 
                             if (executor.getException() instanceof CancellationException) {
                                 onEnd();

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/task/AsyncTaskExecutor.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/task/AsyncTaskExecutor.java
@@ -65,7 +65,10 @@ public final class AsyncTaskExecutor extends TaskExecutor {
                     return success;
                 })
                 .exceptionally(e -> {
-                    Lang.handleUncaughtException(resolveException(e));
+                    Throwable resolved = resolveException(e);
+                    if (resolved instanceof OutOfMemoryError)
+                        taskListeners.forEach(it -> it.onStop(false, this));
+                    Lang.handleUncaughtException(resolved);
                     return false;
                 });
         return this;
@@ -190,6 +193,8 @@ public final class AsyncTaskExecutor extends TaskExecutor {
                         }
 
                         task.setState(Task.TaskState.FAILED);
+                    } else if (resolved instanceof OutOfMemoryError e) {
+                        handleOutOfMemoryError(task, e);
                     }
 
                     throw new CompletionException(resolved); // rethrow error
@@ -301,6 +306,8 @@ public final class AsyncTaskExecutor extends TaskExecutor {
                         taskListeners.forEach(it -> it.onFailed(task, e));
 
                         task.setState(Task.TaskState.FAILED);
+                    } else if (resolved instanceof OutOfMemoryError e) {
+                        handleOutOfMemoryError(task, e);
                     }
 
                     throw new CompletionException(resolved); // rethrow error
@@ -313,6 +320,16 @@ public final class AsyncTaskExecutor extends TaskExecutor {
         } else {
             return executeNormalTask(parentTask, task);
         }
+    }
+
+    /// Completes the failed task lifecycle while preserving the original error for the global handler.
+    private void handleOutOfMemoryError(Task<?> task, OutOfMemoryError error) {
+        Exception taskException = new Exception(error);
+        task.setException(taskException);
+        exception = taskException;
+        task.fireDoneEvent(this, true);
+        taskListeners.forEach(it -> it.onFailed(task, error));
+        task.setState(Task.TaskState.FAILED);
     }
 
     private void checkCancellation() {

--- a/HMCLCore/src/test/java/org/jackhuang/hmcl/util/TaskTest.java
+++ b/HMCLCore/src/test/java/org/jackhuang/hmcl/util/TaskTest.java
@@ -20,12 +20,15 @@ package org.jackhuang.hmcl.util;
 import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.task.TaskExecutor;
+import org.jackhuang.hmcl.task.TaskListener;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -45,6 +48,70 @@ public class TaskTest {
         )).whenComplete(Assertions::assertNull).test());
 
         assertInstanceOf(Error.class, throwable.get(), "Error has not been thrown to uncaught exception handler");
+    }
+
+    /// Verifies that OOM completes the task lifecycle and still reaches the global handler.
+    @Test
+    public void testOutOfMemoryErrorLifecycle() {
+        OutOfMemoryError normalTaskError = new OutOfMemoryError("normal task");
+        assertOutOfMemoryErrorLifecycle(Task.runAsync(() -> {
+            throw normalTaskError;
+        }), normalTaskError);
+
+        OutOfMemoryError futureTaskError = new OutOfMemoryError("completable future task");
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        future.completeExceptionally(futureTaskError);
+        assertOutOfMemoryErrorLifecycle(Task.fromCompletableFuture(future), futureTaskError);
+    }
+
+    /// Checks the lifecycle events and recorded exceptions for one OOM task.
+    private void assertOutOfMemoryErrorLifecycle(Task<?> task, OutOfMemoryError error) {
+        AtomicInteger doneCount = new AtomicInteger();
+        AtomicReference<@Nullable Boolean> doneFailed = new AtomicReference<>();
+        AtomicInteger failedCount = new AtomicInteger();
+        AtomicReference<@Nullable Throwable> failedThrowable = new AtomicReference<>();
+        AtomicInteger stopCount = new AtomicInteger();
+        AtomicReference<@Nullable Boolean> stopSuccess = new AtomicReference<>();
+        AtomicReference<@Nullable Throwable> uncaught = new AtomicReference<>();
+
+        task.onDone().register(event -> {
+            doneCount.incrementAndGet();
+            doneFailed.set(event.isFailed());
+        });
+        TaskExecutor executor = task.executor(new TaskListener() {
+            @Override
+            public void onFailed(Task<?> failedTask, Throwable throwable) {
+                failedCount.incrementAndGet();
+                failedThrowable.set(throwable);
+            }
+
+            @Override
+            public void onStop(boolean success, TaskExecutor taskExecutor) {
+                stopCount.incrementAndGet();
+                stopSuccess.set(success);
+            }
+        });
+
+        @Nullable Thread.UncaughtExceptionHandler previousHandler = Thread.getDefaultUncaughtExceptionHandler();
+        try {
+            Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> uncaught.set(throwable));
+            assertFalse(executor.test());
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(previousHandler);
+        }
+
+        assertEquals(1, doneCount.get());
+        assertEquals(Boolean.TRUE, doneFailed.get());
+        assertEquals(1, failedCount.get());
+        assertSame(error, failedThrowable.get());
+        assertEquals(1, stopCount.get());
+        assertEquals(Boolean.FALSE, stopSuccess.get());
+        assertEquals(Task.TaskState.FAILED, task.getState());
+        assertNotNull(task.getException());
+        assertSame(error, task.getException().getCause());
+        assertNotNull(executor.getException());
+        assertSame(error, executor.getException().getCause());
+        assertSame(error, uncaught.get());
     }
 
     /**


### PR DESCRIPTION
该问题是在复现 #6086 和 #6162 时发现的。#6086 在导出包含大量文件的 MCBBS 整合包时发生 OOM；#6162 在导出 Modrinth 整合包计算文件指纹时发生 OOM。两处 OOM 的原因不同，但都表现为进度窗口停留且没有错误提示。

HMCL 的 `AsyncTaskExecutor` 处理时，如果抛出 `OutOfMemoryError`，原实现会将其交给全局 handler，但不会触发任务失败事件和停止通知，导致进度窗口无法关闭且没有错误提示。

此 PR 仅针对 `OutOfMemoryError` 补齐受影响任务的失败事件和执行器停止通知，关闭进度窗口并报错。原始 OOM 仍会交给全局 handler，其他 `Error` 的行为保持不变。如果错误对话框也因内存不足而无法创建，仍会结束当前向导，避免界面继续停留。

<img width="1598" height="1020" alt="QQ20260809-220943" src="https://github.com/user-attachments/assets/f4d9e949-706c-4070-aa18-68bf61a89ab8" />

HMCL 当前对 JVM 虚拟机报错缺少统一的处理机制：全局 `CrashReport` 会过滤所有 `VirtualMachineError`（直接返回False，详见#2520），部分不经过 `AsyncTaskExecutor` 的异步流程又会将其作为普通错误处理。建议后续单独研究 JVM 虚拟机报错的处理机制，并区分 `OutOfMemoryError`等错误的处理方式。

此 PR 仅处理 `AsyncTaskExecutor` 中 OOM 导致的界面假死，