### PR TITLE
新增游戏崩溃后上传日志到 mclo.gs 的功能

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/McLogsUploader.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/McLogsUploader.java
@@ -30,9 +30,10 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.jackhuang.hmcl.util.Lang.wrap;
@@ -61,11 +62,34 @@ public final class McLogsUploader {
     /// Maximum uploaded size in bytes, mirroring the server-side `limit-bytes` filter (10 MiB).
     private static final int MAX_BYTES = 10 * 1024 * 1024;
 
+    /// Placeholder replacing IPv4 addresses before upload.
+    private static final String IPV4_REDACTED = "<IPv4>";
+
+    /// Placeholder replacing the current user's home directory before upload.
+    private static final String HOME_REDACTED = "<user home>";
+
+    /// Placeholder replacing a credential value after redaction.
+    private static final String TOKEN_REDACTED = "<access token>";
+
+    /// Matches IPv4 addresses whose octets are all within 0-255, so unrelated dotted numbers are not touched.
+    private static final Pattern IPV4_PATTERN = Pattern.compile(
+            "\\b(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}\\b");
+
+    /// Matches `name=<value>`, `name: <value>` and `"name": "<value>"` credentials so only the value is masked.
+    private static final Pattern TOKEN_PROPERTY_PATTERN = Pattern.compile(
+            "(?i)(access[_\\-]?token|refresh[_\\-]?token|client[_\\-]?token|session[_\\-]?token)"
+                    + "(\"?\\s*[:=]\\s*[\"']?)([^\\s\"';]+)");
+
+    /// Matches `--name <value>` command-line credentials so only the value is masked.
+    private static final Pattern TOKEN_ARGUMENT_PATTERN = Pattern.compile(
+            "(?i)(--(?:access[_\\-]?token|refresh[_\\-]?token|client[_\\-]?token|session[_\\-]?token)"
+                    + "\\s+)([^\\s\"']+)");
+
     /// Uploads the game log of a crashed game and resolves to the URL of the shared log.
     ///
     /// The log content is read from `logs/latest.log` under [runDirectory] when available, and
     /// falls back to the launcher-collected console output ([logs]) otherwise. The content is
-    /// filtered for forbidden tokens and truncated on the client side to the mclo.gs limits.
+    /// redacted for potentially sensitive data and truncated on the client side to the mclo.gs limits.
     ///
     /// @param runDirectory the game run directory
     /// @param logs         the launcher-collected console output used as fallback content
@@ -75,8 +99,10 @@ public final class McLogsUploader {
     }
 
     private static String uploadGameLogSync(Path runDirectory, List<Log> logs) throws IOException {
+        String content = truncate(sanitize(readGameLog(runDirectory, logs)));
+
         JsonObject payload = new JsonObject();
-        payload.addProperty("content", truncate(readGameLog(runDirectory, logs)));
+        payload.addProperty("content", content);
         payload.addProperty("source", SOURCE);
 
         String responseJson = HttpRequest.POST(API_URL).json(payload).ignoreHttpCode().getString();
@@ -84,8 +110,6 @@ public final class McLogsUploader {
     }
 
     /// Reads the game log, preferring `logs/latest.log` and falling back to the console output.
-    ///
-    /// The returned content has every known forbidden token filtered out before it leaves the machine.
     ///
     /// @param runDirectory the game run directory
     /// @param logs         the launcher-collected console output
@@ -95,19 +119,19 @@ public final class McLogsUploader {
         if (content == null || content.isEmpty()) {
             content = logs.stream().map(Log::getLog).collect(Collectors.joining("\n"));
         }
-        return Logger.filterForbiddenToken(content);
+        return content;
     }
 
-    /// Reads the content of `latest.log`, or `null` when it is missing or unreadable.
+    /// Reads the tail of `latest.log`, or `null` when it is missing, empty, or unreadable.
     ///
     /// @param latestLog the path to `logs/latest.log`
-    /// @return the file content, or `null` when it cannot be read
+    /// @return the tail of the file, or `null` when it cannot be read
     private static @Nullable String readLatestLog(Path latestLog) {
-        if (!Files.isReadable(latestLog)) {
+        if (!Files.isRegularFile(latestLog) || !Files.isReadable(latestLog)) {
             return null;
         }
         try {
-            return FileUtils.readTextMaybeNativeEncoding(latestLog);
+            return FileUtils.readTextTailMaybeNativeEncoding(latestLog, MAX_BYTES);
         } catch (IOException e) {
             LOG.warning("Failed to read the game log, falling back to the console output", e);
             return null;
@@ -116,19 +140,118 @@ public final class McLogsUploader {
 
     /// Truncates the log content to the mclo.gs limits while keeping the tail, where the crash details live.
     ///
+    /// The line limit is applied first (keeping the last [MAX_LINES] lines), then the byte limit, so the
+    /// result always fits both limits and never splits a multi-byte character.
+    ///
     /// @param content the raw log content
     /// @return the truncated log content
     static String truncate(String content) {
-        String[] lines = content.split("\n", -1);
-        if (lines.length > MAX_LINES) {
-            content = String.join("\n", Arrays.copyOfRange(lines, lines.length - MAX_LINES, lines.length));
+        return limitBytes(limitLines(content), MAX_BYTES);
+    }
+
+    /// Keeps at most the last [MAX_LINES] lines, scanning backwards for newlines instead of splitting the
+    /// whole content into per-line strings.
+    ///
+    /// @param content the log content
+    /// @return the content limited to the last [MAX_LINES] lines
+    private static String limitLines(String content) {
+        int remaining = MAX_LINES;
+        int fromIndex = content.length();
+        while (remaining-- > 0) {
+            int index = content.lastIndexOf('\n', fromIndex - 1);
+            if (index < 0) {
+                return content;
+            }
+            fromIndex = index;
+        }
+        return content.substring(fromIndex + 1);
+    }
+
+    /// Drops leading bytes until the UTF-8 encoding of [content] fits into [maxBytes], keeping the tail and
+    /// never splitting a multi-byte character.
+    ///
+    /// @param content  the log content
+    /// @param maxBytes the byte limit
+    /// @return the byte-limited content
+    private static String limitBytes(String content, int maxBytes) {
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length <= maxBytes) {
+            return content;
         }
 
-        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
-        if (bytes.length > MAX_BYTES) {
-            content = new String(bytes, bytes.length - MAX_BYTES, MAX_BYTES, StandardCharsets.UTF_8);
+        int start = bytes.length - maxBytes;
+        while (start < bytes.length && (bytes[start] & 0xC0) == 0x80) {
+            start++;
+        }
+        return new String(bytes, start, bytes.length - start, StandardCharsets.UTF_8);
+    }
+
+    /// Redacts potentially sensitive information before the log leaves the machine for a third-party service.
+    ///
+    /// This first masks credential arguments and the user's home directory and IPv4 addresses, then lets
+    /// {@link Logger#filterForbiddenToken(String)} replace any registered access token occurrences.
+    ///
+    /// @param content the raw log content
+    /// @return the redacted log content
+    static String sanitize(String content) {
+        return Logger.filterForbiddenToken(redactSensitiveData(content));
+    }
+
+    /// Applies the local redaction rules that do not depend on registered tokens.
+    ///
+    /// @param content the raw log content
+    /// @return the redacted log content
+    private static String redactSensitiveData(String content) {
+        content = redactUserHome(content);
+        content = redactTokens(content);
+        return redactIpv4(content);
+    }
+
+    /// Replaces the current user's home directory (in either slash style) with a placeholder.
+    ///
+    /// @param content the log content
+    /// @return the content with the home directory redacted
+    private static String redactUserHome(String content) {
+        String home = System.getProperty("user.home", "");
+        if (home.length() < 3) {
+            return content;
+        }
+
+        content = redactPathVariant(content, home);
+        String alternate = home.indexOf('\\') >= 0 ? home.replace('\\', '/') : home.replace('/', '\\');
+        if (!alternate.equals(home)) {
+            content = redactPathVariant(content, alternate);
         }
         return content;
+    }
+
+    /// Replaces [path] with a placeholder only when it is followed by a path separator, whitespace, quote or
+    /// the end of the content, so a home directory is not matched as the prefix of a sibling directory.
+    ///
+    /// @param content the log content
+    /// @param path    the path variant to redact
+    /// @return the content with occurrences of [path] redacted
+    private static String redactPathVariant(String content, String path) {
+        Pattern pattern = Pattern.compile(Pattern.quote(path) + "(?=[/\\\\\\s\"']|\\z)", Pattern.CASE_INSENSITIVE);
+        return pattern.matcher(content).replaceAll(Matcher.quoteReplacement(HOME_REDACTED));
+    }
+
+    /// Masks values of known credential arguments without touching unrelated content.
+    ///
+    /// @param content the log content
+    /// @return the content with credential values masked
+    private static String redactTokens(String content) {
+        content = TOKEN_PROPERTY_PATTERN.matcher(content).replaceAll("$1$2" + TOKEN_REDACTED);
+        content = TOKEN_ARGUMENT_PATTERN.matcher(content).replaceAll("$1" + TOKEN_REDACTED);
+        return content;
+    }
+
+    /// Masks IPv4 addresses, keeping any trailing port for diagnostics.
+    ///
+    /// @param content the log content
+    /// @return the content with IPv4 addresses redacted
+    private static String redactIpv4(String content) {
+        return IPV4_PATTERN.matcher(content).replaceAll(Matcher.quoteReplacement(IPV4_REDACTED));
     }
 
     /// Parses the mclo.gs response into the URL of the uploaded log.

--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/McLogsUploader.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/McLogsUploader.java
@@ -168,15 +168,16 @@ public final class McLogsUploader {
     }
 
     /// Keeps at most the last [MAX_LINES] lines, scanning backwards for newlines instead of splitting the
-    /// whole content into per-line strings.
+    /// whole content into per-line strings. A line is a newline-terminated segment: a single trailing newline
+    /// ends the last line without adding an empty one, while consecutive trailing newlines count as empty lines.
     ///
     /// @param content the log content
     /// @return the content limited to the last [MAX_LINES] lines
     private static String limitLines(String content) {
-        // A trailing newline terminates the last line rather than adding an empty one, so skip it before
-        // counting; otherwise exactly MAX_LINES lines ending in `\n` would lose their first line.
+        // A single trailing newline only terminates the last line, so skip at most one before counting;
+        // consecutive trailing newlines encode real empty lines and must keep their own line counts.
         int fromIndex = content.length();
-        while (fromIndex > 0 && content.charAt(fromIndex - 1) == '\n') {
+        if (fromIndex > 0 && content.charAt(fromIndex - 1) == '\n') {
             fromIndex--;
         }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/McLogsUploader.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/McLogsUploader.java
@@ -23,11 +23,11 @@ import org.jackhuang.hmcl.util.gson.JsonUtils;
 import org.jackhuang.hmcl.util.io.FileUtils;
 import org.jackhuang.hmcl.util.io.HttpRequest;
 import org.jackhuang.hmcl.util.logging.Logger;
+import org.jackhuang.hmcl.util.platform.OperatingSystem;
 import org.jetbrains.annotations.NotNullByDefault;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -65,6 +65,9 @@ public final class McLogsUploader {
     /// Placeholder replacing IPv4 addresses before upload.
     private static final String IPV4_REDACTED = "<IPv4>";
 
+    /// Placeholder replacing IPv6 addresses before upload.
+    private static final String IPV6_REDACTED = "<IPv6>";
+
     /// Placeholder replacing the current user's home directory before upload.
     private static final String HOME_REDACTED = "<user home>";
 
@@ -75,14 +78,29 @@ public final class McLogsUploader {
     private static final Pattern IPV4_PATTERN = Pattern.compile(
             "\\b(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}\\b");
 
+    /// Matches IPv6 addresses in their full or `::`-compressed form, without touching MAC addresses or other
+    /// colon-separated hex sequences of the wrong length.
+    private static final Pattern IPV6_PATTERN = Pattern.compile(
+            "(?i)(?<![0-9a-f:])(?:"
+                    + "(?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4}"
+                    + "|(?:[0-9a-f]{1,4}:){1,7}:"
+                    + "|(?:[0-9a-f]{1,4}:){1,6}:[0-9a-f]{1,4}"
+                    + "|(?:[0-9a-f]{1,4}:){1,5}(?::[0-9a-f]{1,4}){1,2}"
+                    + "|(?:[0-9a-f]{1,4}:){1,4}(?::[0-9a-f]{1,4}){1,3}"
+                    + "|(?:[0-9a-f]{1,4}:){1,3}(?::[0-9a-f]{1,4}){1,4}"
+                    + "|(?:[0-9a-f]{1,4}:){1,2}(?::[0-9a-f]{1,4}){1,5}"
+                    + "|[0-9a-f]{1,4}:(?::[0-9a-f]{1,4}){1,6}"
+                    + "|:(?:(?::[0-9a-f]{1,4}){1,7}|:)"
+                    + ")(?![0-9a-f:])");
+
     /// Matches `name=<value>`, `name: <value>` and `"name": "<value>"` credentials so only the value is masked.
     private static final Pattern TOKEN_PROPERTY_PATTERN = Pattern.compile(
-            "(?i)(access[_\\-]?token|refresh[_\\-]?token|client[_\\-]?token|session[_\\-]?token)"
+            "(?i)(access[_\\-]?token|refresh[_\\-]?token|client[_\\-]?token|session[_\\-]?token|auth[_\\-]?token)"
                     + "(\"?\\s*[:=]\\s*[\"']?)([^\\s\"';]+)");
 
     /// Matches `--name <value>` command-line credentials so only the value is masked.
     private static final Pattern TOKEN_ARGUMENT_PATTERN = Pattern.compile(
-            "(?i)(--(?:access[_\\-]?token|refresh[_\\-]?token|client[_\\-]?token|session[_\\-]?token)"
+            "(?i)(--(?:access[_\\-]?token|refresh[_\\-]?token|client[_\\-]?token|session[_\\-]?token|auth[_\\-]?token)"
                     + "\\s+)([^\\s\"']+)");
 
     /// Uploads the game log of a crashed game and resolves to the URL of the shared log.
@@ -146,7 +164,7 @@ public final class McLogsUploader {
     /// @param content the raw log content
     /// @return the truncated log content
     static String truncate(String content) {
-        return limitBytes(limitLines(content), MAX_BYTES);
+        return FileUtils.truncateUtf8ToByteLimit(limitLines(content), MAX_BYTES);
     }
 
     /// Keeps at most the last [MAX_LINES] lines, scanning backwards for newlines instead of splitting the
@@ -167,28 +185,9 @@ public final class McLogsUploader {
         return content.substring(fromIndex + 1);
     }
 
-    /// Drops leading bytes until the UTF-8 encoding of [content] fits into [maxBytes], keeping the tail and
-    /// never splitting a multi-byte character.
-    ///
-    /// @param content  the log content
-    /// @param maxBytes the byte limit
-    /// @return the byte-limited content
-    private static String limitBytes(String content, int maxBytes) {
-        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
-        if (bytes.length <= maxBytes) {
-            return content;
-        }
-
-        int start = bytes.length - maxBytes;
-        while (start < bytes.length && (bytes[start] & 0xC0) == 0x80) {
-            start++;
-        }
-        return new String(bytes, start, bytes.length - start, StandardCharsets.UTF_8);
-    }
-
     /// Redacts potentially sensitive information before the log leaves the machine for a third-party service.
     ///
-    /// This first masks credential arguments and the user's home directory and IPv4 addresses, then lets
+    /// This masks credential arguments, the user's home directory and IP addresses, then lets
     /// {@link Logger#filterForbiddenToken(String)} replace any registered access token occurrences.
     ///
     /// @param content the raw log content
@@ -204,10 +203,14 @@ public final class McLogsUploader {
     private static String redactSensitiveData(String content) {
         content = redactUserHome(content);
         content = redactTokens(content);
-        return redactIpv4(content);
+        content = redactIpv4(content);
+        return redactIpv6(content);
     }
 
     /// Replaces the current user's home directory (in either slash style) with a placeholder.
+    ///
+    /// Windows paths are compared case-insensitively, while Unix and macOS paths are compared
+    /// case-sensitively, so a sibling directory differing only in letter case is never redacted.
     ///
     /// @param content the log content
     /// @return the content with the home directory redacted
@@ -217,10 +220,11 @@ public final class McLogsUploader {
             return content;
         }
 
-        content = redactPathVariant(content, home);
+        boolean caseInsensitive = OperatingSystem.CURRENT_OS == OperatingSystem.WINDOWS;
+        content = redactPathVariant(content, home, caseInsensitive);
         String alternate = home.indexOf('\\') >= 0 ? home.replace('\\', '/') : home.replace('/', '\\');
         if (!alternate.equals(home)) {
-            content = redactPathVariant(content, alternate);
+            content = redactPathVariant(content, alternate, caseInsensitive);
         }
         return content;
     }
@@ -228,11 +232,13 @@ public final class McLogsUploader {
     /// Replaces [path] with a placeholder only when it is followed by a path separator, whitespace, quote or
     /// the end of the content, so a home directory is not matched as the prefix of a sibling directory.
     ///
-    /// @param content the log content
-    /// @param path    the path variant to redact
+    /// @param content         the log content
+    /// @param path            the path variant to redact
+    /// @param caseInsensitive whether the comparison should ignore letter case (Windows paths)
     /// @return the content with occurrences of [path] redacted
-    private static String redactPathVariant(String content, String path) {
-        Pattern pattern = Pattern.compile(Pattern.quote(path) + "(?=[/\\\\\\s\"']|\\z)", Pattern.CASE_INSENSITIVE);
+    static String redactPathVariant(String content, String path, boolean caseInsensitive) {
+        int flags = caseInsensitive ? Pattern.CASE_INSENSITIVE : 0;
+        Pattern pattern = Pattern.compile(Pattern.quote(path) + "(?=[/\\\\\\s\"']|\\z)", flags);
         return pattern.matcher(content).replaceAll(Matcher.quoteReplacement(HOME_REDACTED));
     }
 
@@ -254,13 +260,21 @@ public final class McLogsUploader {
         return IPV4_PATTERN.matcher(content).replaceAll(Matcher.quoteReplacement(IPV4_REDACTED));
     }
 
+    /// Masks IPv6 addresses, keeping any trailing port for diagnostics.
+    ///
+    /// @param content the log content
+    /// @return the content with IPv6 addresses redacted
+    private static String redactIpv6(String content) {
+        return IPV6_PATTERN.matcher(content).replaceAll(Matcher.quoteReplacement(IPV6_REDACTED));
+    }
+
     /// Parses the mclo.gs response into the URL of the uploaded log.
     ///
     /// @param responseJson the raw response body
     /// @return the mclo.gs URL of the uploaded log
     /// @throws IOException when the upload failed or the response is malformed
     static String parseResponse(String responseJson) throws IOException {
-        @Nullable JsonObject response = JsonUtils.fromJson(responseJson, JsonObject.class);
+        @Nullable JsonObject response = JsonUtils.fromMaybeMalformedJson(responseJson, JsonObject.class);
         boolean success = response != null && JsonUtils.getBoolean(response, "success", false);
         if (!success) {
             @Nullable String error = response != null ? JsonUtils.getString(response, "error") : null;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/McLogsUploader.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/McLogsUploader.java
@@ -173,8 +173,16 @@ public final class McLogsUploader {
     /// @param content the log content
     /// @return the content limited to the last [MAX_LINES] lines
     private static String limitLines(String content) {
-        int remaining = MAX_LINES;
+        // A trailing newline terminates the last line rather than adding an empty one, so skip it before
+        // counting; otherwise exactly MAX_LINES lines ending in `\n` would lose their first line.
         int fromIndex = content.length();
+        while (fromIndex > 0 && content.charAt(fromIndex - 1) == '\n') {
+            fromIndex--;
+        }
+
+        // Walk back across MAX_LINES line terminators; fromIndex ends at the oldest newline to cut before,
+        // and the loop returns early (keeping everything) when there are fewer lines than the limit.
+        int remaining = MAX_LINES;
         while (remaining-- > 0) {
             int index = content.lastIndexOf('\n', fromIndex - 1);
             if (index < 0) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/McLogsUploader.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/McLogsUploader.java
@@ -1,0 +1,160 @@
+/*
+ * Hello Minecraft! Launcher
+ * Copyright (C) 2026 huangyuhui <huanghongxun2008@126.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.jackhuang.hmcl.game;
+
+import com.google.gson.JsonObject;
+import org.jackhuang.hmcl.task.Schedulers;
+import org.jackhuang.hmcl.util.gson.JsonUtils;
+import org.jackhuang.hmcl.util.io.FileUtils;
+import org.jackhuang.hmcl.util.io.HttpRequest;
+import org.jackhuang.hmcl.util.logging.Logger;
+import org.jetbrains.annotations.NotNullByDefault;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static org.jackhuang.hmcl.util.Lang.wrap;
+import static org.jackhuang.hmcl.util.logging.Logger.LOG;
+
+/// Uploads Minecraft game logs to mclo.gs so that a crashed game log can be shared as a link.
+///
+/// mclo.gs stores a log for a limited time and adds analysis on top of it. The returned URL is
+/// intended to be copied or opened for troubleshooting.
+///
+/// @see <a href="https://mclo.gs/">mclo.gs</a>
+@NotNullByDefault
+public final class McLogsUploader {
+    private McLogsUploader() {
+    }
+
+    /// The mclo.gs "create a log" endpoint.
+    private static final String API_URL = "https://api.mclo.gs/1/log";
+
+    /// Identifier of this application, sent alongside every uploaded log.
+    private static final String SOURCE = "HMCL";
+
+    /// Maximum uploaded line count, mirroring the server-side `limit-lines` filter.
+    private static final int MAX_LINES = 25_000;
+
+    /// Maximum uploaded size in bytes, mirroring the server-side `limit-bytes` filter (10 MiB).
+    private static final int MAX_BYTES = 10 * 1024 * 1024;
+
+    /// Uploads the game log of a crashed game and resolves to the URL of the shared log.
+    ///
+    /// The log content is read from `logs/latest.log` under [runDirectory] when available, and
+    /// falls back to the launcher-collected console output ([logs]) otherwise. The content is
+    /// filtered for forbidden tokens and truncated on the client side to the mclo.gs limits.
+    ///
+    /// @param runDirectory the game run directory
+    /// @param logs         the launcher-collected console output used as fallback content
+    /// @return a future resolving to the mclo.gs URL of the uploaded log
+    public static CompletableFuture<String> uploadGameLog(Path runDirectory, List<Log> logs) {
+        return CompletableFuture.supplyAsync(wrap(() -> uploadGameLogSync(runDirectory, logs)), Schedulers.io());
+    }
+
+    private static String uploadGameLogSync(Path runDirectory, List<Log> logs) throws IOException {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("content", truncate(readGameLog(runDirectory, logs)));
+        payload.addProperty("source", SOURCE);
+
+        String responseJson = HttpRequest.POST(API_URL).json(payload).ignoreHttpCode().getString();
+        return parseResponse(responseJson);
+    }
+
+    /// Reads the game log, preferring `logs/latest.log` and falling back to the console output.
+    ///
+    /// The returned content has every known forbidden token filtered out before it leaves the machine.
+    ///
+    /// @param runDirectory the game run directory
+    /// @param logs         the launcher-collected console output
+    /// @return the game log content
+    private static String readGameLog(Path runDirectory, List<Log> logs) {
+        @Nullable String content = readLatestLog(runDirectory.resolve("logs/latest.log"));
+        if (content == null || content.isEmpty()) {
+            content = logs.stream().map(Log::getLog).collect(Collectors.joining("\n"));
+        }
+        return Logger.filterForbiddenToken(content);
+    }
+
+    /// Reads the content of `latest.log`, or `null` when it is missing or unreadable.
+    ///
+    /// @param latestLog the path to `logs/latest.log`
+    /// @return the file content, or `null` when it cannot be read
+    private static @Nullable String readLatestLog(Path latestLog) {
+        if (!Files.isReadable(latestLog)) {
+            return null;
+        }
+        try {
+            return FileUtils.readTextMaybeNativeEncoding(latestLog);
+        } catch (IOException e) {
+            LOG.warning("Failed to read the game log, falling back to the console output", e);
+            return null;
+        }
+    }
+
+    /// Truncates the log content to the mclo.gs limits while keeping the tail, where the crash details live.
+    ///
+    /// @param content the raw log content
+    /// @return the truncated log content
+    static String truncate(String content) {
+        String[] lines = content.split("\n", -1);
+        if (lines.length > MAX_LINES) {
+            content = String.join("\n", Arrays.copyOfRange(lines, lines.length - MAX_LINES, lines.length));
+        }
+
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length > MAX_BYTES) {
+            content = new String(bytes, bytes.length - MAX_BYTES, MAX_BYTES, StandardCharsets.UTF_8);
+        }
+        return content;
+    }
+
+    /// Parses the mclo.gs response into the URL of the uploaded log.
+    ///
+    /// @param responseJson the raw response body
+    /// @return the mclo.gs URL of the uploaded log
+    /// @throws IOException when the upload failed or the response is malformed
+    static String parseResponse(String responseJson) throws IOException {
+        @Nullable JsonObject response = JsonUtils.fromJson(responseJson, JsonObject.class);
+        boolean success = response != null && JsonUtils.getBoolean(response, "success", false);
+        if (!success) {
+            @Nullable String error = response != null ? JsonUtils.getString(response, "error") : null;
+            throw new IOException("mclo.gs upload failed" + (error != null ? ": " + error : ""));
+        }
+
+        @Nullable String url = response != null ? JsonUtils.getString(response, "url") : null;
+        if (url != null) {
+            return url;
+        }
+
+        // The "url" field is part of the documented response; fall back to building it from the id.
+        @Nullable String id = response != null ? JsonUtils.getString(response, "id") : null;
+        if (id != null) {
+            return "https://mclo.gs/" + id;
+        }
+
+        throw new IOException("mclo.gs upload failed: the response contains no log URL");
+    }
+}

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/GameCrashWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/GameCrashWindow.java
@@ -300,6 +300,37 @@ public class GameCrashWindow extends Stage {
                 }).thenApply(ignored -> logFile);
     }
 
+    /// Uploads the game log of the crashed game to mclo.gs and shows the resulting link.
+    ///
+    /// @param uploadButtonPane the spinner pane wrapping the upload button, toggled while uploading
+    private void uploadGameLogToMcLogs(SpinnerPane uploadButtonPane) {
+        uploadButtonPane.showSpinner();
+        McLogsUploader.uploadGameLog(gameInstance.getRunDirectory(), logs).whenCompleteAsync((url, exception) -> {
+            uploadButtonPane.hideSpinner();
+
+            if (exception == null) {
+                var dialog = new MessageDialogPane.Builder(
+                        i18n("game.crash.upload_mclogs.success"),
+                        i18n("message.success"),
+                        MessageDialogPane.MessageType.SUCCESS)
+                        .addHyperLink(url, url)
+                        .addAction(i18n("button.copy"), () -> FXUtils.copyText(url))
+                        .ok(null)
+                        .build();
+                DialogUtils.show(stackPane, dialog);
+            } else {
+                LOG.warning("Failed to upload the game log to mclo.gs", exception);
+                var dialog = new MessageDialogPane.Builder(
+                        i18n("game.crash.upload_mclogs.failed") + "\n" + StringUtils.getStackTrace(exception),
+                        i18n("message.error"),
+                        MessageDialogPane.MessageType.ERROR)
+                        .ok(null)
+                        .build();
+                DialogUtils.show(stackPane, dialog);
+            }
+        }, Schedulers.javafx());
+    }
+
     private final class View extends VBox {
 
         View() {
@@ -455,6 +486,13 @@ public class GameCrashWindow extends Stage {
                     }, Schedulers.javafx());
                 });
 
+                SpinnerPane uploadButtonPane = new SpinnerPane();
+                uploadButtonPane.getStyleClass().add("small-spinner-pane");
+
+                JFXButton uploadButton = FXUtils.newRaisedButton(i18n("game.crash.upload_mclogs"));
+                uploadButtonPane.setContent(uploadButton);
+                uploadButton.setOnAction(e -> uploadGameLogToMcLogs(uploadButtonPane));
+
                 JFXButton logButton = FXUtils.newRaisedButton(i18n("logwindow.title"));
                 logButton.setOnAction(e -> showLogWindow());
 
@@ -465,7 +503,7 @@ public class GameCrashWindow extends Stage {
                 toolBar.setPadding(new Insets(8));
                 toolBar.setSpacing(8);
                 toolBar.getStyleClass().add("jfx-tool-bar");
-                toolBar.getChildren().setAll(exportButtonPane, logButton, helpButton);
+                toolBar.getChildren().setAll(exportButtonPane, uploadButtonPane, logButton, helpButton);
             }
 
             getChildren().setAll(titlePane, infoPane, moddedPane, gameDirPane, toolBar);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/GameCrashWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/GameCrashWindow.java
@@ -304,6 +304,9 @@ public class GameCrashWindow extends Stage {
     ///
     /// @param uploadButtonPane the spinner pane wrapping the upload button, toggled while uploading
     private void uploadGameLogToMcLogs(SpinnerPane uploadButtonPane) {
+        if (uploadButtonPane.isLoading()) {
+            return;
+        }
         uploadButtonPane.showSpinner();
         McLogsUploader.uploadGameLog(gameInstance.getRunDirectory(), logs).whenCompleteAsync((url, exception) -> {
             uploadButtonPane.hideSpinner();

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -721,6 +721,9 @@ game.crash.reason.unsatisfied_link_error=Failed to launch Minecraft because of m
    \n\
    Otherwise, if you believe this is caused by HMCL, please provide feedback to us.
 game.crash.title=Game Crashed
+game.crash.upload_mclogs=Upload to mclo.gs
+game.crash.upload_mclogs.failed=Failed to upload the game log to mclo.gs.
+game.crash.upload_mclogs.success=The game log has been uploaded to mclo.gs. You can open or copy the link below to share it.
 game.directory=Game Path
 game.version=Game Instance
 

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -533,6 +533,9 @@ game.crash.reason.too_old_java=目前遊戲由於 Java 版本過低，無法繼�
 game.crash.reason.unknown=原因未知。請點擊日誌按鈕查看詳細訊息。
 game.crash.reason.unsatisfied_link_error=目前遊戲由於缺少本機庫，無法繼續執行。\n這些本機庫缺失：%1$s。\n如果你在「(全域/實例特定) 遊戲設定 → 進階設定」中修改了本機庫路徑選項，請你修改回預設模式。\n如果你正在使用預設模式，請檢查遊戲目錄路徑是否只包含英文字母、數字和底線。\n如果是，那麼請檢查是否為模組或 HMCL 引起的本機庫缺失的問題。如果你確定是 HMCL 引起的，建議你向我們回報。\n<b>對於 Windows 使用者，你還可以嘗試在「控制台 → 時鐘和區域 → 地區 → 系統管理 → 變更系統區域設定」中，關閉「Beta：使用 Unicode UTF-8 提供全球語言支援」選項；</b>\n<b>或將遊戲目錄路徑中的所有非英文字母的名稱 (例如中文、空格等) 修改為英文字母。</b>\n如果你確實需要自訂本機庫路徑，你需要保證其中包含缺失的本機庫！
 game.crash.title=遊戲意外退出
+game.crash.upload_mclogs=上傳至 mclo.gs
+game.crash.upload_mclogs.failed=上傳遊戲日誌至 mclo.gs 失敗。
+game.crash.upload_mclogs.success=遊戲日誌已上傳至 mclo.gs。你可以開啟或複製下方的連結進行分享。
 game.directory=遊戲目錄路徑
 game.version=遊戲實例
 

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -539,6 +539,9 @@ game.crash.reason.too_old_java=当前游戏由于 Java 版本过低，无法继�
 game.crash.reason.unknown=原因未知。请点击日志按钮查看详细信息。
 game.crash.reason.unsatisfied_link_error=当前游戏由于缺少本地库，无法继续运行。\n这些本地库缺失：%1$s。\n如果你在“(全局/实例特定) 游戏设置 → 高级设置”中修改了本地库路径选项，请你修改回默认模式。\n如果你正在使用默认模式，请检查游戏文件夹路径是否只包含英文字母、数字和下划线。\n如果是，那么请检查是否为模组或 HMCL 导致了本地库缺失的问题。如果你确定是 HMCL 引起的，建议你向我们反馈。\n<b>对于 Windows 用户，你还可以尝试在“控制面板 → 时钟和区域 → 区域 → 管理 → 更改系统区域设置”中将“当前系统区域设置”修改为“中文(简体，中国大陆)”，并关闭“Beta 版：使用 Unicode UTF-8 提供全球语言支持”选项；</b>\n<b>或将游戏文件夹路径中的所有非英文字符的名称 (例如中文、空格等) 修改为英文字符。</b>\n如果你确实需要自定义本地库路径，你需要保证其中包含缺失的本地库！
 game.crash.title=游戏意外退出
+game.crash.upload_mclogs=上传至 mclo.gs
+game.crash.upload_mclogs.failed=上传游戏日志至 mclo.gs 失败。
+game.crash.upload_mclogs.success=游戏日志已上传至 mclo.gs。你可以打开或复制下方的链接进行分享。
 game.directory=游戏文件夹路径
 game.version=游戏实例
 

--- a/HMCL/src/test/java/org/jackhuang/hmcl/game/McLogsUploaderTest.java
+++ b/HMCL/src/test/java/org/jackhuang/hmcl/game/McLogsUploaderTest.java
@@ -372,16 +372,17 @@ public final class McLogsUploaderTest {
     }
 
     /// Verifies that the byte limit keeps the tail of an over-long single line, since no line start is
-    /// available within the read range, and that the very end of the line is preserved.
+    /// available within the read range, and that the very end of the line is preserved. The 20 MiB line is
+    /// sparse, so the test stays cheap while still exercising a logical single line well over the limit.
     @Test
     public void readsTailOfSingleOversizedLine(@TempDir Path tempDir) throws IOException {
         int maxBytes = 10 * 1024 * 1024;
         Path file = tempDir.resolve("single-long-line.log");
         String marker = "TAIL-MARKER";
-        byte[] line = new byte[20 * 1024 * 1024];
-        Arrays.fill(line, (byte) 'A');
-        Files.write(file, line);
-        Files.write(file, marker.getBytes(UTF_8), StandardOpenOption.APPEND);
+        try (FileChannel channel = FileChannel.open(file, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+            channel.position(20L * 1024 * 1024);
+            channel.write(ByteBuffer.wrap(marker.getBytes(UTF_8)));
+        }
 
         String tail = FileUtils.readTextTailMaybeNativeEncoding(file, maxBytes);
 
@@ -389,14 +390,14 @@ public final class McLogsUploaderTest {
         assertTrue(tail.endsWith(marker));
     }
 
-    /// Verifies that an over-long single line of multi-byte characters still keeps the file end without
-    /// producing invalid UTF-8.
+    /// Verifies that an over-long single line of mixed multi-byte characters (CJK + emoji) still keeps the
+    /// file end without producing invalid UTF-8.
     @Test
     public void readsTailOfOversizedMultibyteLineWithMarker(@TempDir Path tempDir) throws IOException {
         int maxBytes = 1024;
         Path file = tempDir.resolve("multibyte-long-line.log");
         String marker = "TAIL-MARKER";
-        byte[] line = "你".repeat(8 * maxBytes).getBytes(UTF_8); // 3 bytes per char, well over the limit
+        byte[] line = "你日😀".repeat(2048).getBytes(UTF_8); // 3+3+4 bytes per unit, well over the limit
         try (OutputStream out = Files.newOutputStream(file)) {
             out.write(line);
             out.write(marker.getBytes(UTF_8));
@@ -527,6 +528,48 @@ public final class McLogsUploaderTest {
         assertEquals("line-1", result[0]);               // "first-line" was dropped
         assertEquals("line-25000", result[result.length - 2]);
         assertTrue(result[result.length - 1].isEmpty()); // trailing newline is not a phantom line
+    }
+
+    /// Verifies that only one trailing newline is ignored; consecutive trailing newlines keep their empty
+    /// lines instead of being swallowed.
+    @Test
+    public void preservesConsecutiveTrailingNewlines() {
+        assertEquals("a\n\n", McLogsUploader.truncate("a\n\n"));
+        assertEquals("a\n\n\n", McLogsUploader.truncate("a\n\n\n"));
+    }
+
+    /// Verifies that trailing empty lines count towards the line limit, so the oldest real line is dropped
+    /// first while the newest empty lines are kept.
+    @Test
+    public void trailingEmptyLinesCountTowardsLineLimit() {
+        // 24,999 real lines + 2 trailing newlines = 25,000 lines; everything fits.
+        assertEquals(shortLog(24_999) + "\n\n", McLogsUploader.truncate(shortLog(24_999) + "\n\n"));
+
+        // 25,000 real lines + 2 trailing newlines = 25,001 lines; the oldest real line is dropped.
+        String result = McLogsUploader.truncate(shortLog(25_000) + "\n\n");
+        assertTrue(result.startsWith("line-1\n"));
+        assertTrue(result.endsWith("\n\n"));
+        assertFalse(result.contains("first-line"));
+        assertTrue(result.contains("line-24999"));
+    }
+
+    /// Verifies that non-positive byte limits are rejected before any file I/O.
+    @Test
+    public void rejectsNonPositiveMaxBytes(@TempDir Path tempDir) {
+        Path file = tempDir.resolve("any.log");
+        assertThrows(IllegalArgumentException.class,
+                () -> FileUtils.readTextTailMaybeNativeEncoding(file, 0));
+        assertThrows(IllegalArgumentException.class,
+                () -> FileUtils.readTextTailMaybeNativeEncoding(file, -1));
+    }
+
+    /// Verifies that a byte limit that would overflow the guard addition is rejected, so it can never turn
+    /// into a negative array length.
+    @Test
+    public void rejectsMaxBytesThatWouldOverflowGuard(@TempDir Path tempDir) {
+        Path file = tempDir.resolve("any.log");
+        assertThrows(IllegalArgumentException.class,
+                () -> FileUtils.readTextTailMaybeNativeEncoding(file, Integer.MAX_VALUE));
     }
 
     /// Builds a log with [lines] short lines, so the byte limit never kicks in. The first line is named

--- a/HMCL/src/test/java/org/jackhuang/hmcl/game/McLogsUploaderTest.java
+++ b/HMCL/src/test/java/org/jackhuang/hmcl/game/McLogsUploaderTest.java
@@ -17,12 +17,18 @@
  */
 package org.jackhuang.hmcl.game;
 
+import org.jackhuang.hmcl.util.io.FileUtils;
 import org.jetbrains.annotations.NotNullByDefault;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
 
 /// Tests for the mclo.gs log uploader's pure client-side logic.
@@ -34,6 +40,18 @@ public final class McLogsUploaderTest {
         String content = "a short log";
 
         assertEquals(content, McLogsUploader.truncate(content));
+    }
+
+    /// Verifies that the byte limit keeps the tail of an oversized log.
+    @Test
+    public void keepsTailBytesOverByteLimit() {
+        String marker = "END-OF-LOG";
+        String content = "a".repeat(10 * 1024 * 1024) + marker;
+
+        String truncated = McLogsUploader.truncate(content);
+
+        assertEquals(10 * 1024 * 1024, truncated.getBytes(UTF_8).length);
+        assertTrue(truncated.endsWith(marker));
     }
 
     /// Verifies that the line limit keeps the tail, where the crash details live.
@@ -52,16 +70,127 @@ public final class McLogsUploaderTest {
         assertEquals("line " + (all.length - 1), result[result.length - 1]);
     }
 
-    /// Verifies that the byte limit keeps the tail of an oversized log.
+    /// Verifies that both the line and byte limits are satisfied at once while the tail is kept.
     @Test
-    public void keepsTailBytesOverByteLimit() {
-        String marker = "END-OF-LOG";
-        String content = "a".repeat(10 * 1024 * 1024) + marker;
+    public void keepsTailWhenBothLimitsAreExceeded() {
+        String line = "0123456789".repeat(60); // ~600 bytes per line
+        String[] all = new String[25_000 + 7];
+        for (int i = 0; i < all.length; i++) {
+            all[i] = line + "-line-" + i;
+        }
+
+        String truncated = McLogsUploader.truncate(String.join("\n", all));
+
+        assertTrue(truncated.getBytes(UTF_8).length <= 10 * 1024 * 1024);
+        assertTrue(truncated.split("\n", -1).length <= 25_000);
+        assertTrue(truncated.contains("-line-" + (all.length - 1)));
+    }
+
+    /// Verifies that multi-byte characters survive byte truncation intact (no replacement characters).
+    @Test
+    public void keepsMultibyteCharactersIntact() {
+        String tail = "崩溃日志" + "\uD83D\uDCDD"; // Chinese + emoji
+        String content = "a".repeat(10 * 1024 * 1024) + tail;
 
         String truncated = McLogsUploader.truncate(content);
 
-        assertEquals(10 * 1024 * 1024, truncated.getBytes(StandardCharsets.UTF_8).length);
-        assertTrue(truncated.endsWith(marker));
+        assertFalse(truncated.contains("\uFFFD"));
+        assertTrue(truncated.endsWith(tail));
+    }
+
+    /// Verifies that only the tail of an oversized file is read (the result is larger than the limit by the
+    /// alignment guard, which a whole-file-read-then-truncate implementation would never produce).
+    @Test
+    public void readsTailInsteadOfWholeFile(@TempDir Path tempDir) throws IOException {
+        int maxBytes = 1024 * 1024;
+        Path file = tempDir.resolve("large.log");
+        String marker = "TAIL-MARKER-END";
+        byte[] head = new byte[maxBytes + 64 * 1024];
+        Arrays.fill(head, (byte) 'a');
+        try (OutputStream out = Files.newOutputStream(file)) {
+            out.write(head);
+            out.write(marker.getBytes(UTF_8));
+        }
+
+        String tail = FileUtils.readTextTailMaybeNativeEncoding(file, maxBytes);
+
+        assertTrue(tail.getBytes(UTF_8).length > maxBytes);
+        assertTrue(tail.endsWith(marker));
+    }
+
+    /// Verifies that a UTF-8 multi-byte character is never split when only the tail is read.
+    @Test
+    public void neverSplitsUtf8Characters(@TempDir Path tempDir) throws IOException {
+        int maxBytes = 10_000;
+        Path file = tempDir.resolve("cjk.log");
+        byte[] cjk = "汉".repeat(10_000).getBytes(UTF_8); // 30_000 bytes, 3 bytes each
+        try (OutputStream out = Files.newOutputStream(file)) {
+            out.write(cjk);
+            out.write("-END".getBytes(UTF_8));
+        }
+
+        String tail = FileUtils.readTextTailMaybeNativeEncoding(file, maxBytes);
+
+        assertFalse(tail.contains("\uFFFD"));
+        assertTrue(tail.endsWith("-END"));
+        assertTrue(tail.startsWith("汉"));
+    }
+
+    /// Verifies that an empty file yields an empty result.
+    @Test
+    public void readsEmptyFile(@TempDir Path tempDir) throws IOException {
+        Path file = Files.createFile(tempDir.resolve("empty.log"));
+
+        assertEquals("", FileUtils.readTextTailMaybeNativeEncoding(file, 1024));
+    }
+
+    /// Verifies that a missing file raises IOException, which the uploader turns into a fallback.
+    @Test
+    public void failsOnMissingFile(@TempDir Path tempDir) {
+        Path file = tempDir.resolve("missing.log");
+
+        assertThrows(IOException.class, () -> FileUtils.readTextTailMaybeNativeEncoding(file, 1024));
+    }
+
+    /// Verifies that access and refresh token arguments are masked, wherever their value appears.
+    @Test
+    public void sanitizeMasksTokenArguments() {
+        String sanitized = McLogsUploader.sanitize(
+                "java --accessToken SECRET_VALUE_123 --version 8 && refresh_token=REFRESH_VALUE_456");
+
+        assertFalse(sanitized.contains("SECRET_VALUE_123"));
+        assertFalse(sanitized.contains("REFRESH_VALUE_456"));
+        assertTrue(sanitized.contains("<access token>"));
+    }
+
+    /// Verifies that JSON-style tokens are masked while the surrounding name is preserved.
+    @Test
+    public void sanitizeMasksJsonStyleTokens() {
+        String sanitized = McLogsUploader.sanitize("{ \"accessToken\" : \"SECRET_VALUE_123\" }");
+
+        assertFalse(sanitized.contains("SECRET_VALUE_123"));
+        assertTrue(sanitized.contains("accessToken"));
+        assertTrue(sanitized.contains("<access token>"));
+    }
+
+    /// Verifies that IPv4 addresses are masked but a trailing port remains visible.
+    @Test
+    public void sanitizeMasksIpv4Addresses() {
+        String sanitized = McLogsUploader.sanitize("Connecting to 192.168.1.1:25565");
+
+        assertFalse(sanitized.contains("192.168.1.1"));
+        assertTrue(sanitized.contains("<IPv4>:25565"));
+    }
+
+    /// Verifies that the current user's home directory is masked.
+    @Test
+    public void sanitizeMasksUserHome() {
+        String home = System.getProperty("user.home");
+
+        String sanitized = McLogsUploader.sanitize(home + "/.minecraft/logs/latest.log");
+
+        assertTrue(sanitized.contains("<user home>"));
+        assertFalse(sanitized.contains(home));
     }
 
     /// Verifies that a successful response yields the documented URL.

--- a/HMCL/src/test/java/org/jackhuang/hmcl/game/McLogsUploaderTest.java
+++ b/HMCL/src/test/java/org/jackhuang/hmcl/game/McLogsUploaderTest.java
@@ -370,4 +370,128 @@ public final class McLogsUploaderTest {
         assertThrows(IOException.class,
                 () -> McLogsUploader.parseResponse("this is not json"));
     }
+
+    /// Verifies that the byte limit keeps the tail of an over-long single line, since no line start is
+    /// available within the read range.
+    @Test
+    public void readsTailOfSingleOversizedLine(@TempDir Path tempDir) throws IOException {
+        int maxBytes = 10 * 1024 * 1024;
+        Path file = tempDir.resolve("single-long-line.log");
+        byte[] line = new byte[20 * 1024 * 1024];
+        Arrays.fill(line, (byte) 'A');
+        Files.write(file, line);
+
+        String tail = FileUtils.readTextTailMaybeNativeEncoding(file, maxBytes);
+
+        assertEquals(maxBytes, tail.getBytes(UTF_8).length);
+        assertEquals("A".repeat(maxBytes), tail);
+    }
+
+    /// Verifies that an over-long final line after normal lines is read from its tail.
+    @Test
+    public void readsTailAfterOversizedFinalLine(@TempDir Path tempDir) throws IOException {
+        int maxBytes = 1024;
+        Path file = tempDir.resolve("mixed-long-line.log");
+        try (OutputStream out = Files.newOutputStream(file)) {
+            out.write("normal line\n".repeat(400).getBytes(UTF_8));
+            byte[] longLine = new byte[8 * maxBytes];
+            Arrays.fill(longLine, (byte) 'D');
+            out.write(longLine);
+        }
+
+        String tail = FileUtils.readTextTailMaybeNativeEncoding(file, maxBytes);
+
+        assertEquals("D".repeat(maxBytes), tail);
+    }
+
+    /// Verifies that a single line exactly at the byte limit is returned in full.
+    @Test
+    public void readsSingleLineExactlyAtLimit(@TempDir Path tempDir) throws IOException {
+        int maxBytes = 1024;
+        Path file = tempDir.resolve("exact-line.log");
+        byte[] line = new byte[maxBytes];
+        Arrays.fill(line, (byte) 'B');
+        Files.write(file, line);
+
+        assertEquals("B".repeat(maxBytes), FileUtils.readTextTailMaybeNativeEncoding(file, maxBytes));
+    }
+
+    /// Verifies that a single line just over the byte limit is truncated to exactly that limit.
+    @Test
+    public void readsSingleLineJustOverLimit(@TempDir Path tempDir) throws IOException {
+        int maxBytes = 1024;
+        Path file = tempDir.resolve("over-line.log");
+        byte[] line = new byte[maxBytes + 1];
+        Arrays.fill(line, (byte) 'C');
+        Files.write(file, line);
+
+        assertEquals("C".repeat(maxBytes), FileUtils.readTextTailMaybeNativeEncoding(file, maxBytes));
+    }
+
+    /// Verifies that, when a newline follows an over-long line inside the read range, the tail starts at that
+    /// complete line instead.
+    @Test
+    public void readsCompleteLineAfterOversizedLine(@TempDir Path tempDir) throws IOException {
+        int maxBytes = 1024;
+        Path file = tempDir.resolve("long-then-line.log");
+        try (OutputStream out = Files.newOutputStream(file)) {
+            byte[] longLine = new byte[8 * maxBytes];
+            Arrays.fill(longLine, (byte) 'E');
+            out.write(longLine);
+            out.write("\nTAIL-MARKER".getBytes(UTF_8));
+        }
+
+        String tail = FileUtils.readTextTailMaybeNativeEncoding(file, maxBytes);
+
+        assertEquals("TAIL-MARKER", tail);
+    }
+
+    /// Verifies that a UTF-8 BOM in the file head never leaks into the returned tail.
+    @Test
+    public void ignoresLeadingBomInTailRead(@TempDir Path tempDir) throws IOException {
+        int maxBytes = 1024;
+        Path file = tempDir.resolve("bom.log");
+        try (OutputStream out = Files.newOutputStream(file)) {
+            out.write(new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF}); // UTF-8 BOM
+            byte[] head = new byte[maxBytes + 100];
+            Arrays.fill(head, (byte) 'A');
+            out.write(head);
+            out.write("-END".getBytes(UTF_8));
+        }
+
+        String tail = FileUtils.readTextTailMaybeNativeEncoding(file, maxBytes);
+
+        assertFalse(tail.contains("\uFEFF"));
+        assertTrue(tail.endsWith("-END"));
+    }
+
+    /// Verifies that a log just under the line limit is kept whole.
+    @Test
+    public void keepsAllLinesBelowLineLimit() {
+        assertEquals(24_999, McLogsUploader.truncate(shortLog(24_999)).split("\n", -1).length);
+    }
+
+    /// Verifies that a log exactly at the line limit is kept whole.
+    @Test
+    public void keepsLinesAtExactLineLimit() {
+        assertEquals(25_000, McLogsUploader.truncate(shortLog(25_000)).split("\n", -1).length);
+    }
+
+    /// Verifies that a log one line over the limit drops only the earliest line.
+    @Test
+    public void dropsEarliestLineJustOverLineLimit() {
+        String[] result = McLogsUploader.truncate(shortLog(25_001)).split("\n", -1);
+
+        assertEquals(25_000, result.length);
+        assertEquals("line 1", result[0]);
+    }
+
+    /// Builds a log with [lines] short lines, so the byte limit never kicks in.
+    private static String shortLog(int lines) {
+        String[] all = new String[lines];
+        for (int i = 0; i < lines; i++) {
+            all[i] = "line " + i;
+        }
+        return String.join("\n", all);
+    }
 }

--- a/HMCL/src/test/java/org/jackhuang/hmcl/game/McLogsUploaderTest.java
+++ b/HMCL/src/test/java/org/jackhuang/hmcl/game/McLogsUploaderTest.java
@@ -1,0 +1,100 @@
+/*
+ * Hello Minecraft! Launcher
+ * Copyright (C) 2026 huangyuhui <huanghongxun2008@126.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.jackhuang.hmcl.game;
+
+import org.jetbrains.annotations.NotNullByDefault;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/// Tests for the mclo.gs log uploader's pure client-side logic.
+@NotNullByDefault
+public final class McLogsUploaderTest {
+    /// Verifies that content under every limit is returned unchanged.
+    @Test
+    public void keepsShortContentUnchanged() {
+        String content = "a short log";
+
+        assertEquals(content, McLogsUploader.truncate(content));
+    }
+
+    /// Verifies that the line limit keeps the tail, where the crash details live.
+    @Test
+    public void keepsTailLinesOverLineLimit() {
+        String[] all = new String[25_000 + 7];
+        for (int i = 0; i < all.length; i++) {
+            all[i] = "line " + i;
+        }
+
+        String truncated = McLogsUploader.truncate(String.join("\n", all));
+        String[] result = truncated.split("\n", -1);
+
+        assertEquals(25_000, result.length);
+        assertEquals("line 7", result[0]);
+        assertEquals("line " + (all.length - 1), result[result.length - 1]);
+    }
+
+    /// Verifies that the byte limit keeps the tail of an oversized log.
+    @Test
+    public void keepsTailBytesOverByteLimit() {
+        String marker = "END-OF-LOG";
+        String content = "a".repeat(10 * 1024 * 1024) + marker;
+
+        String truncated = McLogsUploader.truncate(content);
+
+        assertEquals(10 * 1024 * 1024, truncated.getBytes(StandardCharsets.UTF_8).length);
+        assertTrue(truncated.endsWith(marker));
+    }
+
+    /// Verifies that a successful response yields the documented URL.
+    @Test
+    public void parsesSuccessUrl() throws IOException {
+        String url = McLogsUploader.parseResponse(
+                "{\"success\":true,\"id\":\"WnMMikq\",\"url\":\"https://mclo.gs/WnMMikq\"}");
+
+        assertEquals("https://mclo.gs/WnMMikq", url);
+    }
+
+    /// Verifies that the URL is rebuilt from the id when the url field is absent.
+    @Test
+    public void rebuildsUrlFromId() throws IOException {
+        String url = McLogsUploader.parseResponse("{\"success\":true,\"id\":\"WnMMikq\"}");
+
+        assertEquals("https://mclo.gs/WnMMikq", url);
+    }
+
+    /// Verifies that a server-side error is surfaced with its message.
+    @Test
+    public void surfacesServerError() {
+        IOException exception = assertThrows(IOException.class,
+                () -> McLogsUploader.parseResponse(
+                        "{\"success\":false,\"error\":\"Required field 'content' not found.\"}"));
+
+        assertTrue(exception.getMessage().contains("Required field 'content' not found."));
+    }
+
+    /// Verifies that a successful response without any locator field is rejected.
+    @Test
+    public void rejectsResponseWithoutUrl() {
+        assertThrows(IOException.class,
+                () -> McLogsUploader.parseResponse("{\"success\":true}"));
+    }
+}

--- a/HMCL/src/test/java/org/jackhuang/hmcl/game/McLogsUploaderTest.java
+++ b/HMCL/src/test/java/org/jackhuang/hmcl/game/McLogsUploaderTest.java
@@ -372,19 +372,41 @@ public final class McLogsUploaderTest {
     }
 
     /// Verifies that the byte limit keeps the tail of an over-long single line, since no line start is
-    /// available within the read range.
+    /// available within the read range, and that the very end of the line is preserved.
     @Test
     public void readsTailOfSingleOversizedLine(@TempDir Path tempDir) throws IOException {
         int maxBytes = 10 * 1024 * 1024;
         Path file = tempDir.resolve("single-long-line.log");
+        String marker = "TAIL-MARKER";
         byte[] line = new byte[20 * 1024 * 1024];
         Arrays.fill(line, (byte) 'A');
         Files.write(file, line);
+        Files.write(file, marker.getBytes(UTF_8), StandardOpenOption.APPEND);
 
         String tail = FileUtils.readTextTailMaybeNativeEncoding(file, maxBytes);
 
         assertEquals(maxBytes, tail.getBytes(UTF_8).length);
-        assertEquals("A".repeat(maxBytes), tail);
+        assertTrue(tail.endsWith(marker));
+    }
+
+    /// Verifies that an over-long single line of multi-byte characters still keeps the file end without
+    /// producing invalid UTF-8.
+    @Test
+    public void readsTailOfOversizedMultibyteLineWithMarker(@TempDir Path tempDir) throws IOException {
+        int maxBytes = 1024;
+        Path file = tempDir.resolve("multibyte-long-line.log");
+        String marker = "TAIL-MARKER";
+        byte[] line = "你".repeat(8 * maxBytes).getBytes(UTF_8); // 3 bytes per char, well over the limit
+        try (OutputStream out = Files.newOutputStream(file)) {
+            out.write(line);
+            out.write(marker.getBytes(UTF_8));
+        }
+
+        String tail = FileUtils.readTextTailMaybeNativeEncoding(file, maxBytes);
+
+        assertTrue(tail.getBytes(UTF_8).length <= maxBytes);
+        assertFalse(tail.contains("\uFFFD"));
+        assertTrue(tail.endsWith(marker));
     }
 
     /// Verifies that an over-long final line after normal lines is read from its tail.
@@ -483,15 +505,40 @@ public final class McLogsUploaderTest {
         String[] result = McLogsUploader.truncate(shortLog(25_001)).split("\n", -1);
 
         assertEquals(25_000, result.length);
-        assertEquals("line 1", result[0]);
+        assertEquals("line-1", result[0]);
+        assertEquals("line-25000", result[result.length - 1]);
     }
 
-    /// Builds a log with [lines] short lines, so the byte limit never kicks in.
+    /// Verifies that exactly MAX_LINES lines ending with a newline are kept whole: the trailing newline
+    /// terminates the last line rather than adding an empty one, so the first line must not be dropped.
+    @Test
+    public void keepsExactLineLimitWithTrailingNewline() {
+        String content = shortLog(25_000) + "\n";
+
+        assertEquals(content, McLogsUploader.truncate(content));
+    }
+
+    /// Verifies that one line over the limit with a trailing newline drops only the oldest line.
+    @Test
+    public void dropsOnlyOldestLineOverLimitWithTrailingNewline() {
+        String[] result = McLogsUploader.truncate(shortLog(25_001) + "\n").split("\n", -1);
+
+        assertEquals(25_001, result.length);             // 25,000 kept lines plus the empty trailing segment
+        assertEquals("line-1", result[0]);               // "first-line" was dropped
+        assertEquals("line-25000", result[result.length - 2]);
+        assertTrue(result[result.length - 1].isEmpty()); // trailing newline is not a phantom line
+    }
+
+    /// Builds a log with [lines] short lines, so the byte limit never kicks in. The first line is named
+    /// `first-line` and the rest `line-N`, so assertions never have to infer an off-by-one from `line 0`.
     private static String shortLog(int lines) {
-        String[] all = new String[lines];
+        StringBuilder builder = new StringBuilder();
         for (int i = 0; i < lines; i++) {
-            all[i] = "line " + i;
+            if (i > 0) {
+                builder.append('\n');
+            }
+            builder.append(i == 0 ? "first-line" : "line-" + i);
         }
-        return String.join("\n", all);
+        return builder.toString();
     }
 }

--- a/HMCL/src/test/java/org/jackhuang/hmcl/game/McLogsUploaderTest.java
+++ b/HMCL/src/test/java/org/jackhuang/hmcl/game/McLogsUploaderTest.java
@@ -24,8 +24,11 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -86,26 +89,45 @@ public final class McLogsUploaderTest {
         assertTrue(truncated.contains("-line-" + (all.length - 1)));
     }
 
-    /// Verifies that multi-byte characters survive byte truncation intact (no replacement characters).
+    /// Verifies that byte truncation never splits a multi-byte character, for every possible byte limit.
     @Test
-    public void keepsMultibyteCharactersIntact() {
-        String tail = "崩溃日志" + "\uD83D\uDCDD"; // Chinese + emoji
-        String content = "a".repeat(10 * 1024 * 1024) + tail;
+    public void truncateNeverProducesReplacementCharacters() {
+        String content = "é汉😀日ア" + "abcd"; // 2-byte, 3-byte and 4-byte characters mixed with ASCII
+        byte[] all = content.getBytes(UTF_8);
 
-        String truncated = McLogsUploader.truncate(content);
-
-        assertFalse(truncated.contains("\uFFFD"));
-        assertTrue(truncated.endsWith(tail));
+        for (int limit = 1; limit <= all.length; limit++) {
+            String result = FileUtils.truncateUtf8ToByteLimit(content, limit);
+            assertFalse(result.contains("\uFFFD"), "limit=" + limit);
+            assertTrue(result.getBytes(UTF_8).length <= limit, "limit=" + limit);
+        }
     }
 
-    /// Verifies that only the tail of an oversized file is read (the result is larger than the limit by the
-    /// alignment guard, which a whole-file-read-then-truncate implementation would never produce).
+    /// Verifies that a file smaller than the limit is read in full.
     @Test
-    public void readsTailInsteadOfWholeFile(@TempDir Path tempDir) throws IOException {
-        int maxBytes = 1024 * 1024;
-        Path file = tempDir.resolve("large.log");
-        String marker = "TAIL-MARKER-END";
-        byte[] head = new byte[maxBytes + 64 * 1024];
+    public void readsWholeFileWhenSmall(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("small.log");
+        Files.write(file, "hello log".getBytes(UTF_8));
+
+        assertEquals("hello log", FileUtils.readTextTailMaybeNativeEncoding(file, 1024));
+    }
+
+    /// Verifies that a file exactly at the limit is read in full.
+    @Test
+    public void readsFileExactlyAtLimit(@TempDir Path tempDir) throws IOException {
+        int maxBytes = 1024;
+        Path file = tempDir.resolve("exact.log");
+        Files.write(file, "a".repeat(maxBytes).getBytes(UTF_8));
+
+        assertEquals("a".repeat(maxBytes), FileUtils.readTextTailMaybeNativeEncoding(file, maxBytes));
+    }
+
+    /// Verifies that a file larger than the limit keeps its tail within the byte limit.
+    @Test
+    public void readsTailWhenLargerThanLimit(@TempDir Path tempDir) throws IOException {
+        int maxBytes = 1024;
+        String marker = "END-MARKER";
+        Path file = tempDir.resolve("medium.log");
+        byte[] head = new byte[maxBytes + 512];
         Arrays.fill(head, (byte) 'a');
         try (OutputStream out = Files.newOutputStream(file)) {
             out.write(head);
@@ -114,95 +136,210 @@ public final class McLogsUploaderTest {
 
         String tail = FileUtils.readTextTailMaybeNativeEncoding(file, maxBytes);
 
-        assertTrue(tail.getBytes(UTF_8).length > maxBytes);
+        assertTrue(tail.getBytes(UTF_8).length <= maxBytes);
         assertTrue(tail.endsWith(marker));
     }
 
-    /// Verifies that a UTF-8 multi-byte character is never split when only the tail is read.
+    /// Verifies that a 100 MiB file is read by seeking to its tail instead of loading it whole.
     @Test
-    public void neverSplitsUtf8Characters(@TempDir Path tempDir) throws IOException {
-        int maxBytes = 10_000;
-        Path file = tempDir.resolve("cjk.log");
-        byte[] cjk = "汉".repeat(10_000).getBytes(UTF_8); // 30_000 bytes, 3 bytes each
-        try (OutputStream out = Files.newOutputStream(file)) {
-            out.write(cjk);
-            out.write("-END".getBytes(UTF_8));
+    public void readsTailOfLargeFileBySeeking(@TempDir Path tempDir) throws IOException {
+        int maxBytes = 1024 * 1024;
+        String marker = "CRASH-AT-END";
+        Path file = tempDir.resolve("sparse.log");
+        try (FileChannel channel = FileChannel.open(file, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+            channel.position(100L * 1024 * 1024);
+            channel.write(ByteBuffer.wrap(marker.getBytes(UTF_8)));
         }
 
         String tail = FileUtils.readTextTailMaybeNativeEncoding(file, maxBytes);
 
-        assertFalse(tail.contains("\uFFFD"));
-        assertTrue(tail.endsWith("-END"));
-        assertTrue(tail.startsWith("汉"));
+        assertTrue(tail.getBytes(UTF_8).length <= maxBytes);
+        assertTrue(tail.endsWith(marker));
     }
 
-    /// Verifies that an empty file yields an empty result.
+    /// Verifies that an empty file reads as an empty string.
     @Test
     public void readsEmptyFile(@TempDir Path tempDir) throws IOException {
-        Path file = Files.createFile(tempDir.resolve("empty.log"));
+        Path file = tempDir.resolve("empty.log");
+        Files.write(file, new byte[0]);
 
         assertEquals("", FileUtils.readTextTailMaybeNativeEncoding(file, 1024));
     }
 
-    /// Verifies that a missing file raises IOException, which the uploader turns into a fallback.
+    /// Verifies that a missing file surfaces an exception rather than crashing.
     @Test
     public void failsOnMissingFile(@TempDir Path tempDir) {
-        Path file = tempDir.resolve("missing.log");
-
-        assertThrows(IOException.class, () -> FileUtils.readTextTailMaybeNativeEncoding(file, 1024));
+        assertThrows(IOException.class,
+                () -> FileUtils.readTextTailMaybeNativeEncoding(tempDir.resolve("missing.log"), 1024));
     }
 
-    /// Verifies that access and refresh token arguments are masked, wherever their value appears.
+    /// Verifies that a UTF-8 cut in the middle of a 3-byte character is aligned to a character boundary.
+    @Test
+    public void neverSplitsUtf8Characters(@TempDir Path tempDir) throws IOException {
+        int maxBytes = 10_000;
+        Path file = tempDir.resolve("chinese.log");
+        Files.write(file, ("汉".repeat(10_000) + "-END").getBytes(UTF_8));
+
+        String tail = FileUtils.readTextTailMaybeNativeEncoding(file, maxBytes);
+
+        assertTrue(tail.getBytes(UTF_8).length <= maxBytes);
+        assertFalse(tail.contains("\uFFFD"));
+        assertTrue(tail.startsWith("汉"));
+        assertTrue(tail.endsWith("-END"));
+    }
+
+    /// Verifies that the tail never opens with a truncated first line.
+    @Test
+    public void dropsTruncatedLeadingLine(@TempDir Path tempDir) throws IOException {
+        int maxBytes = 1024;
+        Path file = tempDir.resolve("lines.log");
+        byte[] head = "skipped-partial-line-".repeat(200).getBytes(UTF_8); // no newline
+        String tailContent = "\nCOMPLETE-LINE-1\nCOMPLETE-LINE-2";
+        try (OutputStream out = Files.newOutputStream(file)) {
+            out.write(head);
+            out.write(tailContent.getBytes(UTF_8));
+        }
+
+        String tail = FileUtils.readTextTailMaybeNativeEncoding(file, maxBytes);
+
+        assertTrue(tail.startsWith("COMPLETE-LINE-1"));
+        assertTrue(tail.endsWith("COMPLETE-LINE-2"));
+    }
+
+    /// Verifies that credentials in command-line argument form have their values masked.
     @Test
     public void sanitizeMasksTokenArguments() {
-        String sanitized = McLogsUploader.sanitize(
-                "java --accessToken SECRET_VALUE_123 --version 8 && refresh_token=REFRESH_VALUE_456");
+        String content = String.join("\n",
+                "--accessToken abc123",
+                "--refresh_token refresh456",
+                "--clientToken client789",
+                "--session-token sessionABC");
 
-        assertFalse(sanitized.contains("SECRET_VALUE_123"));
-        assertFalse(sanitized.contains("REFRESH_VALUE_456"));
-        assertTrue(sanitized.contains("<access token>"));
+        String sanitized = McLogsUploader.sanitize(content);
+
+        assertFalse(sanitized.contains("abc123"));
+        assertFalse(sanitized.contains("refresh456"));
+        assertFalse(sanitized.contains("client789"));
+        assertFalse(sanitized.contains("sessionABC"));
+        assertTrue(sanitized.contains("--accessToken <access token>"));
     }
 
-    /// Verifies that JSON-style tokens are masked while the surrounding name is preserved.
+    /// Verifies that credentials in JSON form have their values masked, with and without surrounding spaces.
     @Test
     public void sanitizeMasksJsonStyleTokens() {
-        String sanitized = McLogsUploader.sanitize("{ \"accessToken\" : \"SECRET_VALUE_123\" }");
+        String content = "{\"accessToken\":\"SECRET_TOKEN_1\",\"refreshToken\" : \"SECRET_TOKEN_2\"}";
 
-        assertFalse(sanitized.contains("SECRET_VALUE_123"));
-        assertTrue(sanitized.contains("accessToken"));
-        assertTrue(sanitized.contains("<access token>"));
+        String sanitized = McLogsUploader.sanitize(content);
+
+        assertFalse(sanitized.contains("SECRET_TOKEN_1"));
+        assertFalse(sanitized.contains("SECRET_TOKEN_2"));
+        assertTrue(sanitized.contains("\"accessToken\":\"<access token>\""));
+        assertTrue(sanitized.contains("\"refreshToken\" : \"<access token>\""));
     }
 
-    /// Verifies that IPv4 addresses are masked but a trailing port remains visible.
+    /// Verifies that `authToken` and its hyphenated/underscored variants are masked.
+    @Test
+    public void sanitizeMasksAuthToken() {
+        String content = "authToken=ghp_S3cr3t\n--auth_token tkn123\n\"auth-token\": \"tkn-456\"";
+
+        String sanitized = McLogsUploader.sanitize(content);
+
+        assertFalse(sanitized.contains("ghp_S3cr3t"));
+        assertFalse(sanitized.contains("tkn123"));
+        assertFalse(sanitized.contains("tkn-456"));
+        assertTrue(sanitized.contains("authToken=<access token>"));
+    }
+
+    /// Verifies that valid IPv4 addresses are masked while keeping a trailing port.
     @Test
     public void sanitizeMasksIpv4Addresses() {
-        String sanitized = McLogsUploader.sanitize("Connecting to 192.168.1.1:25565");
+        String sanitized = McLogsUploader.sanitize(
+                "Connecting to 192.168.1.1:25565 and 127.0.0.1 and 255.255.255.255");
 
         assertFalse(sanitized.contains("192.168.1.1"));
+        assertFalse(sanitized.contains("127.0.0.1"));
+        assertFalse(sanitized.contains("255.255.255.255"));
         assertTrue(sanitized.contains("<IPv4>:25565"));
     }
 
-    /// Verifies that the current user's home directory is masked.
+    /// Verifies that invalid dotted numbers and unrelated dotted versions are left untouched.
+    @Test
+    public void sanitizeDoesNotTouchInvalidIpv4() {
+        String content = "256.1.1.1 and 1.2.3.999 and version 1.20.4";
+
+        String sanitized = McLogsUploader.sanitize(content);
+
+        assertTrue(sanitized.contains("256.1.1.1"));
+        assertTrue(sanitized.contains("1.2.3.999"));
+        assertTrue(sanitized.contains("1.20.4"));
+    }
+
+    /// Verifies that IPv6 addresses in full and compressed form are masked.
+    @Test
+    public void sanitizeMasksIpv6Addresses() {
+        String[] addresses = {"::1", "fe80::1", "2001:db8::1", "2001:db8:1234:5678::abcd"};
+
+        for (String address : addresses) {
+            String sanitized = McLogsUploader.sanitize("Connecting to [" + address + "]:25565");
+            assertFalse(sanitized.contains(address), address);
+            assertTrue(sanitized.contains("<IPv6>]:25565"), address);
+        }
+    }
+
+    /// Verifies that a MAC address, which is also colon-separated hex, is not mistaken for IPv6.
+    @Test
+    public void sanitizeDoesNotTouchMacAddress() {
+        String mac = "00:1A:2B:3C:4D:5E";
+
+        String sanitized = McLogsUploader.sanitize("Shaders: device " + mac);
+
+        assertTrue(sanitized.contains(mac));
+    }
+
+    /// Verifies that the current user's home directory, in either slash style, is masked.
     @Test
     public void sanitizeMasksUserHome() {
-        String home = System.getProperty("user.home");
+        String home = System.getProperty("user.home", "");
+        String content = home + "/.minecraft/logs/latest.log";
 
-        String sanitized = McLogsUploader.sanitize(home + "/.minecraft/logs/latest.log");
+        String sanitized = McLogsUploader.sanitize(content);
 
-        assertTrue(sanitized.contains("<user home>"));
         assertFalse(sanitized.contains(home));
+        assertTrue(sanitized.contains("<user home>"));
     }
 
-    /// Verifies that a successful response yields the documented URL.
+    /// Verifies that Unix-style paths are compared case-sensitively, so a sibling directory is kept intact.
+    @Test
+    public void redactPathVariantIsCaseSensitiveForUnix() {
+        assertEquals("<user home>/.minecraft",
+                McLogsUploader.redactPathVariant("/home/alice/.minecraft", "/home/alice", false));
+        assertEquals("/home/Alice/.minecraft",
+                McLogsUploader.redactPathVariant("/home/Alice/.minecraft", "/home/alice", false));
+    }
+
+    /// Verifies that Windows-style paths are compared case-insensitively.
+    @Test
+    public void redactPathVariantIsCaseInsensitiveForWindows() {
+        assertEquals("<user home>/.minecraft",
+                McLogsUploader.redactPathVariant("/home/Alice/.minecraft", "/home/alice", true));
+    }
+
+    /// Verifies that a macOS home directory style is supported.
+    @Test
+    public void redactPathVariantCoversMacOsHome() {
+        assertEquals("<user home>/Library/Application Support",
+                McLogsUploader.redactPathVariant("/Users/alice/Library/Application Support", "/Users/alice", false));
+    }
+
+    /// Verifies that a successful response returns the URL it contains.
     @Test
     public void parsesSuccessUrl() throws IOException {
-        String url = McLogsUploader.parseResponse(
-                "{\"success\":true,\"id\":\"WnMMikq\",\"url\":\"https://mclo.gs/WnMMikq\"}");
+        String url = McLogsUploader.parseResponse("{\"success\":true,\"url\":\"https://mclo.gs/abcd\"}");
 
-        assertEquals("https://mclo.gs/WnMMikq", url);
+        assertEquals("https://mclo.gs/abcd", url);
     }
 
-    /// Verifies that the URL is rebuilt from the id when the url field is absent.
+    /// Verifies that a successful response without an explicit URL falls back to the id.
     @Test
     public void rebuildsUrlFromId() throws IOException {
         String url = McLogsUploader.parseResponse("{\"success\":true,\"id\":\"WnMMikq\"}");
@@ -225,5 +362,12 @@ public final class McLogsUploaderTest {
     public void rejectsResponseWithoutUrl() {
         assertThrows(IOException.class,
                 () -> McLogsUploader.parseResponse("{\"success\":true}"));
+    }
+
+    /// Verifies that a malformed response body is treated as a failure instead of crashing.
+    @Test
+    public void treatsMalformedJsonAsFailure() {
+        assertThrows(IOException.class,
+                () -> McLogsUploader.parseResponse("this is not json"));
     }
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/FileUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/FileUtils.java
@@ -27,6 +27,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
@@ -246,6 +247,9 @@ public final class FileUtils {
     /// character boundary (UTF-8 uses at most 4 bytes per character).
     private static final int TAIL_GUARD_BYTES = 16;
 
+    /// How many leading bytes to sample when detecting the charset of a large file.
+    private static final int CHARSET_SAMPLE_BYTES = 8192;
+
     /// Reads the whole file and decodes it with HMCL's charset-detection rules.
     public static String readTextMaybeNativeEncoding(Path file) throws IOException {
         byte[] bytes = Files.readAllBytes(file);
@@ -254,24 +258,38 @@ public final class FileUtils {
 
     /// Reads at most the last [maxBytes] bytes of [file], decoded with HMCL's charset-detection rules.
     ///
-    /// Unlike {@link #readTextMaybeNativeEncoding(Path)}, a file larger than [maxBytes] is never read into
-    /// memory in full: only the tail is read, and the returned content stays within a few bytes of
-    /// [maxBytes]. The cut is aligned to a character boundary whenever the content is detected as UTF-8, so
-    /// multi-byte characters (CJK, emoji, ...) are never split into invalid sequences.
+    /// A file larger than [maxBytes] is never read into memory in full: the charset is detected from a small
+    /// head sample, then only the tail is read by seeking straight to its offset. The returned text is
+    /// guaranteed to be at most [maxBytes] bytes after re-encoding with the detected charset, never starts in
+    /// the middle of a multi-byte character or a line, and always keeps the very end of the file.
     ///
     /// @param file     the file to read from
     /// @param maxBytes the maximum number of bytes to keep from the tail; must be non-negative
-    /// @return the decoded tail content
+    /// @return the decoded tail content, at most [maxBytes] bytes long
     /// @throws IOException if the file cannot be read
     public static String readTextTailMaybeNativeEncoding(Path file, long maxBytes) throws IOException {
         long size = Files.size(file);
         if (size <= maxBytes)
             return readTextMaybeNativeEncoding(file);
 
+        Charset charset = detectCharset(readHead(file));
         byte[] tail = readTailBytes(file, size, maxBytes);
-        Charset charset = detectCharset(tail);
-        int leading = leadingCharacterBoundary(tail, charset);
-        return new String(tail, leading, tail.length - leading, charset);
+
+        int start = alignToCharacterBoundary(tail, charset);
+        start = alignToLineStart(tail, start);
+
+        String content = new String(tail, start, tail.length - start, charset);
+        return trimTailToByteLimit(content, charset, (int) maxBytes);
+    }
+
+    /// Truncates [content] so its UTF-8 encoding fits within [maxBytes], keeping the tail and never splitting
+    /// a multi-byte character.
+    ///
+    /// @param content  the text to truncate
+    /// @param maxBytes the UTF-8 byte limit
+    /// @return [content], truncated to at most [maxBytes] UTF-8 bytes
+    public static String truncateUtf8ToByteLimit(String content, int maxBytes) {
+        return trimTailToByteLimit(content, UTF_8, maxBytes);
     }
 
     /// Detects the charset of [bytes] using the same heuristics used by the text readers.
@@ -292,8 +310,19 @@ public final class FileUtils {
             return OperatingSystem.NATIVE_CHARSET;
     }
 
-    /// Reads the last bytes of a file larger than [maxBytes], keeping a small guard so a UTF-8 cut can later
-    /// be aligned to a character boundary.
+    /// Reads a small head sample of [file] for charset detection.
+    ///
+    /// @param file the file to sample
+    /// @return the leading bytes of [file]
+    /// @throws IOException if the file cannot be read
+    private static byte[] readHead(Path file) throws IOException {
+        try (InputStream input = Files.newInputStream(file)) {
+            return input.readNBytes(CHARSET_SAMPLE_BYTES);
+        }
+    }
+
+    /// Reads the last bytes of a file larger than [maxBytes] via random access, keeping a small guard so a
+    /// UTF-8 cut can later be aligned to a character boundary.
     ///
     /// @param file     the file to read from
     /// @param size     the size of the file, obtained upfront
@@ -305,29 +334,27 @@ public final class FileUtils {
         int length = (int) Math.min(size - offset, maxBytes + TAIL_GUARD_BYTES);
         byte[] tail = new byte[length];
 
-        try (InputStream input = Files.newInputStream(file)) {
-            IOUtils.skipNBytes(input, offset);
-            int read = 0;
-            while (read < length) {
-                int n = input.read(tail, read, length - read);
-                if (n < 0)
+        try (FileChannel channel = FileChannel.open(file, StandardOpenOption.READ)) {
+            channel.position(offset);
+            ByteBuffer buffer = ByteBuffer.wrap(tail);
+            while (buffer.hasRemaining()) {
+                if (channel.read(buffer) < 0)
                     break;
-                read += n;
             }
+            int read = buffer.position();
             return read == length ? tail : Arrays.copyOf(tail, read);
         }
     }
 
-    /// Returns the index within the guard window that starts on a character boundary.
+    /// Returns the smallest index within the guard window that starts on a character boundary.
     ///
     /// UTF-8 boundary bytes never start with `10xxxxxx`, so continuation bytes are skipped. Other charsets
-    /// are probed with a strict decoder; if none decodes cleanly the method falls back to `0` and a single
-    /// replacement character may appear (a rare native-encoding case).
+    /// are probed with a strict decoder over the leading window.
     ///
     /// @param bytes   the bytes to align
     /// @param charset the charset to decode with
     /// @return the leading offset that keeps the first character intact
-    private static int leadingCharacterBoundary(byte[] bytes, Charset charset) {
+    private static int alignToCharacterBoundary(byte[] bytes, Charset charset) {
         int limit = Math.min(TAIL_GUARD_BYTES, bytes.length);
         if (charset == UTF_8) {
             int index = 0;
@@ -349,6 +376,57 @@ public final class FileUtils {
             }
         }
         return 0;
+    }
+
+    /// Skips to the start of the next line so the returned tail never opens with a truncated first line.
+    ///
+    /// @param bytes the tail bytes
+    /// @param start the first character boundary
+    /// @return the offset of the first byte of a complete line
+    private static int alignToLineStart(byte[] bytes, int start) {
+        for (int i = start; i < bytes.length; i++) {
+            if (bytes[i] == '\n')
+                return i + 1;
+        }
+        return start;
+    }
+
+    /// Truncates [content] so its [charset] encoding fits within [maxBytes], keeping the tail and never
+    /// splitting a multi-byte character.
+    ///
+    /// @param content  the decoded content
+    /// @param charset  the charset [content] was decoded with
+    /// @param maxBytes the byte limit
+    /// @return [content], truncated to at most [maxBytes] bytes
+    private static String trimTailToByteLimit(String content, Charset charset, int maxBytes) {
+        byte[] bytes = content.getBytes(charset);
+        if (bytes.length <= maxBytes) {
+            return content;
+        }
+
+        int start = bytes.length - maxBytes;
+        if (charset == UTF_8) {
+            while (start < bytes.length && (bytes[start] & 0xC0) == 0x80)
+                start++;
+            return new String(bytes, start, bytes.length - start, UTF_8);
+        }
+
+        // Non-UTF-8 native encodings are rare; align with a strict decoder over the small over-run window so
+        // a multi-byte character is never split in two.
+        CharsetDecoder decoder = charset.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT);
+        int limit = Math.min(bytes.length, start + TAIL_GUARD_BYTES);
+        for (int index = start; index <= limit; index++) {
+            try {
+                decoder.reset();
+                decoder.decode(ByteBuffer.wrap(bytes, index, bytes.length - index));
+                return new String(bytes, index, bytes.length - index, charset);
+            } catch (CharacterCodingException ignored) {
+                // The byte at `index` is still a tail byte of a multi-byte character; try the next one.
+            }
+        }
+        return new String(bytes, start, bytes.length - start, charset);
     }
 
     public static void deleteDirectory(Path directory) throws IOException {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/FileUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/FileUtils.java
@@ -26,7 +26,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -238,20 +242,113 @@ public final class FileUtils {
         }
     }
 
+    /// How many extra leading bytes to keep when reading only a tail, so the cut can be aligned to a
+    /// character boundary (UTF-8 uses at most 4 bytes per character).
+    private static final int TAIL_GUARD_BYTES = 16;
+
+    /// Reads the whole file and decodes it with HMCL's charset-detection rules.
     public static String readTextMaybeNativeEncoding(Path file) throws IOException {
         byte[] bytes = Files.readAllBytes(file);
+        return new String(bytes, detectCharset(bytes));
+    }
 
+    /// Reads at most the last [maxBytes] bytes of [file], decoded with HMCL's charset-detection rules.
+    ///
+    /// Unlike {@link #readTextMaybeNativeEncoding(Path)}, a file larger than [maxBytes] is never read into
+    /// memory in full: only the tail is read, and the returned content stays within a few bytes of
+    /// [maxBytes]. The cut is aligned to a character boundary whenever the content is detected as UTF-8, so
+    /// multi-byte characters (CJK, emoji, ...) are never split into invalid sequences.
+    ///
+    /// @param file     the file to read from
+    /// @param maxBytes the maximum number of bytes to keep from the tail; must be non-negative
+    /// @return the decoded tail content
+    /// @throws IOException if the file cannot be read
+    public static String readTextTailMaybeNativeEncoding(Path file, long maxBytes) throws IOException {
+        long size = Files.size(file);
+        if (size <= maxBytes)
+            return readTextMaybeNativeEncoding(file);
+
+        byte[] tail = readTailBytes(file, size, maxBytes);
+        Charset charset = detectCharset(tail);
+        int leading = leadingCharacterBoundary(tail, charset);
+        return new String(tail, leading, tail.length - leading, charset);
+    }
+
+    /// Detects the charset of [bytes] using the same heuristics used by the text readers.
+    ///
+    /// @param bytes the bytes whose charset should be detected
+    /// @return the charset to decode [bytes] with
+    private static Charset detectCharset(byte[] bytes) {
         if (OperatingSystem.NATIVE_CHARSET == UTF_8)
-            return new String(bytes, UTF_8);
+            return UTF_8;
 
         EncodingDetector detector = EncodingDetector.MODERN_WEB;
         EncodingDetector.@Nullable Encoding bestEncoding = detector.detect(bytes).bestEncoding();
         @Nullable Charset detectedCharset = bestEncoding != null ? bestEncoding.approximateCharset() : null;
 
         if (detectedCharset != null && (detectedCharset == UTF_8 || detectedCharset == US_ASCII))
-            return new String(bytes, UTF_8);
+            return UTF_8;
         else
-            return new String(bytes, OperatingSystem.NATIVE_CHARSET);
+            return OperatingSystem.NATIVE_CHARSET;
+    }
+
+    /// Reads the last bytes of a file larger than [maxBytes], keeping a small guard so a UTF-8 cut can later
+    /// be aligned to a character boundary.
+    ///
+    /// @param file     the file to read from
+    /// @param size     the size of the file, obtained upfront
+    /// @param maxBytes the maximum number of bytes to keep from the tail
+    /// @return the raw tail bytes
+    /// @throws IOException if the file cannot be read
+    private static byte[] readTailBytes(Path file, long size, long maxBytes) throws IOException {
+        long offset = Math.max(0, size - maxBytes - TAIL_GUARD_BYTES);
+        int length = (int) Math.min(size - offset, maxBytes + TAIL_GUARD_BYTES);
+        byte[] tail = new byte[length];
+
+        try (InputStream input = Files.newInputStream(file)) {
+            IOUtils.skipNBytes(input, offset);
+            int read = 0;
+            while (read < length) {
+                int n = input.read(tail, read, length - read);
+                if (n < 0)
+                    break;
+                read += n;
+            }
+            return read == length ? tail : Arrays.copyOf(tail, read);
+        }
+    }
+
+    /// Returns the index within the guard window that starts on a character boundary.
+    ///
+    /// UTF-8 boundary bytes never start with `10xxxxxx`, so continuation bytes are skipped. Other charsets
+    /// are probed with a strict decoder; if none decodes cleanly the method falls back to `0` and a single
+    /// replacement character may appear (a rare native-encoding case).
+    ///
+    /// @param bytes   the bytes to align
+    /// @param charset the charset to decode with
+    /// @return the leading offset that keeps the first character intact
+    private static int leadingCharacterBoundary(byte[] bytes, Charset charset) {
+        int limit = Math.min(TAIL_GUARD_BYTES, bytes.length);
+        if (charset == UTF_8) {
+            int index = 0;
+            while (index < limit && (bytes[index] & 0xC0) == 0x80)
+                index++;
+            return index;
+        }
+
+        CharsetDecoder decoder = charset.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT);
+        for (int index = 0; index <= limit; index++) {
+            try {
+                decoder.reset();
+                decoder.decode(ByteBuffer.wrap(bytes, index, bytes.length - index));
+                return index;
+            } catch (CharacterCodingException ignored) {
+                // The byte at `index` is still a tail byte of a multi-byte character; try the next one.
+            }
+        }
+        return 0;
     }
 
     public static void deleteDirectory(Path directory) throws IOException {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/FileUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/FileUtils.java
@@ -248,6 +248,10 @@ public final class FileUtils {
     /// character boundary (UTF-8 uses at most 4 bytes per character).
     private static final int TAIL_GUARD_BYTES = 16;
 
+    /// The largest [maxBytes] that still leaves room for the guard bytes without overflowing the int range
+    /// used for the tail buffer length.
+    private static final int MAX_TAIL_BYTES = Integer.MAX_VALUE - TAIL_GUARD_BYTES;
+
     /// How many leading bytes to sample when detecting the charset of a large file.
     private static final int CHARSET_SAMPLE_BYTES = 8192;
 
@@ -266,11 +270,21 @@ public final class FileUtils {
     /// the earliest allowed offset; if a single line is longer than [maxBytes], the returned text starts inside
     /// that line instead (a deliberate trade-off to keep the read size bounded) and still keeps the file end.
     ///
+    /// The guarantee holds for a file that is not modified concurrently: [file] is only measured once before
+    /// reading, so a file that grows past [maxBytes] in the meantime can make the whole-file branch exceed the
+    /// limit. Crash logs stop growing before upload, so this is not a concern in practice.
+    ///
     /// @param file     the file to read from
-    /// @param maxBytes the maximum number of bytes to keep from the tail; must be non-negative
+    /// @param maxBytes the maximum number of bytes to keep from the tail; must be in `(0, MAX_TAIL_BYTES]`
     /// @return the decoded tail content, at most [maxBytes] bytes long
-    /// @throws IOException if the file cannot be read
+    /// @throws IOException              if the file cannot be read
+    /// @throws IllegalArgumentException if [maxBytes] is not positive or leaves no room for the guard bytes
     public static String readTextTailMaybeNativeEncoding(Path file, int maxBytes) throws IOException {
+        if (maxBytes <= 0)
+            throw new IllegalArgumentException("maxBytes must be positive: " + maxBytes);
+        if (maxBytes > MAX_TAIL_BYTES)
+            throw new IllegalArgumentException("maxBytes must not exceed " + MAX_TAIL_BYTES + ": " + maxBytes);
+
         long size = Files.size(file);
         if (size <= maxBytes)
             return readTextMaybeNativeEncoding(file);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/FileUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/FileUtils.java
@@ -262,15 +262,15 @@ public final class FileUtils {
     /// A file larger than [maxBytes] is never read into memory in full: the charset is detected from a small
     /// head sample, then only the tail is read by seeking straight to its offset. The returned text, when it is
     /// re-encoded with the detected charset, is guaranteed to be at most [maxBytes] bytes and never starts in
-    /// the middle of a multi-byte character. It starts at a line boundary whenever one is available within the
-    /// read range; if a single line is longer than the read range, the returned text starts inside that line
-    /// instead (a deliberate trade-off to keep the read size bounded). The very end of the file is kept.
+    /// the middle of a multi-byte character. It starts at a line boundary whenever a newline is available after
+    /// the earliest allowed offset; if a single line is longer than [maxBytes], the returned text starts inside
+    /// that line instead (a deliberate trade-off to keep the read size bounded) and still keeps the file end.
     ///
     /// @param file     the file to read from
-    /// @param maxBytes the maximum number of bytes to keep from the tail; must be non-negative and at most 2 GiB
+    /// @param maxBytes the maximum number of bytes to keep from the tail; must be non-negative
     /// @return the decoded tail content, at most [maxBytes] bytes long
     /// @throws IOException if the file cannot be read
-    public static String readTextTailMaybeNativeEncoding(Path file, long maxBytes) throws IOException {
+    public static String readTextTailMaybeNativeEncoding(Path file, int maxBytes) throws IOException {
         long size = Files.size(file);
         if (size <= maxBytes)
             return readTextMaybeNativeEncoding(file);
@@ -278,9 +278,11 @@ public final class FileUtils {
         Charset charset = detectCharset(readHead(file));
         byte[] tail = readTailBytes(file, size, maxBytes);
 
-        int start = alignToCharacterBoundary(tail, charset, 0);
+        // Anchor the start at the earliest allowed offset (`tail.length - maxBytes`), then align it onto a
+        // character boundary and a line start, in that order, so the byte limit and the line-start preference
+        // hold at once instead of trimming back over an already-found line boundary.
+        int start = alignToCharacterBoundary(tail, charset, tail.length - maxBytes);
         start = alignToLineStart(tail, start);
-        start = alignToByteLimit(tail, charset, start, maxBytes);
 
         // `start` is a character boundary and leaves at most `maxBytes` bytes, so this is a single decode.
         return new String(tail, start, tail.length - start, charset);
@@ -342,9 +344,9 @@ public final class FileUtils {
     /// @param maxBytes the maximum number of bytes to keep from the tail
     /// @return the raw tail bytes
     /// @throws IOException if the file cannot be read
-    private static byte[] readTailBytes(Path file, long size, long maxBytes) throws IOException {
+    private static byte[] readTailBytes(Path file, long size, int maxBytes) throws IOException {
         long offset = Math.max(0, size - maxBytes - TAIL_GUARD_BYTES);
-        int length = (int) Math.min(size - offset, maxBytes + TAIL_GUARD_BYTES);
+        int length = (int) Math.min(size - offset, (long) maxBytes + TAIL_GUARD_BYTES);
         byte[] tail = new byte[length];
 
         try (FileChannel channel = FileChannel.open(file, StandardOpenOption.READ)) {
@@ -381,13 +383,17 @@ public final class FileUtils {
         CharsetDecoder decoder = charset.newDecoder()
                 .onMalformedInput(CodingErrorAction.REPORT)
                 .onUnmappableCharacter(CodingErrorAction.REPORT);
-        CharBuffer singleCharacter = CharBuffer.allocate(1);
+        // Two chars hold any single code point (including a surrogate pair), so the output buffer itself
+        // never forces an OVERFLOW while a character is being emitted.
+        CharBuffer singleCharacter = CharBuffer.allocate(2);
         for (int index = from; index <= limit; index++) {
             decoder.reset();
             singleCharacter.clear();
             CoderResult result = decoder.decode(ByteBuffer.wrap(bytes, index, bytes.length - index),
                     singleCharacter, false);
-            if (!result.isMalformed() && !result.isUnmappable())
+            // UNDERFLOW and OVERFLOW both mean decoding made progress from `index` (a character was
+            // emitted), so `index` is a boundary; only MALFORMED / UNMAPPABLE mean it is a stray byte.
+            if (!result.isError())
                 return index;
         }
         return from;
@@ -408,21 +414,6 @@ public final class FileUtils {
                 return i + 1;
         }
         return start;
-    }
-
-    /// Moves [start] forward when the remaining bytes exceed [maxBytes], aligning to a character boundary so
-    /// the result stays within the byte limit without splitting a character.
-    ///
-    /// @param bytes    the tail bytes
-    /// @param charset  the charset [bytes] decode with
-    /// @param start    the current character boundary
-    /// @param maxBytes the byte limit
-    /// @return the adjusted start offset, leaving at most [maxBytes] bytes before the end of [bytes]
-    private static int alignToByteLimit(byte[] bytes, Charset charset, int start, long maxBytes) {
-        if (bytes.length - start <= maxBytes) {
-            return start;
-        }
-        return alignToCharacterBoundary(bytes, charset, bytes.length - (int) maxBytes);
     }
 
     public static void deleteDirectory(Path directory) throws IOException {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/FileUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/FileUtils.java
@@ -27,10 +27,11 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
 import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
@@ -259,12 +260,14 @@ public final class FileUtils {
     /// Reads at most the last [maxBytes] bytes of [file], decoded with HMCL's charset-detection rules.
     ///
     /// A file larger than [maxBytes] is never read into memory in full: the charset is detected from a small
-    /// head sample, then only the tail is read by seeking straight to its offset. The returned text is
-    /// guaranteed to be at most [maxBytes] bytes after re-encoding with the detected charset, never starts in
-    /// the middle of a multi-byte character or a line, and always keeps the very end of the file.
+    /// head sample, then only the tail is read by seeking straight to its offset. The returned text, when it is
+    /// re-encoded with the detected charset, is guaranteed to be at most [maxBytes] bytes and never starts in
+    /// the middle of a multi-byte character. It starts at a line boundary whenever one is available within the
+    /// read range; if a single line is longer than the read range, the returned text starts inside that line
+    /// instead (a deliberate trade-off to keep the read size bounded). The very end of the file is kept.
     ///
     /// @param file     the file to read from
-    /// @param maxBytes the maximum number of bytes to keep from the tail; must be non-negative
+    /// @param maxBytes the maximum number of bytes to keep from the tail; must be non-negative and at most 2 GiB
     /// @return the decoded tail content, at most [maxBytes] bytes long
     /// @throws IOException if the file cannot be read
     public static String readTextTailMaybeNativeEncoding(Path file, long maxBytes) throws IOException {
@@ -275,21 +278,31 @@ public final class FileUtils {
         Charset charset = detectCharset(readHead(file));
         byte[] tail = readTailBytes(file, size, maxBytes);
 
-        int start = alignToCharacterBoundary(tail, charset);
+        int start = alignToCharacterBoundary(tail, charset, 0);
         start = alignToLineStart(tail, start);
+        start = alignToByteLimit(tail, charset, start, maxBytes);
 
-        String content = new String(tail, start, tail.length - start, charset);
-        return trimTailToByteLimit(content, charset, (int) maxBytes);
+        // `start` is a character boundary and leaves at most `maxBytes` bytes, so this is a single decode.
+        return new String(tail, start, tail.length - start, charset);
     }
 
     /// Truncates [content] so its UTF-8 encoding fits within [maxBytes], keeping the tail and never splitting
-    /// a multi-byte character.
+    /// a multi-byte character. Returns [content] unchanged when it already fits.
     ///
     /// @param content  the text to truncate
     /// @param maxBytes the UTF-8 byte limit
     /// @return [content], truncated to at most [maxBytes] UTF-8 bytes
     public static String truncateUtf8ToByteLimit(String content, int maxBytes) {
-        return trimTailToByteLimit(content, UTF_8, maxBytes);
+        byte[] bytes = content.getBytes(UTF_8);
+        if (bytes.length <= maxBytes) {
+            return content;
+        }
+
+        // Walk forward past UTF-8 continuation bytes so the cut never splits a multi-byte character.
+        int start = bytes.length - maxBytes;
+        while (start < bytes.length && (bytes[start] & 0xC0) == 0x80)
+            start++;
+        return new String(bytes, start, bytes.length - start, UTF_8);
     }
 
     /// Detects the charset of [bytes] using the same heuristics used by the text readers.
@@ -346,18 +359,20 @@ public final class FileUtils {
         }
     }
 
-    /// Returns the smallest index within the guard window that starts on a character boundary.
+    /// Returns the first character boundary at or after [from].
     ///
-    /// UTF-8 boundary bytes never start with `10xxxxxx`, so continuation bytes are skipped. Other charsets
-    /// are probed with a strict decoder over the leading window.
+    /// UTF-8 continuation bytes are `10xxxxxx`, so they are skipped directly. Other charsets have no such
+    /// marker; they are probed with a strict decoder that only needs to decode a single character, so aligning
+    /// a boundary never scans the whole tail buffer.
     ///
     /// @param bytes   the bytes to align
     /// @param charset the charset to decode with
-    /// @return the leading offset that keeps the first character intact
-    private static int alignToCharacterBoundary(byte[] bytes, Charset charset) {
-        int limit = Math.min(TAIL_GUARD_BYTES, bytes.length);
+    /// @param from    the offset to start searching from; may fall in the middle of a multi-byte character
+    /// @return the first offset `>= from` that starts a complete character
+    private static int alignToCharacterBoundary(byte[] bytes, Charset charset, int from) {
+        int limit = Math.min(from + TAIL_GUARD_BYTES, bytes.length);
         if (charset == UTF_8) {
-            int index = 0;
+            int index = from;
             while (index < limit && (bytes[index] & 0xC0) == 0x80)
                 index++;
             return index;
@@ -366,23 +381,27 @@ public final class FileUtils {
         CharsetDecoder decoder = charset.newDecoder()
                 .onMalformedInput(CodingErrorAction.REPORT)
                 .onUnmappableCharacter(CodingErrorAction.REPORT);
-        for (int index = 0; index <= limit; index++) {
-            try {
-                decoder.reset();
-                decoder.decode(ByteBuffer.wrap(bytes, index, bytes.length - index));
+        CharBuffer singleCharacter = CharBuffer.allocate(1);
+        for (int index = from; index <= limit; index++) {
+            decoder.reset();
+            singleCharacter.clear();
+            CoderResult result = decoder.decode(ByteBuffer.wrap(bytes, index, bytes.length - index),
+                    singleCharacter, false);
+            if (!result.isMalformed() && !result.isUnmappable())
                 return index;
-            } catch (CharacterCodingException ignored) {
-                // The byte at `index` is still a tail byte of a multi-byte character; try the next one.
-            }
         }
-        return 0;
+        return from;
     }
 
-    /// Skips to the start of the next line so the returned tail never opens with a truncated first line.
+    /// Skips to the start of the next line when one is inside the read range, so the returned tail opens with
+    /// a complete line whenever possible.
+    ///
+    /// When no newline is present (a single line longer than the read range), this returns [start] unchanged so
+    /// the read stays bounded; the result may then start in the middle of that over-long line.
     ///
     /// @param bytes the tail bytes
     /// @param start the first character boundary
-    /// @return the offset of the first byte of a complete line
+    /// @return the offset of the first byte of a complete line, or [start] when no newline follows
     private static int alignToLineStart(byte[] bytes, int start) {
         for (int i = start; i < bytes.length; i++) {
             if (bytes[i] == '\n')
@@ -391,42 +410,19 @@ public final class FileUtils {
         return start;
     }
 
-    /// Truncates [content] so its [charset] encoding fits within [maxBytes], keeping the tail and never
-    /// splitting a multi-byte character.
+    /// Moves [start] forward when the remaining bytes exceed [maxBytes], aligning to a character boundary so
+    /// the result stays within the byte limit without splitting a character.
     ///
-    /// @param content  the decoded content
-    /// @param charset  the charset [content] was decoded with
+    /// @param bytes    the tail bytes
+    /// @param charset  the charset [bytes] decode with
+    /// @param start    the current character boundary
     /// @param maxBytes the byte limit
-    /// @return [content], truncated to at most [maxBytes] bytes
-    private static String trimTailToByteLimit(String content, Charset charset, int maxBytes) {
-        byte[] bytes = content.getBytes(charset);
-        if (bytes.length <= maxBytes) {
-            return content;
+    /// @return the adjusted start offset, leaving at most [maxBytes] bytes before the end of [bytes]
+    private static int alignToByteLimit(byte[] bytes, Charset charset, int start, long maxBytes) {
+        if (bytes.length - start <= maxBytes) {
+            return start;
         }
-
-        int start = bytes.length - maxBytes;
-        if (charset == UTF_8) {
-            while (start < bytes.length && (bytes[start] & 0xC0) == 0x80)
-                start++;
-            return new String(bytes, start, bytes.length - start, UTF_8);
-        }
-
-        // Non-UTF-8 native encodings are rare; align with a strict decoder over the small over-run window so
-        // a multi-byte character is never split in two.
-        CharsetDecoder decoder = charset.newDecoder()
-                .onMalformedInput(CodingErrorAction.REPORT)
-                .onUnmappableCharacter(CodingErrorAction.REPORT);
-        int limit = Math.min(bytes.length, start + TAIL_GUARD_BYTES);
-        for (int index = start; index <= limit; index++) {
-            try {
-                decoder.reset();
-                decoder.decode(ByteBuffer.wrap(bytes, index, bytes.length - index));
-                return new String(bytes, index, bytes.length - index, charset);
-            } catch (CharacterCodingException ignored) {
-                // The byte at `index` is still a tail byte of a multi-byte character; try the next one.
-            }
-        }
-        return new String(bytes, start, bytes.length - start, charset);
+        return alignToCharacterBoundary(bytes, charset, bytes.length - (int) maxBytes);
     }
 
     public static void deleteDirectory(Path directory) throws IOException {


### PR DESCRIPTION
游戏崩溃后，目前只能通过「导出游戏崩溃信息」把 zip 文件发给他人分析，流程较繁琐。
本 PR 在崩溃窗口新增「上传至 mclo.gs」按钮，一键把游戏日志上传到 mclo.gs，
得到可分享的链接，方便用户求助时直接发链接。

## 预览

<img width="794" height="505" alt="image" src="https://github.com/user-attachments/assets/cb551ded-de97-4065-8e5b-4fe69d382b1a" />

<img width="800" height="508" alt="image" src="https://github.com/user-attachments/assets/29ab19e8-45c9-4c7c-9f8f-9c4a0666d29f" />

<img width="1407" height="890" alt="image" src="https://github.com/user-attachments/assets/1b86cb2b-94b7-4f05-9d4d-230a177a4807" />
