### PR TITLE
[Enhancement] 优先按照游戏版本排序实例

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java
@@ -388,8 +388,8 @@ public final class HMCLGameRepository extends DefaultGameRepository {
     public Stream<HMCLGameInstance> getDisplayInstances() {
         return getSnapshot().getInstances().stream()
                 .filter(it -> !it.getManifest().isHidden())
-                .sorted(Comparator.comparing((HMCLGameInstance instance) -> Lang.requireNonNullElse(instance.getLaunchManifest().releaseTime(), Instant.EPOCH))
-                        .thenComparing(DefaultGameInstance::getVersion)
+                .sorted(Comparator.comparing(DefaultGameInstance::getVersion)
+                        .thenComparing(instance -> Lang.requireNonNullElse(instance.getLaunchManifest().releaseTime(), Instant.EPOCH))
                         .thenComparing(instance -> VersionNumber.asVersion(instance.getId().id())));
     }
 


### PR DESCRIPTION
Fixes #4679

本来优先按发布时间排序，但是 Forge 等加载器等发布时间会覆盖原版发布时间