### PR TITLE
OAuthserver 仅在 localhost 监听端口

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/OAuthServer.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/OAuthServer.java
@@ -53,7 +53,7 @@ public final class OAuthServer extends NanoHTTPD implements OAuth.Session {
     private String idToken;
 
     private OAuthServer(int port) {
-        super(port);
+        super("localhost", port);
 
         this.port = port;
 


### PR DESCRIPTION
 目前会在所有 IP 监听端口，导致 Windows 跳出防火墙提示。