### PR TITLE
Fix #6819: 实例管理工具栏文字变小

### DIFF
--- a/HMCL/src/main/resources/assets/css/root.css
+++ b/HMCL/src/main/resources/assets/css/root.css
@@ -745,6 +745,7 @@
 
 .jfx-tool-bar-button {
     -fx-text-fill: -monet-on-surface;
+    -fx-font-size: 14px;
     -fx-toggle-icon4-size: 37px;
     -fx-pref-height: -fx-toggle-icon4-size;
     -fx-max-height: -fx-toggle-icon4-size;


### PR DESCRIPTION
Close #6819
<img width="1834" height="144" alt="image" src="https://github.com/user-attachments/assets/e8e706d3-5369-49dc-a90c-6289c77cee49" />
