### PR TITLE
默认从 MCIM 源下载文件

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/BMCLAPIDownloadProvider.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/BMCLAPIDownloadProvider.java
@@ -94,15 +94,17 @@ public final class BMCLAPIDownloadProvider implements DownloadProvider {
                 pair("https://repo.maven.apache.org/maven2", "https://mirrors.cloud.tencent.com/nexus/repository/maven-public"),
                 pair("https://hmcl.glavo.site/metadata/cleanroom", "https://alist.8mi.tech/d/mirror/HMCL-Metadata/Auto/cleanroom"),
                 pair("https://hmcl.glavo.site/metadata/fmllibs", "https://alist.8mi.tech/d/mirror/HMCL-Metadata/Auto/fmllibs"),
-                pair("https://zkitefly.github.io/unlisted-versions-of-minecraft", "https://alist.8mi.tech/d/mirror/unlisted-versions-of-minecraft/Auto")
+                pair("https://zkitefly.github.io/unlisted-versions-of-minecraft", "https://alist.8mi.tech/d/mirror/unlisted-versions-of-minecraft/Auto"),
+
+                // https://github.com/mcmod-info-mirror/mcim-rust-api
+                pair("https://cdn.modrinth.com", "https://mod.mcimirror.top"),
+                pair("https://edge.forgecdn.net", "https://mod.mcimirror.top")
         );
 
         this.fallbackReplacement = List.of(
                 // https://github.com/mcmod-info-mirror/mcim-rust-api
                 pair("https://api.modrinth.com", "https://mod.mcimirror.top/modrinth"),
-                pair("https://cdn.modrinth.com", "https://mod.mcimirror.top"),
-                pair("https://api.curseforge.com", "https://mod.mcimirror.top/curseforge"),
-                pair("https://edge.forgecdn.net", "https://mod.mcimirror.top")
+                pair("https://api.curseforge.com", "https://mod.mcimirror.top/curseforge")
         );
     }
 


### PR DESCRIPTION
近期 Modrinth  和 CurseForge 文件在境内的下载速度似乎都很慢，本 PR 尝试将模组/整合包的默认下载源切换至 MCIM。