### PR TITLE
优化 LineSelectButton popup 副标题配色

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/StyleSheets.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/StyleSheets.java
@@ -153,6 +153,7 @@ public final class StyleSheets {
         addColor(builder, "-monet-primary-seed", scheme.getPrimaryColorSeed());
 
         addColor(builder, scheme, ColorRole.PRIMARY, 0.5);
+        addColor(builder, scheme, ColorRole.PRIMARY, 0.8);
         addColor(builder, scheme, ColorRole.SECONDARY_CONTAINER, 0.5);
         addColor(builder, scheme, ColorRole.SURFACE, 0.5);
         addColor(builder, scheme, ColorRole.SURFACE, 0.8);

--- a/HMCL/src/main/resources/assets/css/blue.css
+++ b/HMCL/src/main/resources/assets/css/blue.css
@@ -50,6 +50,7 @@
     -monet-surface-tint: #4858AB;
     -monet-primary-seed: #5C6BC0;
     -monet-primary-transparent-50: #4352A580;
+    -monet-primary-transparent-80: #4352A5CC;
     -monet-secondary-container-transparent-50: #D0D5FD80;
     -monet-surface-transparent-50: #FBF8FF80;
     -monet-surface-transparent-80: #FBF8FFCC;

--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -1939,7 +1939,7 @@
 }
 
 .line-select-button .menu-container:selected .subtitle-label {
-    -fx-text-fill: -monet-primary-container;
+    -fx-text-fill: -monet-primary-transparent-80;
 }
 
 .line-toggle-button .jfx-toggle-button {


### PR DESCRIPTION
目前的颜色在部分配色方案下可读性较差
<img width="434" height="489" alt="image" src="https://github.com/user-attachments/assets/d31fffed-8856-4edb-9106-9f5e4d78e78d" />
<img width="445" height="498" alt="image" src="https://github.com/user-attachments/assets/e15f9587-a082-427a-a3f7-80d459383a53" />
