### PR TITLE
修复导出mrpack时，已禁用模组有关bug

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/modrinth/ModrinthModpackExportTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/modrinth/ModrinthModpackExportTask.java
@@ -21,9 +21,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 
+import org.jackhuang.hmcl.addon.LocalAddonManager;
 import org.jackhuang.hmcl.addon.mod.ModManager;
 import org.jackhuang.hmcl.addon.repository.ModrinthRemoteAddonRepository;
 import org.jackhuang.hmcl.game.DefaultGameInstance;
@@ -34,6 +34,7 @@ import org.jackhuang.hmcl.modpack.Modpack;
 import org.jackhuang.hmcl.modpack.ModpackExportInfo;
 import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.util.DigestUtils;
+import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.gson.JsonUtils;
 import org.jackhuang.hmcl.util.io.Zipper;
 import org.jackhuang.hmcl.util.versioning.GameVersionNumber;
@@ -93,7 +94,7 @@ public class ModrinthModpackExportTask extends Task<Void> {
 
         boolean isDisabled = modManager.isDisabled(file);
         if (isDisabled) {
-            relativePath = modManager.enableMod(Paths.get(relativePath)).toString().replace(File.separatorChar, '/');
+            relativePath = StringUtils.removeSuffix(relativePath, LocalAddonManager.DISABLED_EXTENSION);
         }
 
         Optional<RemoteAddon.Version> modrinthVersion = Optional.empty();

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/modrinth/ModrinthModpackExportTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/modpack/modrinth/ModrinthModpackExportTask.java
@@ -93,7 +93,7 @@ public class ModrinthModpackExportTask extends Task<Void> {
 
         boolean isDisabled = modManager.isDisabled(file);
         if (isDisabled) {
-            relativePath = modManager.enableMod(Paths.get(relativePath)).toString();
+            relativePath = modManager.enableMod(Paths.get(relativePath)).toString().replace(File.separatorChar, '/');
         }
 
         Optional<RemoteAddon.Version> modrinthVersion = Optional.empty();


### PR DESCRIPTION
fix 已禁用模组路径使用反斜杠的问题
fix 获取移除后缀路径时，潜在的实际改动文件的副作用