### PR TITLE
移除 “操作被取消” toast

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/DownloadPage.java
@@ -44,8 +44,8 @@ import org.jackhuang.hmcl.ui.construct.Validator;
 import org.jackhuang.hmcl.ui.decorator.DecoratorAnimatedPage;
 import org.jackhuang.hmcl.ui.decorator.DecoratorPage;
 import org.jackhuang.hmcl.ui.instances.DownloadListPage;
-import org.jackhuang.hmcl.ui.instances.HMCLLocalizedDownloadListPage;
 import org.jackhuang.hmcl.ui.instances.GameInstancePage;
+import org.jackhuang.hmcl.ui.instances.HMCLLocalizedDownloadListPage;
 import org.jackhuang.hmcl.ui.instances.Instances;
 import org.jackhuang.hmcl.ui.wizard.Navigation;
 import org.jackhuang.hmcl.ui.wizard.WizardController;
@@ -170,12 +170,8 @@ public class DownloadPage extends DecoratorAnimatedPage implements DecoratorPage
                 task.setName(file.name());
                 return task;
             }).whenComplete(Schedulers.javafx(), exception -> {
-                if (exception != null) {
-                    if (exception instanceof CancellationException) {
-                        Controllers.showToast(i18n("message.cancelled"));
-                    } else {
-                        Controllers.dialog(DownloadProviders.localizeErrorMessage(exception), i18n("install.failed.downloading"), MessageDialogPane.MessageType.ERROR);
-                    }
+                if (exception != null && !(exception instanceof CancellationException)) {
+                    Controllers.dialog(DownloadProviders.localizeErrorMessage(exception), i18n("install.failed.downloading"), MessageDialogPane.MessageType.ERROR);
                 } else {
                     Controllers.showToast(i18n("install.success"));
                 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/DownloadPage.java
@@ -170,8 +170,10 @@ public class DownloadPage extends DecoratorAnimatedPage implements DecoratorPage
                 task.setName(file.name());
                 return task;
             }).whenComplete(Schedulers.javafx(), exception -> {
-                if (exception != null && !(exception instanceof CancellationException)) {
-                    Controllers.dialog(DownloadProviders.localizeErrorMessage(exception), i18n("install.failed.downloading"), MessageDialogPane.MessageType.ERROR);
+                if (exception != null) {
+                    if (!(exception instanceof CancellationException)) {
+                        Controllers.dialog(DownloadProviders.localizeErrorMessage(exception), i18n("install.failed.downloading"), MessageDialogPane.MessageType.ERROR);
+                    }
                 } else {
                     Controllers.showToast(i18n("install.success"));
                 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/instances/Instances.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/instances/Instances.java
@@ -28,11 +28,7 @@ import org.jackhuang.hmcl.download.DownloadProvider;
 import org.jackhuang.hmcl.download.game.GameAssetDownloadTask;
 import org.jackhuang.hmcl.download.game.GameDownloadTask;
 import org.jackhuang.hmcl.download.game.GameLibrariesTask;
-import org.jackhuang.hmcl.game.GameInstanceID;
-import org.jackhuang.hmcl.game.GameInstanceManifest;
-import org.jackhuang.hmcl.game.HMCLGameRepository;
-import org.jackhuang.hmcl.game.LauncherHelper;
-import org.jackhuang.hmcl.game.QuickPlayOption;
+import org.jackhuang.hmcl.game.*;
 import org.jackhuang.hmcl.setting.*;
 import org.jackhuang.hmcl.task.FileDownloadTask;
 import org.jackhuang.hmcl.task.Schedulers;
@@ -106,9 +102,7 @@ public final class Instances {
                                 if (StringUtils.isNotBlank(mod.iconUrl()))
                                     installWizardProvider.setIconUrl(mod.iconUrl());
                                 Controllers.getDecorator().startWizard(installWizardProvider);
-                            } else if (e instanceof CancellationException) {
-                                Controllers.showToast(i18n("message.cancelled"));
-                            } else {
+                            } else if (!(e instanceof CancellationException)) {
                                 Controllers.dialog(
                                         i18n("install.failed.downloading.detail", file.file().url()) + "\n" + StringUtils.getStackTrace(e),
                                         i18n("download.failed.no_code"), MessageDialogPane.MessageType.ERROR);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/MainPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/MainPage.java
@@ -380,9 +380,7 @@ public final class MainPage extends StackPane implements DecoratorPage {
                     if (exception == null) {
                         GameDirectoryManager.getSelectedRepository().setSelectedInstance(instanceHolder.value);
                         launch();
-                    } else if (exception instanceof CancellationException) {
-                        Controllers.showToast(i18n("message.cancelled"));
-                    } else {
+                    } else if (!(exception instanceof CancellationException)) {
                         LOG.warning("Failed to install game", exception);
                         Controllers.dialog(StringUtils.getStackTrace(exception),
                                 i18n("install.failed"),

--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateHandler.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateHandler.java
@@ -159,9 +159,7 @@ public final class UpdateHandler {
                 } else {
                     Exception e = executor.getException();
                     LOG.warning("Failed to update to " + version, e);
-                    if (e instanceof CancellationException) {
-                        Platform.runLater(() -> Controllers.showToast(i18n("message.cancelled")));
-                    } else {
+                    if (!(e instanceof CancellationException)) {
                         Platform.runLater(() -> Controllers.dialog(e.toString(), i18n("update.failed"), MessageType.ERROR));
                     }
                 }


### PR DESCRIPTION
操作取消的唯一方式是点击 “取消” 按钮，用户自己点击的 “取消” 按钮自己肯定知道。
并且这个 toast 有的地方有有的地方没有，全部移除了比较好。