### PR TITLE
fix(modloader): 修复 #6628 Cleanroom 和 LiteLoader 实例不读取子文件夹里的模组

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/addon/mod/ModManager.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/addon/mod/ModManager.java
@@ -187,7 +187,9 @@ public final class ModManager extends LocalAddonManager<LocalModFile> {
             }
 
             boolean supportSubfolders = analyzer.has(LibraryAnalyzer.LibraryType.FORGE)
-                    || analyzer.has(LibraryAnalyzer.LibraryType.QUILT);
+                    || analyzer.has(LibraryAnalyzer.LibraryType.QUILT)
+                    || analyzer.has(LibraryAnalyzer.LibraryType.CLEANROOM)
+                    || analyzer.has(LibraryAnalyzer.LibraryType.LITELOADER);
 
             if (Files.isDirectory(getDirectory())) {
                 try (DirectoryStream<Path> modsDirectoryStream = Files.newDirectoryStream(getDirectory())) {


### PR DESCRIPTION
Fixes #6628 