### PR TITLE
修复游戏日志过多导致日志窗口 OOM 的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/LauncherHelper.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/LauncherHelper.java
@@ -848,7 +848,8 @@ public final class LauncherHelper {
         private final CountDownLatch launchingLatch;
         private final String forbiddenAccessToken;
         private Thread submitLogThread;
-        private LinkedBlockingQueue<Log> logBuffer;
+        /// Pending logs for the log window.
+        private final BlockingDeque<Log> logBuffer = new LinkedBlockingDeque<>(Log.getLogLines());
 
         public HMCLProcessListener(HMCLGameRepository repository, GameInstanceManifest manifest, AuthInfo authInfo, LaunchOptions launchOptions, CountDownLatch launchingLatch, boolean detectWindow) {
             this.repository = repository;
@@ -881,7 +882,6 @@ public final class LauncherHelper {
                     logWindowLatch.countDown();
                 });
 
-                logBuffer = new LinkedBlockingQueue<>();
                 submitLogThread = Lang.thread(new Runnable() {
                     private final ArrayList<Log> currentLogs = new ArrayList<>();
                     private final Semaphore semaphore = new Semaphore(0);
@@ -980,7 +980,7 @@ public final class LauncherHelper {
             if (showLogs) {
                 if (level == null)
                     level = Lang.requireNonNullElse(Log4jLevel.guessLevel(log), Log4jLevel.INFO);
-                logBuffer.add(new Log(log, level));
+                enqueueLog(new Log(log, level));
             } else {
                 lock.lock();
                 try {
@@ -1011,7 +1011,7 @@ public final class LauncherHelper {
         @Override
         public void onExit(int exitCode, ExitType exitType) {
             if (showLogs) {
-                logBuffer.add(new Log(String.format("[%s] [HMCL ProcessListener] Minecraft exit with code %d(0x%x), type is %s.", TIME_FORMATTER.format(Instant.now()), exitCode, exitCode, exitType), Log4jLevel.INFO));
+                enqueueLog(new Log(String.format("[%s] [HMCL ProcessListener] Minecraft exit with code %d(0x%x), type is %s.", TIME_FORMATTER.format(Instant.now()), exitCode, exitCode, exitType), Log4jLevel.INFO));
                 submitLogThread.interrupt();
                 try {
                     submitLogThread.join();
@@ -1042,6 +1042,12 @@ public final class LauncherHelper {
             }
 
             checkExit();
+        }
+
+        /// Adds a log to the display queue, discarding the oldest pending log when full.
+        private void enqueueLog(Log log) {
+            while (!logBuffer.offerLast(log))
+                logBuffer.pollFirst();
         }
 
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/LauncherHelper.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/LauncherHelper.java
@@ -849,7 +849,7 @@ public final class LauncherHelper {
         private final String forbiddenAccessToken;
         private Thread submitLogThread;
         /// Pending logs for the log window.
-        private final BlockingDeque<Log> logBuffer = new LinkedBlockingDeque<>(Log.getLogLines());
+        private final BlockingDeque<Log> logBuffer = new LinkedBlockingDeque<>();
 
         public HMCLProcessListener(HMCLGameRepository repository, GameInstanceManifest manifest, AuthInfo authInfo, LaunchOptions launchOptions, CountDownLatch launchingLatch, boolean detectWindow) {
             this.repository = repository;
@@ -1044,10 +1044,13 @@ public final class LauncherHelper {
             checkExit();
         }
 
-        /// Adds a log to the display queue, discarding the oldest pending log when full.
+        /// Adds a log to the display queue, retaining at most the configured number of lines.
         private void enqueueLog(Log log) {
-            while (!logBuffer.offerLast(log))
-                logBuffer.pollFirst();
+            synchronized (logBuffer) {
+                while (logBuffer.size() >= Log.getLogLines())
+                    logBuffer.pollFirst();
+                logBuffer.addLast(log);
+            }
         }
 
     }


### PR DESCRIPTION
#5685 中 burningtnt 提到，HMCL 会将 200ms 内收到的游戏日志聚合后一次性提交到日志窗口。当游戏短时间内输出大量日志时，待上屏日志会在无界队列中持续积压，并形成过大的上屏批次，导致 HMCL 内存占用过高、界面无响应甚至 OOM。

此 PR 根据日志窗口配置的显示行数限制待上屏日志数量。缓冲区达到上限时，丢弃尚未显示的最旧日志并保留最新日志，避免待上屏队列和单次上屏批次无限增长。

注：#6667 修复的问题也会在相同场景下独立导致 OOM。建议两个 PR 一并合并；若仅合并此 PR，尽管日志窗口的队列不再无限积压，但 `ManagedProcess` 仍会保存全部游戏输出，大量日志下 HMCL 仍可能发生 OOM。