### PR TITLE
Bump kala-compress to 1.27.1-5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 hmclauncher = "3.7.0.1"
 jetbrains-annotations = "26.1.0"
-kala-compress = "1.27.1-4"
+kala-compress = "1.27.1-5"
 kala-encoding-detctor = "0.1.0"
 simple-png-javafx = "0.3.0"
 gson = "2.14.0"


### PR DESCRIPTION
commons-compress 的原始实现在启用了 `ignoreLocalFileHeader` 的情况下，会忽略 unicode extra field 标记，导致无法正确处理部分 unicode entry name。

kala-compress 1.27.1-5 修复了这个问题，并进行了一些其他的优化和清理，应该能略微提高性能和降低内存分配。