### PR TITLE
修复游戏日志过多导致启动器内存占用过高的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
@@ -872,19 +872,11 @@ public class DefaultLauncher extends Launcher {
             throw new ExecutionPolicyLimitException();
     }
 
+    /// Starts the process output pumps and exit monitor.
     private void startMonitors(ManagedProcess managedProcess, Path nativeFolder, ProcessListener processListener, Charset encoding, boolean isDaemon) {
         processListener.setProcess(managedProcess);
-        Thread stdout = Lang.thread(new StreamPump(managedProcess.getProcess().getInputStream(), it -> {
-            processListener.onLog(it, false);
-            managedProcess.addLine(it);
-        }, encoding), "stdout-pump", isDaemon);
-        managedProcess.addRelatedThread(stdout);
-        Thread stderr = Lang.thread(new StreamPump(managedProcess.getProcess().getErrorStream(), it -> {
-            processListener.onLog(it, true);
-            managedProcess.addLine(it);
-        }, encoding), "stderr-pump", isDaemon);
-        managedProcess.addRelatedThread(stderr);
-        managedProcess.addRelatedThread(Lang.thread(new ExitWaiter(managedProcess, Arrays.asList(stdout, stderr), (exitCode, exitType) -> {
+        List<Thread> joins = new ArrayList<>(2);
+        ExitWaiter exitWaiter = new ExitWaiter(managedProcess, joins, (exitCode, exitType) -> {
             processListener.onExit(exitCode, exitType);
 
             if (StringUtils.isNotBlank(options.getPostExitCommand())) {
@@ -896,7 +888,20 @@ public class DefaultLauncher extends Launcher {
                     LOG.warning("An Exception happened while running exit command.", e);
                 }
             }
-        }), "exit-waiter", isDaemon));
+        });
+        Thread stdout = Lang.thread(new StreamPump(managedProcess.getProcess().getInputStream(), it -> {
+            processListener.onLog(it, false);
+            exitWaiter.onLog(it);
+        }, encoding), "stdout-pump", isDaemon);
+        managedProcess.addRelatedThread(stdout);
+        joins.add(stdout);
+        Thread stderr = Lang.thread(new StreamPump(managedProcess.getProcess().getErrorStream(), it -> {
+            processListener.onLog(it, true);
+            exitWaiter.onLog(it);
+        }, encoding), "stderr-pump", isDaemon);
+        managedProcess.addRelatedThread(stderr);
+        joins.add(stderr);
+        managedProcess.addRelatedThread(Lang.thread(exitWaiter, "exit-waiter", isDaemon));
     }
 
     private record Command(

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/ExitWaiter.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/ExitWaiter.java
@@ -27,7 +27,7 @@ import org.jackhuang.hmcl.util.platform.ManagedProcess;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
 import java.util.Collection;
-import java.util.List;
+import java.util.Locale;
 import java.util.function.BiConsumer;
 
 /**
@@ -38,6 +38,10 @@ final class ExitWaiter implements Runnable {
     private final ManagedProcess process;
     private final Collection<Thread> joins;
     private final BiConsumer<Integer, ProcessListener.ExitType> watcher;
+    /// Whether the output indicates that the JVM failed to start.
+    private volatile boolean jvmLaunchFailed;
+    /// Whether the output indicates that the game failed.
+    private volatile boolean applicationFailed;
 
     /**
      * Constructor.
@@ -51,6 +55,31 @@ final class ExitWaiter implements Runnable {
         this.watcher = watcher;
     }
 
+    /// Records exit indicators from a process output line.
+    ///
+    /// @param line the process output line
+    void onLog(String line) {
+        if (jvmLaunchFailed && applicationFailed)
+            return;
+
+        String lowerCaseLine = line.toLowerCase(Locale.ROOT);
+        boolean detectedJvmLaunchFailure = !jvmLaunchFailed && StringUtils.containsOne(lowerCaseLine,
+                "could not create the java virtual machine.",
+                "error occurred during initialization of vm",
+                "a fatal exception has occurred. program will exit.");
+        boolean detectedApplicationFailure = !applicationFailed && StringUtils.containsOne(lowerCaseLine,
+                "crash report saved to", "could not save crash report to", "this crash report has been saved to:",
+                "unable to launch", "an exception was thrown, the game will display an error screen and halt.");
+
+        if (!(detectedJvmLaunchFailure || detectedApplicationFailure) || !Log4jLevel.guessLogLineError(line))
+            return;
+
+        if (detectedJvmLaunchFailure)
+            jvmLaunchFailed = true;
+        if (detectedApplicationFailure)
+            applicationFailed = true;
+    }
+
     @Override
     public void run() {
         try {
@@ -59,19 +88,13 @@ final class ExitWaiter implements Runnable {
             for (Thread thread : joins)
                 thread.join();
 
-            List<String> errorLines = process.getLines(Log4jLevel::guessLogLineError);
             ProcessListener.ExitType exitType;
 
             // LaunchWrapper will catch the exception logged and will exit normally.
-            if (exitCode != 0 && StringUtils.containsOne(errorLines,
-                    "Could not create the Java Virtual Machine.",
-                    "Error occurred during initialization of VM",
-                    "A fatal exception has occurred. Program will exit.")) {
+            if (exitCode != 0 && jvmLaunchFailed) {
                 EventBus.EVENT_BUS.fireEvent(new JVMLaunchFailedEvent(this, process));
                 exitType = ProcessListener.ExitType.JVM_ERROR;
-            } else if (exitCode != 0 || StringUtils.containsOne(errorLines,
-                    "Crash report saved to", "Could not save crash report to", "This crash report has been saved to:",
-                    "Unable to launch", "An exception was thrown, the game will display an error screen and halt.")) {
+            } else if (exitCode != 0 || applicationFailed) {
                 EventBus.EVENT_BUS.fireEvent(new ProcessExitedAbnormallyEvent(this, process));
 
                 if (exitCode == 137 && OperatingSystem.CURRENT_OS.isLinuxOrBSD()) {


### PR DESCRIPTION
Fixed #5685 #6640

游戏运行过程中，HMCL 会将游戏的全部标准输出和错误输出保存在 `ManagedProcess` 中，用于游戏退出时判断 JVM 启动失败或异常退出。即使没有打开日志窗口，该缓存仍会随日志量持续增长；日志过多时会导致启动器内存占用过高，并可能发生 OOM。

此 PR 改为在接收日志时直接记录退出判断所需的错误标志，不再保存完整的游戏输出。游戏退出类型的判断行为保持不变。

使用测试模组输出约 608 MiB 日志，HMCL 分配 256 MiB 堆内存。修改前，HMCL 堆占用增长至约 255 MiB，发生 OOM 并最终发生 JVM 崩溃；修改后，游戏正常进入主菜单，HMCL 堆占用稳定在约 77 MiB。

注：部分注释由AI完成。