### PR TITLE
修复部分TwoLineListItem布局

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
@@ -23,8 +23,10 @@ import javafx.beans.property.StringPropertyBase;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.css.PseudoClass;
+import javafx.geometry.Orientation;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
@@ -46,11 +48,11 @@ public class TwoLineListItem extends VBox {
         lblTitle = new Label();
         lblTitle.getStyleClass().add("title");
         lblTitle.setWrapText(true);
-        lblTitle.setMaxWidth(Double.MAX_VALUE);
+        HBox.setHgrow(lblTitle, Priority.ALWAYS);
 
         this.firstLine = new HBox(lblTitle);
         firstLine.getStyleClass().add("first-line");
-        firstLine.setAlignment(Pos.CENTER_LEFT);
+        firstLine.setAlignment(Pos.TOP_LEFT);
 
         this.getChildren().setAll(firstLine);
     }
@@ -166,17 +168,15 @@ public class TwoLineListItem extends VBox {
         if (tags == null) {
             tags = FXCollections.observableArrayList();
 
-            var tagsBox = new HBox(8);
+            var tagsBox = new FlowPane(Orientation.HORIZONTAL, 8, 4);
             tagsBox.getStyleClass().add("tags");
             tagsBox.setAlignment(Pos.CENTER_LEFT);
             tagsBox.setMinWidth(0);
-            HBox.setHgrow(tagsBox, Priority.ALWAYS);
+            tagsBox.setMaxWidth(200);
             Bindings.bindContent(tagsBox.getChildren(), tags);
             var isNotEmpty = Bindings.isNotEmpty(tags);
             tagsBox.managedProperty().bind(isNotEmpty);
             tagsBox.visibleProperty().bind(isNotEmpty);
-
-            FXUtils.setOverflowHidden(tagsBox);
 
             firstLine.getChildren().setAll(lblTitle, tagsBox);
         }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
@@ -54,8 +54,11 @@ public class TwoLineListItem extends VBox {
         firstLine.getStyleClass().add("first-line");
         firstLine.setMaxWidth(Double.MAX_VALUE);
         firstLine.setMinWidth(0);
+        firstLine.prefWidthProperty().bind(widthProperty());
         firstLine.minHeightProperty().bind(lblTitle.heightProperty());
         firstLine.prefHeightProperty().bind(lblTitle.heightProperty());
+
+        widthProperty().addListener((obs, old, val) -> firstLine.requestLayout());
 
         this.getChildren().setAll(firstLine);
     }
@@ -90,7 +93,6 @@ public class TwoLineListItem extends VBox {
         @Override
         protected void invalidated() {
             lblTitle.setText(get());
-//            firstLine.requestLayout();
         }
     };
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
@@ -45,6 +45,8 @@ public class TwoLineListItem extends VBox {
 
         lblTitle = new Label();
         lblTitle.getStyleClass().add("title");
+        lblTitle.setWrapText(true);
+        lblTitle.setMaxWidth(Double.MAX_VALUE);
 
         this.firstLine = new HBox(lblTitle);
         firstLine.getStyleClass().add("first-line");
@@ -176,7 +178,6 @@ public class TwoLineListItem extends VBox {
 
             FXUtils.setOverflowHidden(tagsBox);
 
-            lblTitle.setMinWidth(Label.USE_PREF_SIZE);
             firstLine.getChildren().setAll(lblTitle, tagsBox);
         }
         return tags;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
@@ -28,14 +28,14 @@ import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
-import javafx.scene.layout.Priority;
+import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
 import org.jackhuang.hmcl.ui.FXUtils;
 
 public class TwoLineListItem extends VBox {
     private static final String DEFAULT_STYLE_CLASS = "two-line-list-item";
 
-    private final HBox firstLine;
+    private final Pane firstLine;
     private HBox secondLine;
 
     private final Label lblTitle;
@@ -48,11 +48,14 @@ public class TwoLineListItem extends VBox {
         lblTitle = new Label();
         lblTitle.getStyleClass().add("title");
         lblTitle.setWrapText(true);
-        HBox.setHgrow(lblTitle, Priority.ALWAYS);
+        lblTitle.setMinWidth(0);
 
-        this.firstLine = new HBox(lblTitle);
+        this.firstLine = new Pane(lblTitle);
         firstLine.getStyleClass().add("first-line");
-        firstLine.setAlignment(Pos.TOP_LEFT);
+        firstLine.setMaxWidth(Double.MAX_VALUE);
+        firstLine.setMinWidth(0);
+        firstLine.minHeightProperty().bind(lblTitle.heightProperty());
+        firstLine.prefHeightProperty().bind(lblTitle.heightProperty());
 
         this.getChildren().setAll(firstLine);
     }
@@ -87,6 +90,7 @@ public class TwoLineListItem extends VBox {
         @Override
         protected void invalidated() {
             lblTitle.setText(get());
+//            firstLine.requestLayout();
         }
     };
 
@@ -149,7 +153,7 @@ public class TwoLineListItem extends VBox {
         subtitleProperty().set(subtitle);
     }
 
-    public HBox getFirstLine() {
+    public Pane getFirstLine() {
         return firstLine;
     }
 
@@ -170,15 +174,24 @@ public class TwoLineListItem extends VBox {
 
             var tagsBox = new FlowPane(Orientation.HORIZONTAL, 8, 4);
             tagsBox.getStyleClass().add("tags");
-            tagsBox.setAlignment(Pos.CENTER_LEFT);
+            tagsBox.setAlignment(Pos.CENTER_RIGHT);
             tagsBox.setMinWidth(0);
-            tagsBox.setMaxWidth(200);
             Bindings.bindContent(tagsBox.getChildren(), tags);
             var isNotEmpty = Bindings.isNotEmpty(tags);
             tagsBox.managedProperty().bind(isNotEmpty);
             tagsBox.visibleProperty().bind(isNotEmpty);
 
             firstLine.getChildren().setAll(lblTitle, tagsBox);
+
+            tagsBox.layoutXProperty().bind(
+                    firstLine.widthProperty().subtract(tagsBox.widthProperty())
+            );
+
+            lblTitle.maxWidthProperty().bind(
+                    firstLine.widthProperty().subtract(tagsBox.widthProperty()).subtract(8)
+            );
+
+            firstLine.widthProperty().addListener((obs, old, val) -> firstLine.requestLayout());
         }
         return tags;
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/TwoLineListItem.java
@@ -30,7 +30,6 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
-import org.jackhuang.hmcl.ui.FXUtils;
 
 public class TwoLineListItem extends VBox {
     private static final String DEFAULT_STYLE_CLASS = "two-line-list-item";


### PR DESCRIPTION
修复 #6682 的布局问题
修改了一些布局
1. 文本配置为可换行
2. 标签也可以换行
以此来规避组件宽度溢出

但此分支仍旧存在如下问题 希望有大佬继续完善（请勿直接合并）
1. 下载 -> 游戏 打开后列表的宽度可能会显示错误 如果显示是正确的 拉大宽度后再缩小 会发现组件无法缩小了（出现了横向滚动条）
4. 这应该是所有调用了TwoLineListItem都有可能出现的问题 标题文本的宽度太小了 导致换行很频繁 我找了几个小时没找到这是怎么引起的（