### PR TITLE
i18n: update Russian translation

### DIFF
--- a/HMCL/src/main/resources/assets/lang/I18N_ru.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_ru.properties
@@ -16,21 +16,21 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-# Contributors: vanja-san
+# Contributors: vanja-san, szizoid
 
 about=О лаунчере
 about.copyright=Авторские права
-# about.copyright.statement=
+about.copyright.statement=Copyright © 2013-2026 huangyuhui и контрибьюторы.
 about.author.statement=bilibili @huanghongxun
 about.claim=EULA
 about.claim.statement=Кликните на ссылку, чтобы увидеть весь текст.
-about.dependency=Зависимости
-about.legal=Юридическое подтверждение
+about.dependency=Сторонние библиотеки
+about.legal=Правовая информация
 about.thanks_to=Отдельная благодарность
-about.thanks_to.bangbang93.statement=За предоставление зеркала загрузки BMCLAPI, пожалуйста, подумайте о пожертвовании!
+about.thanks_to.bangbang93.statement=За предоставление зеркала загрузки BMCLAPI. Пожалуйста, подумайте о пожертвовании!
 about.thanks_to.burningtnt.statement=Оказал большую техническую поддержку HMCL.
 about.thanks_to.contributors=Всем участникам на GitHub
-about.thanks_to.contributors.statement=Без потрясающего сообщества с открытым исходным кодом, HMCL не смог бы добраться так далеко.
+about.thanks_to.contributors.statement=Без потрясающего сообщества с открытым исходным кодом HMCL не добился бы таких успехов.
 about.thanks_to.gamerteam.statement=За предоставление фонового изображения.
 about.thanks_to.glavo.statement=Отвечает за поддержание HMCL.
 about.thanks_to.zekerzhayard.statement=Оказал большую техническую поддержку HMCL.
@@ -46,8 +46,8 @@ about.thanks_to.shulkersakura.statement=За предоставление лог
 about.thanks_to.users=Членам группы пользователей HMCL
 about.thanks_to.users.statement=Спасибо за пожертвования, отчёты об ошибках и так далее.
 about.thanks_to.yushijinhun.statement=За предоставление поддержки, связанной с authlib-injector.
-# about.thanks_to.8mi-tech=
-# about.thanks_to.8mi-tech.statement=
+about.thanks_to.8mi-tech=8Mi-Tech (Quanzhou) Co., Ltd.
+about.thanks_to.8mi-tech.statement=Обеспечивает ускоренную загрузку некоторых статических ресурсов игры.
 about.open_source=Открытый исходный код
 about.open_source.statement=GPL v3 (https://github.com/HMCL-dev/HMCL)
 
@@ -57,83 +57,80 @@ account.character=Игрок
 account.choose=Выберите игрока
 account.create=Добавить аккаунт
 account.create.microsoft=Добавить аккаунт Microsoft
-account.create.offline=Добавить аккаунт в режиме офлайн
+account.create.offline=Добавить аккаунт в оффлайн-режиме
 account.create.authlibInjector=Добавить аккаунт authlib-injector
 account.email=Почта
-# account.empty=
+account.empty=Нет аккаунтов
 account.failed=Не удалось обновить аккаунт.
 account.failed.character_deleted=Игрок уже был удален.
 account.failed.connect_authentication_server=Не удалось связаться с серверами авторизации, проверьте свой интернет.
 account.failed.connect_injector_server=Не удалось подключиться к серверу авторизации. Проверьте свой интернет и убедитесь, что вы ввели правильный URL-адрес.
 account.failed.injector_download_failure=Не удалось скачать authlib-injector. Проверьте свой интернет или попробуйте переключиться на другое зеркало скачивания.
-account.failed.invalid_credentials=Неверный пароль или ограничена скорость, повторите попытку позже.
+account.failed.invalid_credentials=Неверный пароль или ограничение по количеству запросов, повторите попытку позже.
 account.failed.invalid_password=Неверный пароль
 account.failed.invalid_token=Попробуйте выйти из аккаунта и повторно войти.
-account.failed.migration=Ваш аккаунт должен быть перенесён в Microsoft. Если вы уже сделали это, вам следует войти в свой перенесенный аккаунт Microsoft.
-account.failed.no_character=Аккаунт не имеет персонажей.
-account.failed.server_disconnected=Невозможно получить доступ к серверу авторизации, не удалось проверить информацию о аккаунте.\n\
-  Вы можете выбрать «Повторить проверку аккаунта», чтобы попытаться снова.\n\
-  Также можно выбрать «Пропустить проверку аккаунта», чтобы продолжить запуск игры,\n\
-  но информация об аккаунте может быть не актуальной. Если срок действия информации\n\
-  о аккаунте истечёт, будет невозможно войти на сервер, который требует подтверждения\n\
-  аккаунта.
-account.failed.server_response_malformed=Неверный ответ сервера, видимо сервер авторизации не работает.
+account.failed.migration=Ваш аккаунт должен быть перенесён в аккаунт Microsoft. Если вы уже сделали это, вам следует войти в свой перенесенный аккаунт Microsoft.
+account.failed.no_character=К аккаунту не привязан ни один персонаж.
+account.failed.server_disconnected=Не удалось подключиться к серверу авторизации. Вы можете войти в оффлайн-режиме или попробовать войти еще раз.\n\
+    Если проблема не исчезнет после нескольких попыток, попробуйте снова войти в аккаунт.
+account.failed.server_response_malformed=Неверный ответ сервера. Возможно, сервер авторизации не работает.
 account.failed.ssl=При подключении к серверу произошла ошибка SSL. Пожалуйста, попробуйте обновить Java.
 account.failed.dns=При подключении к серверу произошла ошибка SSL. Возможно, проблемы с разрешением DNS. Попробуйте сменить DNS‑сервер или воспользоваться прокси-службой.
 account.failed.wrong_account=Вы вошли в неверный аккаунт.
-# account.storage.read_only=
+account.storage.read_only=Файл аккаунтов был сохранен в более новой версии HMCL. Текущая версия HMCL не может изменять аккаунты.
 account.injector.add=Новый сервер авторизации
-account.injector.empty=Ничего (Вы можете нажать кнопку «плюс», чтобы добавить еще)
-account.injector.http=Предупреждение\: Этот сервер использует небезопасный протокол HTTP, и любой игрок, находящийся между вашими соединениями, сможет увидеть ваши учётные данные в открытом виде.
+account.injector.empty=Нет серверов (нажмите «+», чтобы добавить)
+account.injector.http=Предупреждение\: Этот сервер использует небезопасный протокол HTTP, и любой, кто перехватывает соединение, сможет увидеть ваши учётные данные в открытом виде.
 account.injector.link.homepage=Домашняя страница
 account.injector.link.register=Зарегистрироваться
 account.injector.server=Сервер авторизации
-# account.injector.server.storage.read_only=
+account.injector.server.storage.read_only=Файл сервера authlib-injector был сохранен в более новой версии HMCL. Текущая версия HMCL не может изменять серверы авторизации.
 account.injector.server_url=URL-адрес сервера
 account.injector.server_name=Имя сервера
 account.login=Войти
 account.login.hint=Мы не храним ваш пароль.
-account.login.skip=Войти в режиме офлайн
-account.login.retry=Повторить снова
+account.login.skip=Войти в оффлайн-режиме
+account.login.retry=Повторить
 account.login.refresh=Войти снова
 account.login.refresh.microsoft.hint=Вам необходимо снова войти в аккаунт Microsoft, поскольку авторизация аккаунта недействительна.
-account.login.restricted=Войти в свою аккаунт Microsoft, чтобы включить эту функцию
+account.login.restricted=Войти в свой аккаунт Microsoft, чтобы включить эту функцию
 account.manage=Список аккаунтов
-account.copy_uuid=Копирование UUID
+account.copy_uuid=Скопировать UUID аккаунта
 account.methods=Способ входа
 account.methods.authlib_injector=authlib-injector
 account.methods.microsoft=Microsoft
-# account.methods.microsoft.code=
+account.methods.microsoft.code=Код (скопирован в буфер обмена)
 account.methods.microsoft.close_page=Авторизация аккаунта Microsoft завершена. Осталось выполнить некоторые шаги, которые необходимо завершить позже. Вы можете закрыть эту страницу.
-# account.methods.microsoft.error.add_family=
-# account.methods.microsoft.error.country_unavailable=
-# account.methods.microsoft.error.missing_xbox_account=
-# account.methods.microsoft.error.no_license=
-# account.methods.microsoft.error.no_character=
-# account.methods.microsoft.error.banned=
-# account.methods.microsoft.error.unknown=
-# account.methods.microsoft.error.wrong_verify_method=
-# account.methods.microsoft.hint=
-# account.methods.microsoft.methods.device=
-# account.methods.microsoft.methods.device.hint=
-# account.methods.microsoft.methods.device.hint.completed=
-# account.methods.microsoft.methods.browser=
-# account.methods.microsoft.methods.browser.hint=
-# account.methods.microsoft.manual=
-account.methods.microsoft.profile=Профиль аккаунта...
+account.methods.microsoft.error.add_family=Пожалуйста, нажмите <a href="https://support.microsoft.com/account-billing/837badbc-999e-54d2-2617-d19206b9540a">здесь</a>, чтобы изменить дату рождения вашего аккаунта так, чтобы вам было больше 18 лет, или добавить ваш аккаунт в семейную группу.
+account.methods.microsoft.error.country_unavailable=XBOX Live недоступен в вашей текущей стране/регионе.
+account.methods.microsoft.error.missing_xbox_account=Пожалуйста, подтвердите, что вы приобрели Minecraft: Java Edition. Если да, нажмите <a href="https://www.minecraft.net/msaprofile/mygames/editprofile">здесь</a>, чтобы создать свой игровой профиль.
+account.methods.microsoft.error.no_license=Не найдено записей о покупке Minecraft. Пожалуйста, нажмите <a href="https://www.xbox.com/games/store/minecraft-java-bedrock-edition-for-pc/9nxp44l49shj">здесь</a>, чтобы скачать игру.\n\
+    Если вы пользуетесь Game Pass, создайте игровой профиль <a href="https://www.minecraft.net/msaprofile/mygames/editprofile">здесь</a>. Если вы уже приобрели игру, проверьте, в тот ли аккаунт вы вошли.
+account.methods.microsoft.error.no_character=Вы еще не создали игровой профиль. Пожалуйста, нажмите <a href="https://www.minecraft.net/msaprofile/mygames/editprofile">здесь</a>, чтобы создать его.
+account.methods.microsoft.error.banned=Возможно, ваш аккаунт заблокирован в XBOX Live.\nНажмите <a href="https://enforcement.xbox.com/enforcement/showenforcementhistory">здесь</a>, чтобы проверить статус блокировки аккаунта.
+account.methods.microsoft.error.unknown=Не удалось войти, код ошибки: %d.
+account.methods.microsoft.error.wrong_verify_method=Не удалось войти. Попробуйте войти в аккаунт с помощью ПАРОЛЯ, а не другим способом.
+account.methods.microsoft.hint=Нажмите кнопку «Войти», чтобы добавить аккаунт Microsoft.
+account.methods.microsoft.methods.device=Вход по QR-коду
+account.methods.microsoft.methods.device.hint=Отсканируйте QR-код или перейдите по адресу <a href="%s">%s</a>, чтобы завершить вход, и введите <b>%s</b> на открывшейся странице.
+account.methods.microsoft.methods.device.hint.completed=Авторизация аккаунта Microsoft завершена. Осталось ещё несколько шагов, подождите немного.
+account.methods.microsoft.methods.browser=Вход через браузер
+account.methods.microsoft.methods.browser.hint=Нажмите кнопку «Войти» или <a href="%s">скопируйте ссылку</a> и вставьте её в браузер, чтобы войти.
+account.methods.microsoft.manual=<b>При плохом интернет-соединении веб-страницы могут загружаться медленно или не загружаться совсем.\nПопробуйте позже или подключитесь к другой сети.</b>
+account.methods.microsoft.profile=Профиль аккаунта
 account.methods.microsoft.purchase=Купить Minecraft
-# account.methods.microsoft.snapshot=
-# account.methods.microsoft.snapshot.tooltip=
-account.methods.offline=Офлайн
-account.methods.offline.name.special_characters=Использовать только буквы, цифры и подчеркивания (максимум 16 символов)
-account.methods.offline.name.invalid=Для имени пользователя рекомендуется использовать только английские буквы, цифры и подчеркивания, а его длина не должна превышать 16 символов.\n\
+account.methods.microsoft.snapshot=Вы используете неофициальную версию HMCL. Чтобы войти, скачайте <a href="https://hmcl.huangyuhui.net/download">официальную версию</a>.
+account.methods.microsoft.snapshot.tooltip=Вы используете неофициальную версию HMCL. Чтобы обновить аккаунт, скачайте официальную версию.
+account.methods.offline=Оффлайн
+account.methods.offline.name.special_characters=Используйте только латинские буквы, цифры и подчёркивания (не более 16 символов)
+account.methods.offline.name.invalid=Для имени пользователя рекомендуется использовать только английские буквы, цифры и подчёркивания, а его длина не должна превышать 16 символов.\n\
   \n\
-  \  · Законный: HuangYu, huang_Yu, Huang_Yu_123;\n\
-  \  · Незаконный: Huang Yu, Huang-Yu_%%%, Huang_Yu_hello_world_hello_world.\n\
+  \  · Допустимо: HuangYu, huang_Yu, Huang_Yu_123;\n\
+  \  · Недопустимо: Huang Yu, Huang-Yu_%%%, Huang_Yu_hello_world_hello_world.\n\
   \n\
-  Использование незаконного имени пользователя не позволит вам присоединиться к большинству серверов и может конфликтовать с некоторыми модами, что приведет к отказу игры.
+  С недопустимым именем вы не сможете зайти на большинство серверов, а некоторые моды могут работать с ошибками и привести к вылету игры.
 account.methods.offline.uuid=UUID
-account.methods.offline.uuid.hint=UUID - это уникальный идентификатор игрового персонажа в Minecraft. Способ генерации UUID различается в разных лаунчерах игр. Изменение UUID на тот, который генерируется другим лаунчером гарантирует, что игровые блоки/предметы в рюкзаке вашего офлайн аккаунта останутся. Этот параметр предназначен для экспертов. Если вы не знаете что делаете, мы не советуем вам изменять этот параметр. Эта опция не требуется для присоединения к серверам.
+account.methods.offline.uuid.hint=UUID — уникальный идентификатор игрока в Minecraft, и разные лаунчеры могут генерировать его по-разному. Если указать UUID, сгенерированный другим лаунчером, в инвентаре оффлайн-аккаунта сохранятся ваши предметы.\n\nЭтот параметр предназначен только для опытных пользователей. Не меняйте его, если не уверены, что делаете.
 account.methods.offline.uuid.malformed=Недопустимый формат.
 account.missing=Нет аккаунтов
 account.missing.add=Нажмите здесь, чтобы добавить.
@@ -145,53 +142,53 @@ account.skin=Скин
 account.skin.file=Файл скина
 account.skin.model=Модель
 account.skin.model.default=Классическая
-account.skin.model.slim=Стройная
+account.skin.model.slim=Тонкая
 account.skin.type.alex=Алекс
 account.skin.type.csl_api=Blessing Skin
 account.skin.type.csl_api.location=Адрес
 account.skin.type.csl_api.location.hint=URL-адрес CustomSkinAPI
 account.skin.type.little_skin=LittleSkin
-account.skin.type.little_skin.hint=Вам нужно создать игрока с тем же именем, что и у вашего офлайн-аукнта на сайте поставщика скинов. Теперь ваш скин будет установлен на скин, назначенный вашему игроку на сайте поставщика скинов.
+account.skin.type.little_skin.hint=Вам нужно создать игрока с тем же именем, что и у вашего оффлайн-аккаунта на сайте поставщика скинов. Теперь ваш скин будет установлен на скин, назначенный вашему игроку на сайте поставщика скинов.
 account.skin.type.local_file=Локальный файл скина
 account.skin.type.steve=Стив
-account.skin.upload=Загрузить скин
+account.skin.upload=Загрузить/изменить скин
 account.skin.upload.failed=Не удалось загрузить скин.
 account.skin.invalid_skin=Недопустимый файл скина.
 account.username=Имя пользователя
 
 addon.category=Категория
-# addon.changelog=
-# addon.changelog.empty=
+addon.changelog=Список изменений
+addon.changelog.empty=Список изменений пока пуст
 addon.channel.alpha=Альфа
 addon.channel.beta=Бета
 addon.channel.release=Релиз
-# addon.check_update=
+addon.check_update=Обновление файлов
 addon.check_update.button=Обновить
 addon.check_update.confirm=Обновить
 addon.check_update.current_version=Текущая версия
-addon.check_update.empty=Все моды новейшие
+addon.check_update.empty=Все файлы актуальны
 addon.check_update.failed_check=Не удалось проверить обновления.
 addon.check_update.failed_download=Не удалось скачать некоторые файлы.
 addon.check_update.file=Файл
 addon.check_update.source=Источник
 addon.check_update.target_version=Целевая версия
 addon.curseforge=CurseForge
-# addon.dependency.embedded=
-# addon.dependency.optional=
-# addon.dependency.required=
-# addon.dependency.tool=
-# addon.dependency.include=
-# addon.dependency.incompatible=
-# addon.dependency.broken=
-# addon.dependencies.has_broken=
-# addon.download.recommend=
-# addon.download.title.release=
-# addon.download.title.snapshot=
+addon.dependency.embedded=Встроенные зависимости (уже включены автором в файл аддона, скачивать отдельно не нужно)
+addon.dependency.optional=Необязательные зависимости (без них игра запустится, но часть функций аддона может не работать)
+addon.dependency.required=Обязательные зависимости (нужно скачать отдельно, без них игра может не запуститься)
+addon.dependency.tool=Обязательные зависимости (нужно скачать отдельно, без них игра может не запуститься)
+addon.dependency.include=Встроенные зависимости (уже включены автором в файл аддона, скачивать отдельно не нужно)
+addon.dependency.incompatible=Несовместимые аддоны (если установить их одновременно, игра не запустится)
+addon.dependency.broken=Сломанные зависимости (этот аддон раньше существовал, но теперь недоступен. Попробуйте другой источник скачивания.)
+addon.dependencies.has_broken=У этой версии есть сломанные зависимости. Попробуйте другой источник скачивания, иначе установка может не удаться.
+addon.download.recommend=Рекомендуемая версия для Minecraft %1s
+addon.download.title.release=Minecraft %s
+addon.download.title.snapshot=Minecraft %s (снапшоты)
 addon.modrinth=Modrinth
 addon.sort.date_created=Создан
 addon.sort.last_updated=Обновлён
 addon.sort.popularity=Популярность
-# addon.sort.relevancy=
+addon.sort.relevancy=Релевантность
 addon.sort.total_downloads=Скачиваний
 
 archive.author=Автор(ы)
@@ -199,18 +196,18 @@ archive.date=Дата публикации
 archive.file.name=Имя файла
 archive.version=Версия
 
-assets.download=Скачивание Assets
-assets.download_all=Проверка целостности assets
-assets.index.malformed=Индексные файлы загруженных assets повреждены. Можно попробовать использовать «Обновить игровые assets» в настройках игрового экземпляра, чтобы устранить эту проблему.
+assets.download=Скачивание ассетов
+assets.download_all=Проверка целостности ассетов
+assets.index.malformed=Индексные файлы скачанных ассетов повреждены. Чтобы исправить это, нажмите «Инструменты → Обновить ассеты игры» на странице «Изменить сборку».
 
 button.cancel=Отмена
 button.change_source=Изменить источник скачивания
 button.clear=Очистить
-# button.copy=
+button.copy=Копировать
 button.copy_and_exit=Скопировать и выйти
 button.delete=Удалить
 button.disable=Отключить
-# button.do_not_show_again=
+button.do_not_show_again=Больше не показывать
 button.edit=Изменить
 button.enable=Включить
 button.install=Установить
@@ -218,8 +215,8 @@ button.export=Экспорт
 button.no=Нет
 button.ok=ОК
 button.ok.countdown=ОК (%d)
-# button.reset=
-# button.reveal_dir=
+button.reset=Сбросить
+button.reveal_dir=Показать в папке
 button.refresh=Обновить
 button.remove=Убрать
 button.remove.confirm=Удалить навсегда? Это действие невозможно отменить!
@@ -233,11 +230,11 @@ contact=Обратная связь
 contact.chat=Групповой чат
 contact.chat.discord=Discord
 contact.chat.discord.statement=Добро пожаловать в наш Discord.
-contact.chat.qq_group=Группа QQ пользователя HMCL
+contact.chat.qq_group=Группа QQ пользователей HMCL
 contact.chat.qq_group.statement=Добро пожаловать в нашу группу QQ.
 contact.feedback=Канал обратной связи
-contact.feedback.github=Проблемы GitHub
-contact.feedback.github.statement=Отправить проблему на GitHub.
+contact.feedback.github=GitHub Issues
+contact.feedback.github.statement=Сообщить о проблеме на GitHub.
 
 color.recent=Рекомендуемые
 color.custom=Пользовательский цвет
@@ -248,25 +245,25 @@ crash.user_fault=Лаунчер аварийно завершил работу �
 curse.category.0=Все
 
 # https://addons-ecs.forgesvc.net/api/v2/category/section/4471
-curse.category.4474=НФ
+curse.category.4474=Научная фантастика
 curse.category.4481=Маленький / Легкий
 curse.category.4483=Бой
 curse.category.4477=Мини-игра
 curse.category.4478=Квесты
 curse.category.4484=Сетевая игра
-curse.category.4476=Разведка
+curse.category.4476=Исследование
 curse.category.4736=Скайблок
 curse.category.4475=Приключение и РПГ
 curse.category.4487=FTB
-curse.category.4480=Map Based
+curse.category.4480=На основе карты
 curse.category.4479=Хардкор
 curse.category.4482=Очень большой
 curse.category.4472=Технология
 curse.category.4473=Магия
 curse.category.5128=Ванильное+
-curse.category.7418=Ужас
-# curse.category.9243=
-# curse.category.10683=
+curse.category.7418=Хоррор
+curse.category.9243=Для экспертов
+curse.category.10683=RLCraft
 
 # https://addons-ecs.forgesvc.net/api/v2/category/section/6
 curse.category.5299=Образование
@@ -274,7 +271,7 @@ curse.category.5232=Galacticraft
 curse.category.5129=Ванильное+
 curse.category.5189=Утилита и качество жизни
 curse.category.6814=Производительность
-curse.category.6954=Интегрированная динамика
+curse.category.6954=Integrated Dynamics
 curse.category.6484=Create
 curse.category.6821=Исправления ошибок
 curse.category.6145=Скайблок
@@ -292,12 +289,12 @@ curse.category.419=Магия
 curse.category.412=Технология
 curse.category.4557=Редстоун
 curse.category.428=Tinker's Construct
-# curse.category.8937=
-# curse.category.9026=
-# curse.category.10775=
+curse.category.8937=ModJam 2025
+curse.category.9026=CreativeMode
+curse.category.10775=Хоррор
 # '
 curse.category.414=Транспорт игрока
-curse.category.4486=Счастливые блоки
+curse.category.4486=Lucky Blocks
 curse.category.432=Buildcraft
 curse.category.418=Генетика
 curse.category.4671=Интеграция с Twitch
@@ -316,19 +313,19 @@ curse.category.416=Земледелие
 curse.category.421=API и библиотека
 curse.category.4780=Fabric
 curse.category.424=Косметика
-curse.category.406=Генерация карты
+curse.category.406=Генерация мира
 curse.category.435=Утилита сервера
 curse.category.411=Мобы
 curse.category.407=Биомы
 curse.category.427=Thermal Expansion
-curse.category.410=Размеры
+curse.category.410=Измерения
 curse.category.436=Еда
 curse.category.4558=Редстоун
 curse.category.4843=Автоматизация
 curse.category.4906=MCreator
 curse.category.7669=Twilight Forest
-# curse.category.9049=
-# curse.category.10754=
+curse.category.9049=Refined Storage
+curse.category.10754=Farmer's Delight
 
 # https://addons-ecs.forgesvc.net/api/v2/category/section/12
 curse.category.5244=Пакеты шрифтов
@@ -345,12 +342,12 @@ curse.category.403=Традиционный
 curse.category.394=32x
 curse.category.404=Анимированный
 curse.category.4465=Поддержка модов
-curse.category.402=Medieval
+curse.category.402=Средневековье
 curse.category.401=Современный
-# curse.category.8939=
+curse.category.8939=ModJam 2025
 
 # https://addons-ecs.forgesvc.net/api/v2/category/section/17
-curse.category.4464=Моддинг мир
+curse.category.4464=Мир с модами
 curse.category.250=Игровой мир
 curse.category.249=Создание
 curse.category.251=Паркур
@@ -359,8 +356,8 @@ curse.category.248=Приключение
 curse.category.252=Головоломка
 
 # https://addons-ecs.forgesvc.net/api/v2/category/section/4546
-curse.category.4551=Хардкорный режим квеста
-curse.category.4548=Счастливые блоки
+curse.category.4551=Hardcore Questing Mode
+curse.category.4548=Lucky Blocks
 curse.category.4556=Прогрессия
 curse.category.4752=Building Gadgets
 curse.category.4553=CraftTweaker
@@ -368,12 +365,12 @@ curse.category.4554=Рецепты
 curse.category.4549=Путеводитель
 curse.category.4547=Конфигурация
 curse.category.4550=Квесты
-curse.category.4555=Генерация карты
+curse.category.4555=Генерация мира
 curse.category.4552=Скрипты
 
-# curse.category.6553=
-# curse.category.6554=
-# curse.category.6555=
+curse.category.6553=Реализм
+curse.category.6554=Фэнтези
+curse.category.6555=Ванильный
 
 datetime.format=d MMM yyyy г., HH\:mm\:ss
 
@@ -384,25 +381,22 @@ download.shader=Шейдеры
 download.failed=Не удалось скачать «%1$s», код ответа: %2$d.
 download.failed.empty=Версий нет. Нажмите здесь, чтобы вернуться назад.
 download.failed.no_code=Не удалось скачать
-download.failed.refresh=Не удалось получить список версий. Нажмите здесь, чтобы повторить попытку.
+download.failed.refresh=Не удалось получить данные. Нажмите здесь, чтобы повторить попытку.
 download.game=Новая игра
-# download.provider.bmclapi=
-# download.provider.bmclapi.desc=
-# download.provider.mojang=
-# download.provider.mojang.desc=
+download.provider.bmclapi=BMCLAPI & MCIM
+download.provider.bmclapi.desc=Этот вариант предназначен только для пользователей из материкового Китая.
+download.provider.mojang=Официальный
+download.provider.mojang.desc=Обратите внимание: OptiFine предоставляется через BMCLAPI.
 download.provider.official=Из официальных источников
-# download.provider.official.desc=
+download.provider.official.desc=Всегда скачивать из официальных источников.
 download.provider.balanced=Из самых быстрых доступных
-# download.provider.balanced.desc=
+download.provider.balanced.desc=Лучший выбор для ВСЕХ пользователей.
 download.provider.mirror=Из зеркала
-# download.provider.mirror.desc=
+download.provider.mirror.desc=Рекомендуется для пользователей из материкового Китая.
 download.java=Скачивание Java
 download.java.process=Процесс скачивания Java
 download.javafx=Скачивание зависимостей лаунчера...
-download.javafx.notes=Скачивание зависимостей для лаунчер из Интернета.\n\
-  \n\
-  Можно нажать «Изменить источник скачивания», чтобы выбрать зеркало загрузки, или нажать «Отмена», чтобы остановить и выйти.\n\
-  Примечание: Если ваша скорость скачивания слишком низкая, вы можете попробовать переключиться на другое зеркало.
+download.javafx.notes=Скачивание зависимостей для лаунчера из интернета.\n\nМожно нажать «Изменить источник скачивания», чтобы выбрать зеркало загрузки, или нажать «Отмена», чтобы остановить и выйти.\nПримечание: если ваша скорость скачивания слишком низкая, вы можете попробовать переключиться на другое зеркало.
 download.javafx.component=Скачивание модуля «%s»
 download.javafx.prepare=Подготовка к скачиванию
 download.speed.byte_per_second=%d Б/сек
@@ -412,8 +406,8 @@ download.speed.megabyte_per_second=%.1f МиБ/сек
 exception.access_denied=Лаунчер не может получить доступ к файлу «%s», возможно он занят другим процессом.\n\
   \n\
   Пользователи Windows могут открыть «Монитор ресурсов», чтобы проверить, не использует ли его в данный момент другой процесс. Если использует, вы можете повторить попытку после закрытия этого процесса.\n\
-  Если нет, проверьте, достаточно ли привилегий у вашего аккаунта для доступа к нему. 
-exception.artifact_malformed=Не удалось проверить целостность скачаных файлов.
+  Если нет, проверьте, достаточно ли привилегий у вашего аккаунта для доступа к нему.
+exception.artifact_malformed=Не удалось проверить целостность скачанных файлов.
 exception.ssl_handshake=Не удалось установить SSL-соединение из-за отсутствия SSL-сертификатов в текущей установке Java. Вы можете попробовать запустить лаунчер в другой версии Java, а затем повторить попытку.
 exception.dns.pollution=Не удалось установить SSL‑соединение. Возможно, некорректно разрешаются DNS‑имена. Попробуйте сменить DNS‑сервер или воспользоваться прокси-службой.
 
@@ -421,37 +415,29 @@ extension.bat=Пакетный файл Windows
 extension.png=Файл изображения
 extension.ps1=Сценарий Windows PowerShell
 extension.sh=Сценарий оболочки Bash
-# extension.command=
+extension.command=Сценарий оболочки macOS
 
-extension.datapack=Набор данных
+extension.datapack=Архив набора данных
 extension.mod=Файл мода
-# extension.modloader.installer=
-# extension.resourcepack=
-# extension.schematic=
+extension.modloader.installer=Установщик загрузчика модов
+extension.resourcepack=Архив пакета ресурсов
+extension.schematic=Файл схемы
 extension.world=Архив мира
 
 fatal.create_hmcl_current_directory_failure=Лаунчер не может создать папку HMCL (%s). Пожалуйста, переместите лаунчер в другое место и откройте его снова.
 fatal.javafx.incomplete=Среда JavaFX является неполной.\n\
   Попробуйте заменить Java или переустановить OpenJFX.
-fatal.javafx.missing=Отсутствует среда JavaFX.\n\
-  Откройте Лаунчер с помощью Java, которая включает OpenJFX.
-fatal.config_change_owner_root=Вы используете пользователя root для открытия Launcher. Это может помешать вам открыть HMCL под другим пользователем в будущем.\n\
-  Вы все еще хотите продолжить?
+fatal.javafx.missing=Отсутствует среда JavaFX.\nЗапустите HMCL с помощью Java, которая включает OpenJFX.
+fatal.config_change_owner_root=Вы запускаете HMCL от имени root. Из-за этого в будущем может не получиться открыть HMCL под другим пользователем.\nВсё равно продолжить?
 fatal.config_in_temp_dir=Вы открываете лаунчер во временной папке. Ваши настройки и игровые данные могут быть потеряны.\n\
   Рекомендуется перенести HMCL в другое место и открыть его заново.\n\
   Вы все еще хотите продолжить?
-fatal.config_loading_failure=Не удалось прочитать файлы конфигурации.\n\
-  Предоставьте лаунчеру разрешение на чтение и запись «%s» и файлам в нём.\n\
-  Для пользователей macOS попробуйте поместить HMCL куда-нибудь с разрешениями, отличными от «Рабочий стол», «Загрузки» и «Документы», и повторите попытку.
-fatal.config_loading_failure.unix=Программа запуска не смогла прочитать файл конфигурации, так как он был создан пользователем «%1$s».\n\
-  Откройте HMCL от имени пользователя root (не рекомендуется) или выполните следующую команду в терминале, чтобы изменить право собственности на конфигурационный файл для текущего пользователя:\n%2$s
-# fatal.config_unsupported_version=
-fatal.mac_app_translocation=Лаунчер изолируется ОС во временной папке благодаря механизмам безопасности macOS.\n\
-  Переместите HMCL в другую папку, прежде чем пытаться открыть. В противном случае ваши настройки и игровые данные могут быть потеряны после перезапуска.\n\
-  Вы все еще хотите продолжить?
+fatal.config_loading_failure=Не удалось прочитать файлы конфигурации.\nУбедитесь, что у HMCL есть права на чтение и запись в «%s» и файлы внутри.\nНа macOS попробуйте переместить HMCL в папку, отличную от «Рабочий стол», «Загрузки» и «Документы», и повторите попытку.
+fatal.config_loading_failure.unix=HMCL не смог прочитать файл конфигурации, так как он был создан пользователем «%1$s».\nОткройте HMCL от имени пользователя root (не рекомендуется) или выполните следующую команду в терминале, чтобы изменить право собственности на конфигурационный файл для текущего пользователя:\n%2$s
+fatal.config_unsupported_version=Текущий файл конфигурации создан более новой версией HMCL, и эта версия не может корректно его загрузить.\nОбновите HMCL и перезапустите его.\nДо обновления лаунчера изменённые настройки не будут сохраняться.
+fatal.mac_app_translocation=HMCL изолирован ОС во временной папке из-за механизмов безопасности macOS.\nПереместите HMCL в другую папку, прежде чем пытаться открыть. В противном случае ваши настройки и игровые данные могут быть потеряны после перезапуска.\nВы все еще хотите продолжить?
 fatal.migration_requires_manual_reboot=Обновление завершено. Перезапустите лаунчер.
-fatal.apply_update_failure=Мы сожалеем, лаунчер не смог завершить обновление, потому что что-то пошло не так.\n\
-  Вы можете обновить программу вручную, скачав более новую версию с %s.
+fatal.apply_update_failure=К сожалению, HMCL не удалось обновиться автоматически.\n\nВы можете обновить лаунчер вручную, скачав новую версию с %s.\nЕсли проблема повторяется, сообщите нам об этом.
 fatal.apply_update_need_win7=Лаунчер не может автоматически обновляться на Windows XP/Vista.\n\
   Вы можете обновить программу вручную, скачав более новую версию с %s.
 fatal.deprecated_java_version=В будущем для работы HMCL потребуется Java 17 или более поздняя версия, однако запуск игр будет поддерживаться и на Java 6~16.\n\
@@ -461,25 +447,18 @@ fatal.deprecated_java_version=В будущем для работы HMCL пот�
 Вы можете продолжать использовать старую версию Java. HMCL может распознавать и управлять несколькими версиями Java и автоматически выбирать подходящую Java в зависимости от версии игры.
 fatal.deprecated_java_version.download_link=Скачать Java %d
 fatal.samba=Если вы пытаетесь открыть лаунчер в общей папке Samba, он может не работать, попробуйте обновить Java или запустить лаунчер из локальной папки.
-fatal.illegal_char=Недопустимый символ «=» в пути к папке пользователя. Лаунчер может работать, но некоторые функции не будут работать.\n\
-  Вы не сможете использовать аккаунт authlib-injector или изменить скин для аккаунта в режиме офлайн.
-fatal.unsupported_platform=Minecraft еще не полностью поддерживается на вашей платформе, поэтому вы можете столкнуться с отсутствием функций или даже не сможете запустить игру.\n\
-   \n\
-   Если вы не можете запустить Minecraft версии 1.17 и новее, попробуйте переключить «Рендерер» на «Mesa LLVMpipe» в разделе «Глобальные/настройки экземпляра → Расширенные настройки», чтобы использовать рендеринг через CPU для лучшей совместимости.
-fatal.unsupported_platform.loongarch=Лаунчер обеспечил поддержку платформы Loongson.\n\
-  Если у вас возникнут проблемы во время игры, вы можете обратиться за помощью на сайт https://docs.hmcl.net/groups.html.
-fatal.unsupported_platform.windows_arm64=Лаунчер обеспечил нативную поддержку платформы Windows на архитектуре Arm. Если у вам возникли проблемы во время игры, попробуйте запустить игру с Java на базе архитектуры x86.\n\
-  \n\
-  Если вы используете платформу <b>Qualcomm</b>, вам может потребоваться установить <a href="ms-windows-store://pdp/?productid=9NQPSL29BFFF">пакет совместимости OpenGL</a> перед началом игры.\n\
-  Щелкните ссылку, чтобы перейти в Microsoft Store и установить пакет совместимости.
-# fatal.wine_warning=
+fatal.illegal_char=Путь к рабочей папке содержит недопустимый символ «=». Вы не сможете использовать authlib-injector или менять скин оффлайн-аккаунта.
+fatal.unsupported_platform=Minecraft еще не полностью поддерживается на вашей платформе, поэтому вы можете столкнуться с отсутствием функций или даже не сможете запустить игру.\n\nЕсли вы не можете запустить Minecraft версии 1.17 и новее, попробуйте переключить «Рендерер» на «Mesa LLVMpipe» или «Mesa Lavapipe» в разделе «Глобальные настройки / Раздельные настройки для сборки → Настройки графики», чтобы использовать рендеринг через CPU для лучшей совместимости.
+fatal.unsupported_platform.loongarch=HMCL поддерживает платформу Loongson.\nЕсли у вас возникнут проблемы во время игры, обратитесь за помощью на https://docs.hmcl.net/groups.html.
+fatal.unsupported_platform.windows_arm64=HMCL нативно поддерживает Windows на Arm. Если у вас возникли проблемы во время игры, попробуйте запустить игру с Java для архитектуры x86.\n\nЕсли вы используете платформу <b>Qualcomm</b>, вам может потребоваться установить <a href="ms-windows-store://pdp/?productid=9NQPSL29BFFF">пакет совместимости OpenGL</a> перед началом игры.\nЩелкните ссылку, чтобы перейти в Microsoft Store и установить пакет совместимости.
+fatal.wine_warning=HMCL запущен в Wine или одном из его дистрибутивов.\nHMCL — кроссплатформенное приложение, и лучше всего он работает нативно в вашей ОС.\nНажмите «ОК», чтобы продолжить, но учтите, что возможны проблемы.
 
 file=Файл
 
-folder.config=Конфигурация мод
-folder.game=Рабочие папки
-folder.logs=Журналы
-# folder.crash-reports=
+folder.config=Конфигурации модов
+folder.game=Рабочая папка
+folder.logs=Логи
+folder.crash-reports=Отчёты о вылетах
 folder.mod=Моды
 folder.resourcepacks=Пакеты ресурсов
 folder.shaderpacks=Пакеты шейдеров
@@ -489,139 +468,109 @@ folder.screenshots=Снимки экрана
 folder.world=Папка мира
 
 game=Игры
-game.crash.feedback=<b>Пожалуйста, не делитесь с другими скриншотами или фотографиями этого интерфейса.</b> Если вы просите помощи у других, нажмите <b>«Экспорт журналов с ошибками»</b> и отправьте экспортированный файл другим для анализа.
-game.crash.info=Сведения об отказе
-game.crash.reason=Анализатор сбоев
-game.crash.reason.analyzing=Анализирование...
+game.crash.feedback=<b>Пожалуйста, не делитесь с другими скриншотами или фотографиями этого интерфейса.</b> Если вы просите помощи у других, нажмите <b>«Экспорт логов вылета»</b> и отправьте экспортированный файл другим для анализа.
+game.crash.info=Сведения о вылете
+game.crash.reason=Причина вылета
+game.crash.reason.analyzing=Анализ...
 game.crash.reason.multiple=Обнаружено несколько причин:\n\n
-# game.crash.reason.block=
-game.crash.reason.bootstrap_failed=Игра отказала из-за мода «%1$s».\n\
+game.crash.reason.block=Игра вылетела из-за блока в мире.\n\nПопробуйте удалить этот блок с помощью <a href="https://minecraft.wiki/w/Tutorial:Programs_and_editors/Mapping#Map_editors">редакторов карт</a> или удалить мод, который его добавил.\n\nТип блока: %1$s\nРасположение: %2$s
+game.crash.reason.bootstrap_failed=Игра вылетела из-за мода «%1$s».\n\
   \n\
   Попробуйте удалить или обновить его.
-game.crash.reason.config=Игра отказала из-за того, что мод «%1$s» не смог разобрать свой файл конфигурации «%2$s».
-game.crash.reason.debug_crash=Игра отказала из-за того, что вы инициировали ее вручную. Так что вы, вероятно, знаете, почему :)
-game.crash.reason.duplicated_mod=Не удалось продолжить запуск игры из-за того, что дублируется мод «%1$s».\n\
-  \n\
-  %2$s\n\
-  \n\
-  Каждый мод должен быть установлен только один, удалите дублирующий мод и попробуйте снова.
-# game.crash.reason.entity=
-game.crash.reason.modmixin_failure=Игра отказала из-за невозможности ввести некоторые моды.\n\
-  \n\
-  Обычно это означает, что мод содержит ошибку или несовместим с текущей средой.\n\
-  \n\
-  Вы можете проверить журнал на наличие неправильного мода.
+game.crash.reason.config=Игра вылетела из-за того, что мод «%1$s» не смог разобрать свой файл конфигурации «%2$s».
+game.crash.reason.debug_crash=Вылет игры был вызван вручную. Так что вы, вероятно, знаете причину :)
+game.crash.reason.duplicated_mod=Не удалось продолжить запуск игры из-за того, что дублируется мод «%1$s».\n\n%2$s\n\nКаждый мод можно установить только один раз. Удалите дублирующийся мод и попробуйте снова.
+game.crash.reason.entity=Игра вылетела из-за сущности в мире.\n\nПопробуйте удалить эту сущность с помощью <a href="https://minecraft.wiki/w/Tutorial:Programs_and_editors/Mapping#Map_editors">редакторов карт</a> или удалить мод, который её добавил.\n\nТип сущности: %1$s\nРасположение: %2$s
+game.crash.reason.modmixin_failure=Игра вылетела: не удалось внедрить код некоторых модов.\n\nКак правило, это значит, что в моде ошибка или он несовместим с вашей сборкой.\n\nНайти проблемный мод поможет лог.
 game.crash.reason.forge_error=Возможно, Forge/NeoForge предоставили информацию об ошибке.\n\
   \n\
-  Вы можете просмотреть журнал и выполнить соответствующие действия в соответствии с информацией журнала в отчете об ошибках.\n\
+  Вы можете просмотреть лог и выполнить соответствующие действия в соответствии с информацией лога в отчете об ошибках.\n\
   \n\
   Если вы не видите сообщения об ошибке, вы можете просмотреть отчет об ошибке, чтобы узнать, как она возникла.\n\
   %1$s
-game.crash.reason.mod_resolution0=Игра отказала из-за проблем с модом. Вы можете проверить журнал на наличие неправильного мода.
-game.crash.reason.mixin_apply_mod_failed=Игра отказала из-за невозможности применить mixin к моду «%1$s».\n\
+game.crash.reason.mod_resolution0=Игра вылетела из-за проблем с модами. Проблемные моды можно найти в логах.
+game.crash.reason.mixin_apply_mod_failed=Игра вылетела из-за невозможности применить mixin к моду «%1$s».\n\
   \n\
   Вы можете попробовать удалить или обновить этот мод, чтобы решить проблему.
-game.crash.reason.java_version_is_too_high=Игра отказала из-за того, что версия Java слишком нова для продолжения работы.\n\
-  \n\
-  Укажите предыдущую основную версию Java в разделе «Глобальные настройки / Раздельные настройки для сборки → Java», а затем запустите игру.\n\
-  \n\
-  Если нет, вы можете загрузить его с <a href="https://www.java.com/download/">java.com (Java 8)</a> или <a href="https://bell-sw.com/pages/downloads">BellSoft Liberica Full JRE (Java 17)</a> и другие дистрибутивов, чтобы загрузить и установить ее (перезапустите лаунчер после установки).
-game.crash.reason.need_jdk11=Игра отказала из-за неподходящей версии Java.\n\
+game.crash.reason.java_version_is_too_high=Игра вылетела из-за слишком новой версии Java.\n\nУкажите предыдущую основную версию Java в разделе «Глобальные настройки / Раздельные настройки для сборки → Java», а затем запустите игру.\n\nЕсли её нет, скачайте и установите Java с <a href="https://www.java.com/download/">java.com (Java 8)</a>, <a href="https://bell-sw.com/pages/downloads/#downloads">BellSoft Liberica Full JRE (Java 17)</a> или другого дистрибутива (после установки перезапустите лаунчер).
+game.crash.reason.need_jdk11=Игра вылетела из-за неподходящей версии Java.\n\
   \n\
   Вам необходимо загрузить и установить Java 11, а также указать ее в разделе «Глобальные настройки / Раздельные настройки для сборки → Java».
-game.crash.reason.mod_name=Игра отказала из-за проблем с именем файла мода.\n\
-  \n\
-  В имени файла мода должны использоваться только английские буквы (A~Z, a~z), цифры (0~9), дефисы (-), подчеркивания (_) и точки (.) в половину ширины.\n\
-  \n\
-  Пожалуйста, откройте папку «mods» и измените имена всех несовместимых модов на совместимые символы, указанные выше.
+game.crash.reason.mod_name=Игра вылетела из-за проблем с именами файлов модов.\n\nВ именах файлов модов можно использовать только английские буквы (A~Z, a~z), цифры (0~9), дефисы (-), подчёркивания (_) и точки (.).\n\nОткройте папку «mods» и переименуйте все файлы модов, используя только указанные выше символы.
 game.crash.reason.incomplete_forge_installation=Игра не может быть запущена из-за неполной установки Forge/NeoForge.\n\
   \n\
-  Переустановите Forge/NeoForge в разделе «Изменить сборку → Погрузчики».
+  Переустановите Forge/NeoForge в разделе «Изменить сборку → Загрузчики».
 game.crash.reason.fabric_version_0_12=Fabric 0.12 (и выше) несовместим с установленными модами. Следует понизить версию fabric до 0.11.7.
 game.crash.reason.fabric_warnings=Предупреждения от Fabric Loader:\n\
   \n\
   %1$s
-game.crash.reason.file_already_exists=Игра отказала из-за того, что файл «%1$s» уже существует.\n\
+game.crash.reason.file_already_exists=Игра вылетела из-за того, что файл «%1$s» уже существует.\n\
   \n\
   Вы можете попробовать сделать резервную копию и удалить этот файл, а затем заново запустить игру.
-game.crash.reason.file_changed=Игра отказала из-за сбоя проверки файла.\n\
+game.crash.reason.file_changed=Игра вылетела из-за сбоя проверки файла.\n\
   \n\
   Если вы изменили файл Minecraft.jar, вам придется вернуть модификацию или заново скачать игру.
-game.crash.reason.gl_operation_failure=Игра отказала из-за некоторых модов, пакетов шейдеров/ресурсов.\n\
+game.crash.reason.gl_operation_failure=Игра вылетела из-за некоторых модов, пакетов шейдеров/ресурсов.\n\
   \n\
   Отключите используемые моды, пакеты ресурсов/шейдеров и попробуйте снова.
-game.crash.reason.graphics_driver=Игра отказала из-за проблемы с графическим драйвером. Обновите графический драйвер до последней версии.\n\
-  \n\
-  Если в вашем компьютере установлена дискретная видеокарта, необходимо проверить, использует ли игра интегрированную/ядер графику. Если это так, запустите HMCL и игру с использованием дискретной видеокарты. Если у вас по-прежнему возникают подобные проблемы, вы можете подумать о приобретении новой видеокарты или нового компьютера.\n\
-  \n\
-  Если вы хотите продолжать использовать интегрированную видеокарту, обратите внимание, что для Minecraft 1.16.5 или более ранней версии требуется <a href="https://www.oracle.com/java/technologies/javase/javase8-archive-downloads.html">Java 1.8.0_51</a> или более ранняя версия для процессоров серии Intel(R) Core(TM) 3000 или более ранних.
+game.crash.reason.graphics_driver=Игра вылетела из-за проблемы с графическим драйвером. Обновите графический драйвер до последней версии.\n\nЕсли в вашем компьютере установлена дискретная видеокарта, проверьте, не использует ли игра встроенную графику. Если это так, запустите HMCL и игру на дискретной видеокарте. Если проблема не исчезнет, возможно, стоит задуматься о новой видеокарте или новом компьютере.\n\nЕсли вы используете встроенную видеокарту, обратите внимание: для Minecraft 1.16.5 и более ранних версий на процессорах Intel(R) Core(TM) серии 3000 и более ранних требуется <a href="https://www.oracle.com/java/technologies/javase/javase8-archive-downloads.html">Java 1.8.0_51 или более ранняя</a>.
 game.crash.reason.macos_failed_to_find_service_port_for_display=Игра не может быть запущена из-за сбоя инициализации окна OpenGL на платформе Apple silicon.\n\
   \n\
   Для этой проблемы у HMCL временно нет прямых решений. Попробуйте открыть любой браузер и перейти в полноэкранный режим, затем вернуться в HMCL, запустить игру и <b>быстро вернуться на страницу браузера</b> перед появлением игрового окна, дождаться появления игрового окна, а затем вернуться в игровое окно.
-game.crash.reason.illegal_access_error=Игра отказала из-за некоторых модов.\n\
+game.crash.reason.illegal_access_error=Игра вылетела из-за некоторых модов.\n\nЕсли вам знакомо «%1$s», обновите или удалите соответствующие моды и попробуйте снова.
+game.crash.reason.install_mixinbootstrap=Игра вылетела из-за отсутствия MixinBootstrap.\n\
   \n\
-  Если вы знаете это: «%1$s», вы можете обновить или удалить мод(ы) и повторить попытку.
-game.crash.reason.install_mixinbootstrap=Игра отказала из-за отсутствия MixinBootstrap.\n\
-  \n\
-  Для решения проблемы вы можете попробовать установить <a href="https://www.curseforge.com/minecraft/mc-mods/mixinbootstrap">MixinBootstrap</a>. Если игра отказала после установки, попробуйте добавить восклицательный знак (!) перед именем файла этого мода, чтобы попытаться решить проблему.
-game.crash.reason.optifine_is_not_compatible_with_forge=Игра отказала из-за несовместимости OptiFine с текущей установкой Forge.\n\
-  \n\
-  Пожалуйста, перейдите на «официальный сайт OptiFine», проверьте, совместима ли версия Forge с OptiFine, и переустановите сборку в строгом соответствии с соответствующей версией, либо измените версию OptiFine в «Изменить сборку → Погрузчики».\n\
-  \n\
-  После тестирования мы пришли к выводу, что слишком высокие или слишком низкие версии OptiFine могут вызывать сбои.
-game.crash.reason.mod_files_are_decompressed=Игра отказала из-за того, что файл мода был извлечен.\n\
-  \n\
-  Пожалуйста, поместите весь файл мода прямо в папку с модом!\n\
-  \n\
-  Если извлечение вызывает ошибки в игре, удалите извлеченный мод в папке мод, а затем запустите игру.
-game.crash.reason.shaders_mod=Игра отказала из-за одновременной установки модов OptiFine и Shaders.\n\
+  Для решения проблемы вы можете попробовать установить <a href="https://www.curseforge.com/minecraft/mc-mods/mixinbootstrap">MixinBootstrap</a>. Если игра вылетает после установки, попробуйте добавить восклицательный знак (!) перед именем файла этого мода, чтобы попытаться решить проблему.
+game.crash.reason.optifine_is_not_compatible_with_forge=Игра вылетела из-за несовместимости OptiFine с текущей установкой Forge.\n\nПерейдите на <a href="https://optifine.net/downloads">официальный сайт OptiFine</a>, проверьте, совместима ли версия Forge с OptiFine, и переустановите сборку строго с подходящей версией, либо измените версию OptiFine в «Изменить сборку → Загрузчики».\n\nПо результатам тестирования слишком новые или слишком старые версии OptiFine могут вызывать вылеты.
+game.crash.reason.mod_files_are_decompressed=Игра вылетела, потому что файл мода был распакован.\n\nПоместите файл мода целиком прямо в папку mods!\n\nЕсли распаковка вызывает ошибки в игре, удалите распакованный мод из папки mods и запустите игру.
+game.crash.reason.shaders_mod=Игра вылетела из-за одновременной установки модов OptiFine и Shaders.\n\
   \n\
   Просто удалите мод Shaders, потому что OptiFine имеет встроенную поддержку шейдеров.
-game.crash.reason.rtss_forest_sodium=Игра отказала из-за того, что RivaTuner Statistical Server (RTSS) не совместим с Sodium.\n\
+game.crash.reason.rtss_forest_sodium=Игра вылетела из-за того, что RivaTuner Statistical Server (RTSS) несовместим с Sodium.\n\
   \n\
   Нажмите <a href="https://github.com/CaffeineMC/sodium-fabric/wiki/Known-Issues#rtss-incompatible">здесь</a>, чтобы узнать подробности.
-game.crash.reason.too_many_mods_lead_to_exceeding_the_id_limit=Игра отказала из-за того, что вы установили слишком много модов и превысили лимит игровых идентификаторов.\n\
+game.crash.reason.too_many_mods_lead_to_exceeding_the_id_limit=Игра вылетела из-за того, что вы установили слишком много модов и превысили лимит игровых идентификаторов.\n\
   \n\
   Попробуйте установить <a href="https://www.curseforge.com/minecraft/mc-mods/jeid">JEID</a> или удалить несколько больших модов.
-game.crash.reason.night_config_fixes=Игра отказала из-за некоторых проблем с Night Config.\n\
+game.crash.reason.night_config_fixes=Игра вылетела из-за некоторых проблем с Night Config.\n\
   \n\
   Вы можете попробовать установить мод <a href="https://www.curseforge.com/minecraft/mc-mods/night-config-fixes">Night Config Fixes</a>, который может помочь вам справиться с этой проблемой.\n\
   \n\
   Для получения дополнительной информации посетите <a href="https://www.github.com/Fuzss/nightconfigfixes">репозиторий мода на GitHub</a>.
 game.crash.reason.optifine_causes_the_world_to_fail_to_load=Игра может не запускаться из-за OptiFine.\n\
   \n\
-  Эта проблема возникает только в определенной версии OptiFine. Вы можете попробовать изменить версию OptiFine в разделе «Изменить сборку → Погрузчики».
-game.crash.reason.jdk_9=Игра отказала из-за того, что версия Java слишком новая для этой сборки.\n\
+  Эта проблема возникает только в определенной версии OptiFine. Вы можете попробовать изменить версию OptiFine в разделе «Изменить сборку → Загрузчики».
+game.crash.reason.jdk_9=Игра вылетела из-за того, что версия Java слишком новая для этой сборки.\n\
   \n\
   Вам необходимо загрузить и установить Java 8 и указать ее в разделе «Глобальные настройки / Раздельные настройки для сборки → Java».
-game.crash.reason.jvm_32bit=Игра отказала из-за того, что текущее распределение памяти превысило 32-битный лимит JVM.\n\
+game.crash.reason.jvm_32bit=Игра вылетела из-за того, что текущее распределение памяти превысило 32-битный лимит JVM.\n\
   \n\
-  Если ваша ОС 64-разрядная, установите и используйте 64-разрядная Java. Если ваша ОС 32-разрядная, вам может потребоваться переустановить 64-разрядную ОС или приобрести более современный компьютер.\n\
+  Если ваша ОС 64-разрядная, установите и используйте 64-разрядную Java. Если ваша ОС 32-разрядная, вам может потребоваться переустановить 64-разрядную ОС или приобрести более современный компьютер.\n\
   \n\
   Или вы можете отключить опцию «Автовыделение» в разделе «Глобальные настройки / Раздельные настройки для сборки → Оперативная память» и указать максимальный размер выделяемой памяти 1024 МиБ или меньше.
-game.crash.reason.loading_crashed_forge=Игра отказала из-за мода «%1$s» (%2$s).\n\
+game.crash.reason.loading_crashed_forge=Игра вылетела из-за мода «%1$s» (%2$s).\n\
   \n\
   Вы можете попробовать удалить или обновить его.
-game.crash.reason.loading_crashed_fabric=Игра отказала из-за мода «%1$s».\n\
+game.crash.reason.loading_crashed_fabric=Игра вылетела из-за мода «%1$s».\n\
   \n\
   Вы можете попробовать удалить или обновить его.
-game.crash.reason.mac_jdk_8u261=Игра отказала из-за того, что текущая версия Forge или OptiFine несовместима с установленной вами Java.\n\
+game.crash.reason.mac_jdk_8u261=Игра вылетела из-за того, что текущая версия Forge или OptiFine несовместима с установленной вами Java.\n\
   \n\
   Пожалуйста, попробуйте обновить Forge и OptiFine, или попробуйте использовать Java 8u251 или предыдущие версии.
-game.crash.reason.forge_repeat_installation=Игра отказала из-за дублирующей установки Forge. <a href="https://github.com/HMCL-dev/HMCL/issues/1880">Это известная проблема</a>\n\
+game.crash.reason.forge_repeat_installation=Игра вылетела из-за дублирующей установки Forge. <a href="https://github.com/HMCL-dev/HMCL/issues/1880">Это известная проблема</a>\n\
   \n\
-  Рекомендуется загрузить журнал и отправить отзыв на GitHub, чтобы мы могли найти больше сведений и решить эту проблему.\n\
+  Рекомендуется загрузить лог и отправить отзыв на GitHub, чтобы мы могли найти больше сведений и решить эту проблему.\n\
   \n\
-  В настоящее время вы можете удалить Forge и установить его заново в разделе «Изменить сборку → Погрузчики».
-game.crash.reason.optifine_repeat_installation=Игра отказала из-за дублирующей установки OptiFine.\n\
+  В настоящее время вы можете удалить Forge и установить его заново в разделе «Изменить сборку → Загрузчики».
+game.crash.reason.optifine_repeat_installation=Игра вылетела из-за дублирующей установки OptiFine.\n\
   \n\
-  Пожалуйста, удалите OptiFine из папки «mods» или деинсталлируйте его в «Изменить сборку → Погрузчики».
-game.crash.reason.memory_exceeded=Игра отказала из-за того, что для маленького файла подкачки было выделено слишком много памяти.\n\
+  Пожалуйста, удалите OptiFine из папки «mods» или деинсталлируйте его в «Изменить сборку → Загрузчики».
+game.crash.reason.memory_exceeded=Игра вылетела из-за того, что для маленького файла подкачки было выделено слишком много памяти.\n\
   \n\
   Вы можете попробовать отключить опцию «Автовыделение» в разделе «Глобальные настройки / Раздельные настройки для сборки → Оперативная память» и регулировать значение до тех пор, пока игра не запустится.\n\
   \n\
   Вы также можете попробовать увеличить размер файла подкачки в системных настройках.
-game.crash.reason.mod=Игра отказала из-за мода «%1$s»\n\
+game.crash.reason.mod=Игра вылетела из-за мода «%1$s».\n\
   \n\
   Вы можете обновить или удалить мод и повторить попытку.
 game.crash.reason.mod_resolution=Игра не может быть запущена из-за проблем с зависимостями модов.\n\
@@ -634,21 +583,21 @@ game.crash.reason.forgemod_resolution=Игра не может быть запу
   Forge/NeoForge предоставила следующую информацию:\n\
   \n\
   %1$s
-game.crash.reason.forge_found_duplicate_mods=Игра отказала из-за проблемы с дублированием модов. Forge/NeoForge предоставила следующую информацию:\n\n%1$s
-game.crash.reason.mod_resolution_collection=Игра отказала из-за несовместимости версии мода.\n\
+game.crash.reason.forge_found_duplicate_mods=Игра вылетела из-за проблемы с дублированием модов. Forge/NeoForge предоставила следующую информацию:\n\n%1$s
+game.crash.reason.mod_resolution_collection=Игра вылетела из-за несовместимости версии мода.\n\
   \n\
   «%1$s» требует «%2$s».\n\
   \n\
   Вам необходимо обновить или понизить версию «%3$s», прежде чем продолжить.
-game.crash.reason.mod_resolution_conflict=Игра отказала из-за конфликтующих модов.\n\
+game.crash.reason.mod_resolution_conflict=Игра вылетела из-за конфликтующих модов.\n\
   \n\
-  «%1$s» конфликтуют с «%2$s».
-game.crash.reason.mod_resolution_missing=Игра отказала из-за того, что не установлены некоторые зависимые моды.\n\
+  «%1$s» конфликтует с «%2$s».
+game.crash.reason.mod_resolution_missing=Игра вылетела из-за того, что не установлены некоторые зависимые моды.\n\
   \n\
   «%1$s» требует установки мода «%2$s».\n\
   \n\
   Это означает, что вам нужно сначала скачать и установить «%2$s», чтобы продолжить игру.
-game.crash.reason.mod_resolution_missing_minecraft=Игра отказала из-за несовместимости мода с текущей версией Minecraft.\n\
+game.crash.reason.mod_resolution_missing_minecraft=Игра вылетела из-за несовместимости мода с текущей версией Minecraft.\n\
   \n\
   «%1$s» требует Minecraft версии %2$s.\n\
   \n\
@@ -657,7 +606,7 @@ game.crash.reason.mod_resolution_missing_minecraft=Игра отказала и�
   Если вы хотите играть в текущую версию игры, вам следует установить мод, совместимый с этой версией Minecraft.
 game.crash.reason.mod_resolution_mod_version=%1$s (Версия: %2$s)
 game.crash.reason.mod_resolution_mod_version.any=%1$s (Любая версия)
-game.crash.reason.modlauncher_8=Игра отказала из-за того, что текущая версия Forge несовместима с вашей установкой Java. Пожалуйста, попробуйте обновить Forge.
+game.crash.reason.modlauncher_8=Игра вылетела из-за того, что текущая версия Forge несовместима с вашей установкой Java. Пожалуйста, попробуйте обновить Forge.
 game.crash.reason.no_class_def_found_error=Игра не может продолжить работу из-за неполного кода.\n\
   \n\
   В сборке вашей игры отсутствует «%1$s». Это может быть связано с отсутствием мода, установкой несовместимого мода или повреждением некоторых файлов.\n\
@@ -668,42 +617,38 @@ game.crash.reason.no_such_method_error=Игра не может продолжи
   В вашей сборке игры может отсутствовать мод, установлен несовместимый мод, или некоторые файлы могут быть повреждены.\n\
   \n\
   Возможно, вам придется переустановить игру и все моды или попросить кого-нибудь о помощи.
-game.crash.reason.opengl_not_supported=Игра отказала, потому что ваш графический драйвер не поддерживает OpenGL.\n\
+game.crash.reason.opengl_not_supported=Игра вылетела, потому что ваш графический драйвер не поддерживает OpenGL.\n\
   \n\
   Если вы транслируете игру через Интернет или используете среду удаленного рабочего стола, пожалуйста, играйте на локальной машине.\n\
   \n\
   Или попробуйте обновить графический драйвер до последней версии и перезапустить игру.\n\
   \n\
-  Если на вашем компьютере есть выделенная видaеокарта, убедитесь, что игра действительно использует ее для рендеринга. Если проблема не исчезнет, подумайте о приобретении новой видеокарты или нового компьютера.
+  Если на вашем компьютере есть дискретная видеокарта, убедитесь, что игра действительно использует ее для рендеринга. Если проблема не исчезнет, подумайте о приобретении новой видеокарты или нового компьютера.
 game.crash.reason.openj9=Игра не может быть запущена на OpenJ9 JVM.\n\
   \n\
   Пожалуйста, переключитесь на Java, использующую Hotspot JVM, в разделе «Глобальные настройки / Раздельные настройки для сборки → Java» и запустите игру заново. Если у вас нет такого типа Java, вы можете скачать его.
-game.crash.reason.out_of_memory=Игра отказала из-за того, что на компьютере закончилась память.\n\
+game.crash.reason.out_of_memory=Игра вылетела из-за того, что на компьютере закончилась память.\n\
   \n\
   Возможно, не хватает памяти или установлено слишком много модов. Вы можете попробовать решить эту проблему, увеличив объем выделенной памяти в разделе «Глобальные настройки / Раздельные настройки для сборки → Оперативная память».\n\
   \n\
-  Если вы по-прежнему сталкиваетесь с этими проблемами, возможно, вам нужен более качественный компьютер.
-game.crash.reason.resolution_too_high=Игра отказала из-за слишком высокого разрешения пакета ресурсов.\n\
+  Если вы по-прежнему сталкиваетесь с этими проблемами, возможно, вам нужен более мощный компьютер.
+game.crash.reason.resolution_too_high=Игра вылетела из-за слишком высокого разрешения пакета ресурсов.\n\
   \n\
-  Вам следует перейти на пакет ресурсов с меньшим разрешением или рассмотреть возможность покупки более качественной видеокарты с большим объемом VRAM.
-game.crash.reason.stacktrace=Причина отказа неизвестна. Вы можете просмотреть его детали, нажав «Журналы».\n\
-  \n\
-  Есть несколько ключевых слов, которые могут содержать названия некоторых модов. Вы можете поискать их в Интернете, чтобы выяснить проблему самостоятельно.\n\
-  \n\
-  %s
-game.crash.reason.too_old_java=Игра отказала из-за того, что вы используете устаревшую версию Java.\n\
+  Вам следует перейти на пакет ресурсов с меньшим разрешением или рассмотреть возможность покупки более мощной видеокарты с большим объемом VRAM.
+game.crash.reason.stacktrace=Причина вылета неизвестна. Подробности можно посмотреть, нажав «Логи».\n\nНиже приведены ключевые слова, среди которых могут быть названия модов. Поищите их в интернете, чтобы разобраться в проблеме самостоятельно.\n\n%s
+game.crash.reason.too_old_java=Игра вылетела из-за того, что вы используете устаревшую версию Java.\n\
   \n\
   Вам необходимо указать более новую версию Java (%1$s) в разделе «Глобальные настройки / Раздельные настройки для сборки → Java», а затем перезапустить игру. Скачать Java можно <a href="https://learn.microsoft.com/java/openjdk/download">отсюда</a>.
-game.crash.reason.unknown=Мы не можем выяснить причину отказа в игре. Пожалуйста, обратитесь к логам игры.
+game.crash.reason.unknown=Не удалось определить причину вылета игры. Посмотрите логи игры.
 game.crash.reason.unsatisfied_link_error=Не удалось запустить Minecraft из-за отсутствия библиотек: %1$s.\n\
   \n\
-  Если вы редактировали путь к родным библиотекам, убедитесь, что эти библиотеки существуют. Или попробуйте запустить игру снова после возврата к стандартным настройкам.\n\
+  Если вы редактировали путь к нативным библиотекам, убедитесь, что эти библиотеки существуют. Или попробуйте запустить игру снова после возврата к стандартным настройкам.\n\
   \n\
   Если вы этого не сделали, проверьте, нет ли у вас отсутствующих зависимых модов.\n\
   \n\
   В противном случае, если вы считаете, что это произошло по вине HMCL, пожалуйста, сообщите нам об этом.
-game.crash.title=Игра отказала!
-game.directory=Путь игры
+game.crash.title=Игра вылетела
+game.directory=Путь к игре
 game.version=Сборка
 
 game_directory=Папки с играми
@@ -714,21 +659,21 @@ game_directory.instance_directory=Папка с игрой
 game_directory.instance_directory.choose=Выберите папку с игрой
 game_directory.name=Имя
 game_directory.new=Новая папка
-game_directory.use_relative_path=По возможности используйте относительный путь для игры
-# game_directory.root=
+game_directory.use_relative_path=По возможности использовать относительный путь к папке игры
+game_directory.root=Если использовать корень диска как папку игры, игра может не запуститься, а в корне диска появится множество файлов и папок.\n\nВы уверены, что хотите продолжить?
 
 help=Справка
 help.doc=Документация лаунчера
-help.detail=Для создателей набора данных и модпака.
+help.detail=Для создателей наборов данных и модпаков.
 
 input.email=Имя пользователя должно быть адресом электронной почты.
 input.number=Ввод должен быть числом.
 input.not_empty=Это обязательное поле.
 input.url=Ввод должен быть действительным URL-адресом.
 
-install=Новый сборник
+install=Новая сборка
 install.change_version=Изменить версию
-# install.change_version.title=
+install.change_version.title=Изменить версию - %1s
 install.change_version.confirm=Переключить %s с версии %s на %s?
 install.change_version.process=Процесс изменения версии
 install.failed=Не удалось установить
@@ -736,25 +681,25 @@ install.failed.downloading=Не удалось скачать некоторые
 install.failed.downloading.detail=Не удалось скачать файл: %s
 install.failed.downloading.timeout=Таймаут скачивания при получении данных: %s
 install.failed.install_online=Не удалось идентифицировать предоставленный файл. Если вы хотите установить мод, перейдите на страницу «Моды».
-install.failed.malformed=Скачанные файлы повреждены. Вы можете попробовать решить эту проблему, переключившись на другой источник загрузки в разделе «Настройки → Скачать → Источник скачивания».
-# install.failed.cleanroom_not_compatible_with_forge=
+install.failed.malformed=Скачанные файлы повреждены. Вы можете попробовать решить эту проблему, переключившись на другой источник загрузки в разделе «Настройки → Загрузки → Источник скачивания».
+install.failed.cleanroom_not_compatible_with_forge=Cleanroom несовместим с Forge.
 install.failed.optifine_conflict=Невозможно установить OptiFine и Fabric на Minecraft 1.13 или более поздней версии.
 install.failed.optifine_forge_1.17=Для Minecraft 1.17.1 Forge совместим только с OptiFine H1 pre2 или более поздней версией. Вы можете установить их, отметив «Снапшоты» при выборе версии OptiFine в HMCL.
 install.failed.version_mismatch=Этот загрузчик требует версию игры %s, но установленная версия %s.
 install.installer.change_version=%s (Несовместимо)
 install.installer.choose=Выберите версию %s
-# install.installer.cleanroom=
+install.installer.cleanroom=Cleanroom
 install.installer.do_not_install=Не устанавливать
 install.installer.fabric=Fabric
 install.installer.fabric-api=Fabric API
-# install.installer.legacyfabric=
-# install.installer.legacyfabric-api=
-install.installer.fabric-quilt-api.warning=%1$s является модом и будет установлен в папку mod в сборке игры. Пожалуйста, не меняйте рабочую папку сборки, иначе %1$s не будет работать. Если вы все же хотите изменить папку, вам следует переустановить сборку.
+install.installer.legacyfabric=Legacy Fabric
+install.installer.legacyfabric-api=Legacy Fabric API
+install.installer.fabric-quilt-api.warning=%1$s — это мод, он будет установлен в папку mods сборки. Не меняйте рабочую папку игры, иначе %1$s не будет работать. Если всё же хотите сменить папку, переустановите его.
 install.installer.forge=Forge
 install.installer.neoforge=NeoForge
 install.installer.game=Minecraft
 install.installer.incompatible=Несовместимо с %s
-install.installer.install=Установить %s
+install.installer.install=Установка %s
 install.installer.install_offline=Установить/обновить из локального файла
 install.installer.liteloader=LiteLoader
 install.installer.not_installed=Не установлено
@@ -762,24 +707,24 @@ install.installer.optifine=OptiFine
 install.installer.quilt=Quilt
 install.installer.quilt-api=QSL/QFAPI
 install.installer.version=%s
-install.installer.external_version=%s (Устанавливается внешним процессом, который не может быть изменен)
+install.installer.external_version=%s (установлено внешней программой, настройка недоступна)
 install.installing=Установка
 install.modpack=Установить модпак
-install.modpack.installation=Установка модпак
+install.modpack.installation=Установка модпака
 install.name.invalid=Имя содержит специальные символы (например, эмодзи или символы CJK).\nРекомендуется изменить имя, включив в него только английские буквы, цифры и подчеркивание, чтобы избежать возможных проблем при запуске игры.\nВы хотите продолжить процесс?
 install.new_game=Установить сборку
 install.new_game.already_exists=Это имя сборки уже существует. Пожалуйста, используйте другое имя.
-install.new_game.installation=Установка экземпляра
+install.new_game.installation=Установка сборки
 install.new_game.malformed=Недопустимое имя
-# install.new_game.malformed_json=
+install.new_game.malformed_json=Недопустимый JSON-файл сборки Minecraft.
 install.success=Успешно установлено.
 
 instance=Игры
 instance.name=Название сборки
 instance.empty=Нет сборок
-instance.empty.add=Установить новую сборок
-# instance.empty.launch=
-# instance.empty.launch.goto_download=
+instance.empty.add=Добавить новую сборку
+instance.empty.launch=Нет доступных сборок.\nСкачайте игру на странице «Скачать» или смените папку с игрой на странице «Все сборки».
+instance.empty.launch.goto_download=Перейти к скачиванию
 instance.empty.hint=Нет сборок.\nВы можете попробовать перейти в другую папку с игрой или нажать здесь, чтобы скачать игру.
 instance.game.all=Все
 instance.game.april_fools=День смеха
@@ -788,35 +733,35 @@ instance.game.release=Релиз
 instance.game.releases=Релизы
 instance.game.snapshot=Снапшот
 instance.game.snapshots=Снапшоты
-# instance.game.support_status.unsupported=
-# instance.game.support_status.untested=
+instance.game.support_status.unsupported=Не поддерживается
+instance.game.support_status.untested=Не проверено
 instance.game.type=Тип
 instance.launch=Играть
-# instance.launch_and_enter_world=
+instance.launch_and_enter_world=Играть в этом мире
 instance.launch.empty=Играть
 instance.launch.empty.installing=Установка игры
 instance.launch.empty.tooltip=Установить и запустить последнюю официальную версию игры.
-instance.launch.test=Тестовая игра
+instance.launch.test=Тестовый запуск
 instance.switch=Сменить сборку
 instance.launch_script=Создать сценарий запуска
 instance.launch_script.failed=Невозможно создать сценарий запуска.
 instance.launch_script.save=Сохранить сценарий запуска
 instance.launch_script.success=Создан сценарий %s.
 instance.manage=Все сборки
-instance.manage.clean=Очистить журнал игры
+instance.manage.clean=Удалить файлы логов
 instance.manage.clean.tooltip=Очистить файлы в папках «logs» и «crash-reports».
-instance.manage.duplicate=Скопировать экземпляр сборки
+instance.manage.duplicate=Копировать сборку
 instance.manage.duplicate.duplicate_save=Скопировать миры
 instance.manage.duplicate.prompt=Введите новое название для этой сборки
-instance.manage.duplicate.confirm=Скопированная сборка будет иметь копию всех файлов в папке сборки(«.minecraft/versions/<имя сборки>»), с изолированной рабочей папкой и настройками.
+instance.manage.duplicate.confirm=Скопированная сборка будет иметь копию всех файлов в папке сборки («.minecraft/versions/<имя сборки>»), с изолированной рабочей папкой и настройками.
 instance.manage.manage=Изменить сборку
 instance.manage.manage.title=Изменить сборку - %1s
-instance.manage.redownload_assets_index=Обновить файлы игровых активов
+instance.manage.redownload_assets_index=Обновить ассеты игры
 instance.manage.remove=Удалить
 instance.manage.remove.confirm.trash=Удалить %s? Вы можете восстановить эту сборку с именем %s из корзины системы.
-instance.manage.remove.confirm.independent=Поскольку эта сборка находится в режиме разделения, удаление этой сборки приведет к удалению всех миров, принадлежащих этой сборке. Удалить %s?
-# instance.manage.remove.failed=
-instance.manage.remove_assets=Удалить файлы игровых активов
+instance.manage.remove.confirm.independent=Эта сборка хранится в изолированной папке, поэтому вместе с ней будут удалены её миры и другие данные. Всё равно удалить сборку «%s»?
+instance.manage.remove.failed=Не удалось удалить сборку. Возможно, некоторые файлы используются.
+instance.manage.remove_assets=Удалить все ассеты
 instance.manage.remove_libraries=Удалить файлы библиотек
 instance.manage.rename=Переименовать
 instance.manage.rename.message=Введите новое название для этой сборки
@@ -826,28 +771,28 @@ instance.search.prompt=Введите название версии для по�
 instance.settings=Настройки
 instance.update=Обновить модпак
 
-# java.add=
-java.add.failed=Этот Java недопустим или несовместим с текущей платформой.
+java.add=Добавить
+java.add.failed=Эта версия Java несовместима с текущей платформой.
 java.disable=Отключить Java
 java.disable.confirm=Вы уверены, что хотите отключить эту Java?
 java.disabled.management=Отключенная Java
 java.disabled.management.remove=Удалить эту Java из списка
 java.disabled.management.restore=Включить эту Java
-# java.download=
+java.download=Скачать
 java.download.banshanjdk-8=Скачать Banshan JDK 8
 java.download.load_list.failed=Не удалось загрузить список версий
 java.download.more=Больше дистрибутивов Java
-# java.download.title=
+java.download.title=Скачать Java
 java.download.prompt=Выберите версию Java, которую вы хотите скачать:
-java.download.distribution=Дистрибуция
+java.download.distribution=Дистрибутив
 java.download.version=Версия
-java.download.packageType=Тип упаковки
+java.download.packageType=Тип пакета
 java.management=Управление Java
 java.info.architecture=Архитектура
 java.info.vendor=Поставщик
 java.info.version=Версия
-java.info.disco.distribution=Дистрибуция
-java.install=Установите Java
+java.info.disco.distribution=Дистрибутив
+java.install=Установить Java
 java.install.archive=Расположение
 java.install.failed.exists=Это имя уже используется
 java.install.failed.invalid=Этот архив не является допустимым установочным пакетом Java, поэтому его установка невозможна.
@@ -862,27 +807,26 @@ lang.default=Использовать язык системы
 
 launch.advice=%s Вы все еще хотите продолжить запуск?
 launch.advice.multi=Были обнаружены следующие проблемы:\n\n%s\n\nЭти проблемы могут помешать вам запустить игру или повлиять на игровой процесс.\nВы все еще хотите продолжить запуск?
-launch.advice.java.auto=Текущая версия Java несовместима со сборкой.\n\nНажмите «Да», чтобы автоматически выбрать наиболее совместимую версию Java. Или же вы можете перейти в раздел «Глобальные настройки / Раздельные настройки для сборки → Java», чтобы выбрать один из них самостоятельно.
+launch.advice.java.auto=Текущая версия Java несовместима со сборкой.\n\nНажмите «Да», чтобы автоматически выбрать наиболее совместимую версию Java. Или же вы можете перейти в раздел «Глобальные настройки / Раздельные настройки для сборки → Java», чтобы выбрать её самостоятельно.
 launch.advice.java.modded_java_7=Для Minecraft 1.7.2 или более ранней версии требуется Java 7 или более ранняя версия.
-# launch.advice.cleanroom=
+launch.advice.cleanroom=Cleanroom %2$s работает только на Java %1$s или новее. Используйте Java %1$s или более новую версию.
 launch.advice.uncorrected=Если вы все еще хотите использовать выбранную вами версию Java, вы можете отключить опцию «Не проверять совместимость JVM» в разделе «Глобальные настройки / Раздельные настройки для сборки → Расширенные настройки».
 launch.advice.different_platform=Ваша ОС - 64-разрядная, а Java - 32-разрядная. Рекомендуется использовать 64-разрядную версию Java.
-launch.advice.forge2760_liteloader=Forge 2760 и выше не совместим с LiteLoader. Обновите Forge до 2773 или более новой версии.
-launch.advice.forge28_2_2_optifine=Forge 28.2.2 и более поздние версии не совместимы с OptiFine. Смените Forge на версию 28.2.1 или более старую версию.
-launch.advice.forge37_0_60=Версии Forge ранее 37.0.60 не совместимы с Java 17. Обновите Forge или запустите игру с Java 16.
+launch.advice.forge2760_liteloader=Forge версии 2760 несовместим с LiteLoader. Обновите Forge до версии 2773 или новее.
+launch.advice.forge28_2_2_optifine=Forge 28.2.2 и более поздние версии несовместимы с OptiFine. Смените Forge на версию 28.2.1 или более старую.
+launch.advice.forge37_0_60=Версии Forge до 37.0.60 несовместимы с Java 17. Обновите Forge до версии 37.0.60 или новее либо запустите игру с Java 16.
 launch.advice.java8_51_1_13=Minecraft 1.13 может аварийно завершить работу на более старой версии, чем Java 8 1.8.0_51. Установите последнюю версию Java 8.
 launch.advice.java9=Вы не сможете запустить Minecraft 1.12 и ниже с Java 9 и более новыми версиями Java. Используйте вместо этого Java 8.
-# launch.advice.lwjgl_3_4_1=
-# launch.advice.lwjgl_3_4_1.title=
+launch.advice.lwjgl_3_4_1=В текущей версии игры есть известная проблема, из-за которой игра может подтормаживать.\nHMCL может автоматически оптимизировать производительность игры (с помощью Java Agent).\nРазрешить HMCL автоматически оптимизировать игру?\nЕсли возникнут проблемы, отключите параметр «Разрешить HMCL изменять игру» в настройках сборки.
+launch.advice.lwjgl_3_4_1.title=Разрешить HMCL автоматически оптимизировать игру?
 launch.advice.modded_java=Некоторые моды могут быть несовместимы с новыми версиями Java. Рекомендуется использовать Java %s для запуска Minecraft %s.
 launch.advice.modlauncher8=Используемая вами версия Forge несовместима с текущей версией Java. Попробуйте обновить Forge.
-launch.advice.newer_java=Вы используете старую версию Java для запуска игры. Рекомендуется обновить Java 8, иначе некоторые моды могут привести к сбою игры.
-launch.advice.not_enough_space=Вы выделили слишком много памяти, поскольку размер физической памяти составляет %d МиБ, ваша игра может рухнуть.
+launch.advice.newer_java=Вы запускаете игру на старой версии Java. Рекомендуется обновиться до Java 8, иначе некоторые моды могут вызвать вылет игры.
+launch.advice.not_enough_space=Вы выделили больше памяти, чем установлено в компьютере (%d МиБ). Производительность может снизиться, а игра может вообще не запуститься.
 launch.advice.require_newer_java_version=Для текущей версии игры требуется Java %s, но мы не смогли ее найти. Хотите скачать ее сейчас?
-launch.advice.too_large_memory_for_32bit=Вы выделили слишком много памяти, из-за 32-разрядной JRE ваша игра может рухнуть. Максимальный объем памяти для 32-разрядных систем составляет 1024 МиБ.
-launch.advice.vanilla_linux_java_8=На Linux x86-64, Minecraft 1.12.2 и ниже может работать только на Java 8.\nВерсии Java 9 и выше не могут загружать 32-битные нативные библиотеки, такие как liblwjgl.so.
-launch.advice.vanilla_x86.translation=Minecraft еще не полностью поддерживается на вашей платформе, поэтому вы можете столкнуться с отсутствием функций или даже не сможете запустить игру.\n\
-  Пожалуйста, используйте Java для x86-64 для запуска minecraft через переводчик, или загрузите соответствующую нативную библиотеку платформы и укажите её путь размещения.
+launch.advice.too_large_memory_for_32bit=Вы выделили больше памяти, чем позволяет 32-разрядная Java. Игра может не запуститься.
+launch.advice.vanilla_linux_java_8=На Linux x86-64 Minecraft 1.12.2 и более ранние версии поддерживают только Java 8, потому что более новые версии Java не могут загружать 32-битные нативные библиотеки, такие как liblwjgl.so.\n\nСкачайте Java с java.com или установите OpenJDK 8.
+launch.advice.vanilla_x86.translation=Minecraft еще не полностью поддерживается на вашей платформе, поэтому вы можете столкнуться с отсутствием функций или даже не сможете запустить игру.\nДля полноценной игры скачайте Java для архитектуры <b>x86-64</b> <a href="https://learn.microsoft.com/java/openjdk/download">здесь</a>.
 launch.advice.unknown=Не удалось запустить игру по следующим причинам:
 launch.failed=Не удалось запустить
 launch.failed.cannot_create_jvm=Не удалось создать JVM. Это может быть вызвано неправильными аргументами JVM. Вы можете попробовать решить эту проблему, удалив все аргументы, добавленные в разделе «Глобальные настройки / Раздельные настройки для сборки → Расширенные настройки → Настройки JVM».
@@ -896,52 +840,52 @@ launch.failed.execution_policy.failed_to_set=Не удалось установ�
 launch.failed.execution_policy.hint=Текущая политика выполнения не позволяет выполнять сценарий PowerShell.\n\
   \n\
   Нажмите «ОК», чтобы разрешить текущему пользователю выполнять сценарий PowerShell, или нажмите «Отмена», чтобы оставить всё как есть.
-launch.failed.exited_abnormally=Игра отказала. Дополнительные сведения см. в журналах сбоев.
+launch.failed.exited_abnormally=Игра вылетела. Дополнительные сведения см. в логах вылета.
 launch.failed.java_version_too_low=Указанная вами версия Java слишком низкая. Измените версию Java.
-launch.failed.no_accepted_java=Не удалось найти совместимую версию Java, запустить игру с Java по умолчанию?\nНажмите «Да», чтобы запустить игру с Java по умолчанию.\nИли вы можете перейти в раздел «Глобальные настройки / Раздельные настройки для сборки → Java», чтобы выбрать один из них самостоятельно.
+launch.failed.no_accepted_java=Не удалось найти совместимую версию Java, запустить игру с Java по умолчанию?\nНажмите «Да», чтобы запустить игру с Java по умолчанию.\nИли вы можете перейти в раздел «Глобальные настройки / Раздельные настройки для сборки → Java», чтобы выбрать её самостоятельно.
 launch.failed.sigkill=Игра была принудительно завершена пользователем или системой.
 launch.state.dependencies=Подготовка зависимостей
-launch.state.done=Завершение запуска
+launch.state.done=Запущено
 launch.state.java=Проверка версии Java
 launch.state.logging_in=Вход в систему
 launch.state.modpack=Скачивание зависимостей
 launch.state.waiting_launching=Ожидание запуска игры
-launch.invalid_java=Неверный путь к Java. Переустановите путь к Java.
+launch.invalid_java=Неверный путь к Java. Укажите путь к Java заново.
 
 launcher=Лаунчер
 launcher.agreement=Пользовательское соглашение
 launcher.agreement.accept=Принять
 launcher.agreement.decline=Отклонить
 launcher.agreement.hint=Нужно принять пользовательское соглашение, чтобы использовать это программное обеспечение.
-# launcher.april_fools.switch_lzh=
-# launcher.april_fools.switch_lzh.confirm=
+launcher.april_fools.switch_lzh=Лаунчер HMCL теперь поддерживает классический китайский. Переключиться на классический китайский?\nВернуть прежний язык можно в «置設 → 貫用 → 文».
+launcher.april_fools.switch_lzh.confirm=Переключиться на классический китайский?\nНажмите «ОК», чтобы закрыть HMCL и перезапустить его на классическом китайском; нажмите «Отмена», чтобы оставить текущий язык и перейти на главную страницу HMCL.
 launcher.background=Фоновое изображение
 launcher.background.choose=Выберите фоновое изображение
-# launcher.background.builtin=
+launcher.background.builtin=Встроенный
 launcher.background.default=По умолчанию
-launcher.background.default.tooltip=Или «background.png/.jpg/.gif/.webp» и изображения в папке «bg».
-# launcher.background.fallback=
-# launcher.background.fallback.builtin=
-# launcher.background.fallback.paint=
-# launcher.background.fallback.theme_color=
-# launcher.background.load_policy=
-# launcher.background.load_policy.show_fallback_while_loading=
-# launcher.background.load_policy.wait_for_background=
-# launcher.background.loading=
+launcher.background.default.tooltip=Использует фон выбранной темы, если он есть; иначе ищет локальные файлы фона по умолчанию, а затем использует встроенные обои.
+launcher.background.fallback=Запасной фон
+launcher.background.fallback.builtin=Встроенный фон
+launcher.background.fallback.paint=Сплошной цвет
+launcher.background.fallback.theme_color=Следовать цвету темы
+launcher.background.load_policy=Режим загрузки
+launcher.background.load_policy.show_fallback_while_loading=Показывать запасной фон во время загрузки
+launcher.background.load_policy.wait_for_background=Ждать загрузки фона
+launcher.background.loading=Загрузка фона
 launcher.background.network=По ссылке
-# launcher.background.network.cache=
+launcher.background.network.cache=Кэшировать изображения по ссылке
 launcher.background.paint=Сплошной цвет
 launcher.background.theme=Следовать теме
-# launcher.background.theme_color=
+launcher.background.theme_color=Следовать цвету темы
 launcher.cache_directory=Папка с кэшем
 launcher.cache_directory.clean=Очистить кэш
 launcher.cache_directory.choose=Выберите папку для кэша
 launcher.cache_directory.default=По умолчанию («%APPDATA%/.minecraft» или «~/.minecraft»)
 launcher.cache_directory.disabled=Отключено
-launcher.cache_directory.invalid=Не удалось создать папку для кэша, возвращаем к значению по умолчанию.
+launcher.cache_directory.invalid=Не удалось создать папку для кэша, будет использована папка по умолчанию.
 launcher.contact=Связаться с нами
-launcher.crash=Лаунчер столкнулся с фатальной ошибкой! Скопируйте следующий журнал и попросите помощи в нашем Discord, группе QQ, GitHub или на другом форуме Minecraft.
-launcher.crash.java_internal_error=Лаунчер столкнулся с фатальной ошибкой! Пожалуйста, удалите Java и скачайте подходящую Java <a href="https://bell-sw.com/pages/downloads/#downloads">здесь</a>.
+launcher.crash=Лаунчер столкнулся с фатальной ошибкой! Скопируйте следующий лог и попросите помощи в нашем Discord, группе QQ, GitHub или на другом форуме Minecraft.
+launcher.crash.java_internal_error=HMCL столкнулся с критической ошибкой, потому что ваша Java повреждена. Удалите Java и скачайте подходящую <a href="https://bell-sw.com/pages/downloads/#downloads">здесь</a>.
 launcher.crash.hmcl_out_dated=Лаунчер столкнулся с фатальной ошибкой! Ваш лаунчер устарел. Обновите его!
 launcher.update_java=Пожалуйста, обновите версию Java.
 
@@ -949,16 +893,16 @@ libraries.download=Скачивание библиотек
 
 login.enter_password=Введите пароль.
 
-# logwindow.always_on_top=
-logwindow.show_lines=Показать линии
+logwindow.always_on_top=Поверх всех окон
+logwindow.show_lines=Показывать номера строк
 logwindow.terminate_game=Завершить игру
-logwindow.title=Журнал
+logwindow.title=Лог
 logwindow.help=Вы можете обратиться к сообществу HMCL, чтобы получить помощь от других
 logwindow.autoscroll=Автопрокрутка
-# logwindow.wrap_text=
-logwindow.export_game_crash_logs=Экспорт журналов с ошибками
+logwindow.wrap_text=Перенос строк
+logwindow.export_game_crash_logs=Экспорт логов вылета
 logwindow.export_dump=Экспорт дампа стека игры
-logwindow.export_dump.no_dependency=Ваша Java не содержит зависимостей для создания дампа стека.
+logwindow.export_dump.no_dependency=Ваша Java не содержит зависимостей для создания дампа стека. За помощью обратитесь в наш Discord или группу QQ.
 
 
 message.cancelled=Операция была отменена
@@ -973,19 +917,19 @@ message.info=Сведения
 message.success=Операция успешно завершена
 message.unknown=Неизвестно
 message.warning=Предупреждение
-# message.question=
+message.question=Вопрос
 
 modpack=Модпаки
 modpack.choose=Выберите модпак
 modpack.choose.local=Импорт из файла
 modpack.choose.local.detail=Можно перетащить файл модпака сюда
-modpack.choose.remote=Скачать
+modpack.choose.remote=Скачать по ссылке
 modpack.choose.remote.detail=Необходима прямая ссылка на скачивание модпака
 modpack.choose.repository=Скачать модпак с CurseForge или Modrinth
 modpack.choose.repository.detail=Вы сможете выбрать нужный вам модпак на следующей странице.
 modpack.choose.remote.tooltip=Введите URL-адрес модпака
 modpack.completion=Скачивание зависимостей
-modpack.desc=Опишите модпак, включая введение и журнал изменений. Поддерживаются Markdown и изображения по URL-адресу.
+modpack.desc=Опишите модпак, включая введение и список изменений. Поддерживаются Markdown и изображения по URL-адресу.
 modpack.description=Описание
 modpack.download=Скачать модпак
 modpack.download.title=Скачать модпак - %1s
@@ -995,10 +939,10 @@ modpack.file_api=Префикс URL модпака
 modpack.files.blueprints=Чертежи BuildCraft
 modpack.files.config=Файлы конфигурации мода
 modpack.files.dumps=Выходные файлы отладки NEI
-# modpack.files.empty=
+modpack.files.empty=Нет файлов для экспорта
 modpack.files.hmclversion_cfg=Файл конфигурации лаунчера
 modpack.files.liteconfig=Связанные файлы LiteLoader
-# modpack.files.load_failed=
+modpack.files.load_failed=Не удалось загрузить дерево файлов модпака. Нажмите здесь, чтобы повторить попытку.
 modpack.files.mods=Моды
 modpack.files.mods.voxelmods=Настройки VoxelMods
 modpack.files.options_txt=Файл настроек Minecraft
@@ -1007,10 +951,10 @@ modpack.files.resourcepacks=Пакеты ресурсов/текстур
 modpack.files.saves=Миры
 modpack.files.scripts=Файл конфигурации MineTweaker
 modpack.files.servers_dat=Файл списка серверов
-modpack.installing=Установка модпак
-modpack.installing.given=Установка модпак %s
+modpack.installing=Установка модпака
+modpack.installing.given=Установка модпака %s
 modpack.invalid=Неверный модпак, попробуйте скачать его заново.
-modpack.mismatched_type=Несоответствие типа модпака, текущий сборка имеет тип %s, но предоставленный сборка имеет тип %s.
+modpack.mismatched_type=Тип модпака не совпадает: текущая сборка имеет тип %s, а выбранный модпак — %s.
 modpack.name=Имя модпака
 modpack.origin=Источник
 modpack.origin.url=Официальный сайт
@@ -1020,18 +964,18 @@ modpack.scan=Разбор индекса модпака
 modpack.task.install=Установить модпак
 modpack.task.install.error=Не удалось идентифицировать этот модпак. Поддерживаются только модпаки Curse, Modrinth, MultiMC и MCBBS.
 modpack.type.curse=Curse
-modpack.type.curse.error=Невозможно установить этот модпак. Повторите ещё раз.
+modpack.type.curse.error=Не удалось скачать зависимости. Повторите попытку или используйте прокси-сервер.
 modpack.type.curse.not_found=Некоторые из необходимых ресурсов отсутствуют и поэтому не могут быть загружены. Скачайте последнюю версию или другие модпаки.
 modpack.type.manual.warning=Возможно, вам нужно напрямую распаковать файл этого модпака, а не импортировать его. И запустите игру с помощью прилагаемого лаунчера. Этот модпак создаётся вручную путем сжатия директории .minecraft, а не экспортируется лаунчером. HMCL может попытаться импортировать этот модпак, продолжать?
 modpack.type.mcbbs=MCBBS
 modpack.type.mcbbs.export=Может быть импортирован HMCL
 modpack.type.modrinth=Modrinth
-modpack.type.modrinth.export=Может быть импортирован популярными сторонними лаунчеры
+modpack.type.modrinth.export=Может быть импортирован популярными сторонними лаунчерами
 modpack.type.multimc=MultiMC
 modpack.type.multimc.export=Может быть импортирован HMCL и MultiMC
-modpack.type.server=Сервер автообновления модпака
-modpack.type.server.export=Разрешить менеджеру сервера удаленно обновлять клиент игры
-modpack.type.server.malformed=Некорректный манифест модпака сервера
+modpack.type.server=Автообновление модпака с сервера
+modpack.type.server.export=Позволяет владельцу сервера удалённо обновлять сборку
+modpack.type.server.malformed=Некорректный манифест модпака. Обратитесь к автору модпака, чтобы решить проблему.
 modpack.unsupported=HMCL не поддерживает этот формат пакетов
 modpack.update=Обновление модпака
 modpack.wizard=Мастер экспорта модпака
@@ -1045,12 +989,12 @@ modpack.wizard.step.initialization.exported_version=Сборка игры для
 modpack.wizard.step.initialization.force_update=Принудительное обновление модпака до последней версии (вам понадобится служба хостинга файлов)
 modpack.wizard.step.initialization.include_launcher=Включать лаунчер
 modpack.wizard.step.initialization.modrinth.info=Лаунчер будет использовать удаленные ресурсы CurseForge/Modrinth вместо локальных файлов (включая моды, пакеты ресурсов и пакеты шейдеров) при создании модпака, чтобы уменьшить размер модпака, и помечать файлы с расширением «.disabled» как необязательные для установки.
-modpack.wizard.step.initialization.no_create_remote_files=Не используйте удаленные файлы
+modpack.wizard.step.initialization.no_create_remote_files=Не использовать удалённые файлы
 modpack.wizard.step.initialization.save=Экспортировать в...
-modpack.wizard.step.initialization.skip_curseforge_remote_files=Не используйте удаленные файлы CurseForge
-modpack.wizard.step.initialization.warning=Перед созданием модпака убедитесь, что игра запускается нормально и Minecraft является релизной версией, а не снапшотом. Пусковая установка сохранит ваши настройки скачивания.\n\
+modpack.wizard.step.initialization.skip_curseforge_remote_files=Не использовать удалённые файлы CurseForge
+modpack.wizard.step.initialization.warning=Перед созданием модпака убедитесь, что игра запускается нормально и Minecraft является релизной версией, а не снапшотом. Лаунчер сохранит ваши настройки скачивания.\n\
   \n\
-  Помните, что вам не разрешается добавлять моды и пакет ресурсов, в которых явно указано, что они не подлежат распространению или помещению в модпак.
+  Помните, что вам не разрешается добавлять моды и пакеты ресурсов, в которых явно указано, что они не подлежат распространению или помещению в модпак.
 modpack.wizard.step.initialization.server=Нажмите здесь для получения дополнительных руководств по созданию модпака на сервере, который может автообновляться.
 
 # Translation primarily from modrinth.
@@ -1149,14 +1093,14 @@ modrinth.category.256x=256x
 modrinth.category.512x+=512x и выше
 
 mods=Моды
-# mods.add=
+mods.add=Добавить
 mods.add.failed=Не удалось установить мод %s.
 mods.add.success=%s был успешно добавлен.
-# mods.add.title=
+mods.add.title=Выберите файл мода, который хотите добавить
 mods.disable=Отключить
 mods.download=Скачать мод
 mods.download.title=Скачать мод - %1s
-# mods.empty=
+mods.empty=Нет модов
 mods.enable=Включить
 mods.game.version=Версия игры
 mods.manage=Моды
@@ -1167,30 +1111,30 @@ mods.mcmod.search=Искать на MCMod
 mods.name=Название
 mods.restore=Восстановить
 mods.url=Официальная страница
-mods.update_modpack_mod.warning=Обновление модов в пакете модов может привести к непоправимым результатам, возможно, повредить пакет модов так, что он не сможет запуститься. Вы уверены, что хотите обновить?
-# mods.warning.loader_mismatch=
+mods.update_modpack_mod.warning=Обновление модов в модпаке может привести к непоправимым последствиям: модпак может повредиться и перестать запускаться. Вы уверены, что хотите обновить?
+mods.warning.loader_mismatch=Не тот загрузчик модов
 mods.install=Установить
 mods.save_as=Сохранить как
-# mods.unknown=
+mods.unknown=Неизвестный мод
 
-# menu.undo=
-# menu.redo=
-# menu.cut=
-# menu.copy=
-# menu.paste=
-# menu.deleteselection=
-# menu.selectall=
+menu.undo=Отменить
+menu.redo=Повторить
+menu.cut=Вырезать
+menu.copy=Копировать
+menu.paste=Вставить
+menu.deleteselection=Удалить
+menu.selectall=Выделить всё
 
-nbt.entries=%s записи
+nbt.entries=Записей: %s
 nbt.open.failed=Не удалось открыть файл
 nbt.save.failed=Не удалось сохранить файл
-nbt.title=Смотреть файл - %s
+nbt.title=Просмотр файла - %s
 
 datapack=Наборы данных
-# datapack.add=
-# datapack.add.title=
-# datapack.empty=
-# datapack.reload.toast=
+datapack.add=Добавить
+datapack.add.title=Выберите архив набора данных, который хотите добавить
+datapack.empty=Нет наборов данных
+datapack.reload.toast=Minecraft запущен. Чтобы перезагрузить наборы данных, используйте команду /reload
 datapack.title=Мир [%s] - Наборы данных
 
 web.failed=Не удалось загрузить страницу
@@ -1198,50 +1142,50 @@ web.open_in_browser=Хотите ли вы открыть этот адрес в
 web.view_in_browser=Смотреть в браузере
 
 world=Миры
-# world.add=
+world.add=Добавить
 world.add.already_exists=Мир уже существует.
 world.add.failed=Не удалось импортировать этот мир\: %s
 world.add.invalid=Не удалось разобрать мир.
 world.add.title=Выберите архив мира, который хотите импортировать
-world.backup=Резервный мир
-# world.backup.create.new_one=
+world.backup=Резервные копии мира
+world.backup.create.new_one=Новая резервная копия
 world.backup.create.failed=Не удалось создать резервную копию.\n%s
-world.backup.create.success=Успешно создано новое резервное копирование: %s
+world.backup.create.success=Резервная копия создана: %s
 world.backup.delete=Удалить эту резервную копию
-# world.backup.empty=
+world.backup.empty=Нет резервных копий
 world.backup.processing=Создание новой резервной копии ...
 world.chunkbase=Chunk Base
 world.chunkbase.end_city=Город Края
 world.chunkbase.seed_map=Предпросмотр генерации мира
 world.chunkbase.stronghold=Крепость
 world.chunkbase.nether_fortress=Крепость Нижнего мира
-# world.duplicate=
-# world.duplicate.prompt=
+world.duplicate=Копировать мир
+world.duplicate.prompt=Введите название копии мира
 world.duplicate.failed.already_exists=Папка уже существует
 world.duplicate.failed.invalid_name=Название содержит недопустимые символы
-# world.duplicate.failed=
-# world.duplicate.success.toast=
+world.duplicate.failed=Не удалось скопировать мир
+world.duplicate.success.toast=Мир скопирован
 world.datapack=Наборы данных
 world.datetime=Последний запуск игры %s
 world.delete=Удалить этот мир
 world.delete.failed=Не удалось удалить мир.\n%s
-# world.download=
+world.download=Скачать
 world.download.title=Скачать мир - %1s
-# world.empty=
+world.empty=Нет миров
 world.export=Экспорт мира
 world.export.title=Выберите папку для экспорта мира
 world.export.location=Экспорт в
 world.export.wizard=Экспорт мира %s
 world.game_version=Версия игры
-# world.icon=
-# world.icon.change=
-# world.icon.change.fail.load.title=
-# world.icon.change.fail.load.text=
-# world.icon.change.fail.not_64x64.title=
-# world.icon.change.fail.not_64x64.text=
-# world.icon.change.succeed.toast=
-# world.icon.change.tip=
-# world.icon.choose.title=
+world.icon=Значок мира
+world.icon.change=Изменить значок мира
+world.icon.change.fail.load.title=Не удалось разобрать изображение
+world.icon.change.fail.load.text=Похоже, изображение повреждено, и HMCL не может его разобрать.
+world.icon.change.fail.not_64x64.title=Неверный размер изображения
+world.icon.change.fail.not_64x64.text=Разрешение изображения — %d×%d, а нужно 64×64. Выберите изображение 64×64 и попробуйте снова.
+world.icon.change.succeed.toast=Значок мира обновлён.
+world.icon.change.tip=Нужно изображение PNG размером 64×64. Изображения с другим разрешением Minecraft прочитать не сможет.
+world.icon.choose.title=Выберите значок мира
 world.info=Сведения о мире
 world.info.basic=Основные сведения
 world.info.allow_cheats=Разрешить команды/читы
@@ -1250,20 +1194,20 @@ world.info.dimension.the_end=Край
 world.info.difficulty=Сложность
 world.info.difficulty.peaceful=Мирная
 world.info.difficulty.easy=Лёгкая
-world.info.difficulty.normal=Нормальная
+world.info.difficulty.normal=Обычная
 world.info.difficulty.hard=Сложная
-# world.info.difficulty_lock=
+world.info.difficulty_lock=Зафиксировать сложность
 world.info.failed=Не удалось прочитать сведения о мире
 world.info.game_version=Версия игры
 world.info.last_played=Последний запуск игры
 world.info.generate_features=Генерация строений
-world.info.player=Сведения о игроке
+world.info.player=Сведения об игроке
 world.info.player.food_level=Уровень голода
-# world.info.player.food_saturation_level=
+world.info.player.food_saturation_level=Насыщение
 world.info.player.game_type=Режим игры
 world.info.player.game_type.adventure=Приключение
 world.info.player.game_type.creative=Творчество
-# world.info.player.game_type.hardcore=
+world.info.player.game_type.hardcore=Хардкор
 world.info.player.game_type.spectator=Наблюдение
 world.info.player.game_type.survival=Выживание
 world.info.player.health=Здоровье
@@ -1272,14 +1216,14 @@ world.info.player.location=Расположение
 world.info.player.spawn=Точка возрождения
 world.info.player.xp_level=Уровень опыта
 world.info.random_seed=Ключ генератора мира
-# world.info.spawn=
-# world.info.time=
-# world.info.time.format=
-# world.load.fail=
-world.locked=В эксплуатации
-world.locked.failed=В настоящее время мир находится в эксплуатации. Закройте игру и попробуйте снова.
+world.info.spawn=Точка возрождения мира
+world.info.time=Время в игре
+world.info.time.format=%d д %d ч %d мин
+world.load.fail=Не удалось загрузить мир
+world.locked=Запущен
+world.locked.failed=Мир сейчас запущен. Закройте игру и попробуйте снова.
 world.manage=Миры
-# world.manage.button=
+world.manage.button=Управление миром
 world.manage.title=Мир - %s
 world.name=Название мира
 world.name.enter=Введите название мира
@@ -1287,7 +1231,7 @@ world.show_all=Показать все
 
 repositories.custom=Пользовательский репозиторий Maven (%s)
 repositories.maven_central=Универсальный (Maven Central)
-repositories.tencentcloud_mirror=Зеркало Mainland China (Репозиторий Tencent Cloud Maven)
+repositories.tencentcloud_mirror=Зеркало для материкового Китая (репозиторий Tencent Cloud Maven)
 repositories.chooser=Для работы HMCL требуется JavaFX.\n\
   \n\
   Нажмите «ОК», чтобы скачать JavaFX из указанного репозитория, или нажмите «Отмена» чтобы выйти.\n\
@@ -1296,37 +1240,37 @@ repositories.chooser=Для работы HMCL требуется JavaFX.\n\
 repositories.chooser.title=Выберите зеркало для скачивания JavaFX
 
 resourcepack=Пакеты ресурсов
-# resourcepack.add=
-# resourcepack.add.failed=
-# resourcepack.add.title=
-# resourcepack.delete.failed=
-# resourcepack.download=
+resourcepack.add=Добавить
+resourcepack.add.failed=Не удалось добавить пакеты ресурсов:
+resourcepack.add.title=Выберите архив пакета ресурсов, который хотите добавить
+resourcepack.delete.failed=Не удалось удалить пакет ресурсов
+resourcepack.download=Скачать
 resourcepack.download.title=Скачать пакет ресурсов - %1s
-# resourcepack.empty=
-# resourcepack.manage=
-# resourcepack.update_in_modpack.warning=
-# resourcepack.warning.invalid=
-# resourcepack.warning.manipulate=
-# resourcepack.warning.missing_game_meta=
-# resourcepack.warning.missing_pack_meta=
-# resourcepack.warning.too_new=
-# resourcepack.warning.too_old=
+resourcepack.empty=Нет пакетов ресурсов
+resourcepack.manage=Пакеты ресурсов
+resourcepack.update_in_modpack.warning=Обновление пакетов ресурсов в модпаке может привести к непоправимым последствиям, например к неправильным текстурам и звукам. Вы уверены, что хотите обновить?
+resourcepack.warning.invalid=Недопустимые метаданные пакета
+resourcepack.warning.manipulate=Несовместимые пакеты ресурсов могут некорректно работать в игре.\n\nВы уверены, что хотите включить выбранные пакеты ресурсов?
+resourcepack.warning.missing_game_meta=Нет метаданных сборки
+resourcepack.warning.missing_pack_meta=Нет метаданных пакета
+resourcepack.warning.too_new=Для более новой версии Minecraft
+resourcepack.warning.too_old=Для более старой версии Minecraft
 
-reveal.in_file_manager=Открыть в файловый менеджер
+reveal.in_file_manager=Показать в файловом менеджере
 
 schematics=Схемы
-# schematics.add=
+schematics.add=Добавить
 schematics.add.failed=Не удалось добавить файлы схем
-# schematics.add.title=
+schematics.add.title=Выберите файл схемы для импорта
 schematics.back_to=Назад на «%s»
-# schematics.create_directory=
+schematics.create_directory=Новая папка
 schematics.create_directory.prompt=Введите новое имя папки
 schematics.create_directory.failed=Не удалось создать папку
 schematics.create_directory.failed.already_exists=Папка уже существует
 schematics.create_directory.failed.invalid_name=Название содержит недопустимые символы
-# schematics.empty=
+schematics.empty=Нет схем
 schematics.info.description=Описание
-schematics.info.enclosing_size=Суммарный размер
+schematics.info.enclosing_size=Габариты
 schematics.info.name=Название
 schematics.info.region_count=Регионов
 schematics.info.schematic_author=Автор
@@ -1341,18 +1285,18 @@ schematics.sub_items=%d элемент(ов)
 search=Поиск
 search.hint.chinese=Поиск на китайском и английском языках
 search.hint.english=Поиск только на английском языке
-search.enter=Вводите здесь
+search.enter=Введите текст
 search.sort=Сортировка
-search.first_page=Первый
+search.first_page=Первая
 search.previous_page=Пред.
 search.next_page=След.
-# search.no_results_found=
-search.last_page=Последний
+search.no_results_found=Ничего не найдено
+search.last_page=Последняя
 search.page_n=%d / %s
 
 selector.choose=Выберите
 selector.choose_file=Выберите файл
-# selector.choose_directory=
+selector.choose_directory=Выберите папку
 selector.custom=Свой
 
 settings=Настройки
@@ -1363,32 +1307,32 @@ settings.advanced.title=Расширенные настройки - %s
 settings.advanced.custom_commands=Пользовательские команды
 settings.advanced.dont_check_game_completeness=Не проверять целостность игры
 settings.advanced.dont_check_jvm_validity=Не проверять совместимость JVM
-settings.advanced.dont_patch_natives=Не пытайтесь автоматически заменить нативные библиотеки
+settings.advanced.dont_patch_natives=Не пытаться автоматически заменять нативные библиотеки
 settings.advanced.environment_variables=Переменные среды
-# settings.advanced.environment_variables.subtitle=
+settings.advanced.environment_variables.subtitle=Пары «ключ-значение», которые передаются процессу игры
 settings.advanced.game_dir.default=По умолчанию («.minecraft/»)
-settings.advanced.game_dir.independent=Раздельно («.minecraft/versions/<имя сборки>/», кроме assets и библиотек)
-# settings.advanced.graphics=
-# settings.advanced.graphics_backend=
-# settings.advanced.graphics_backend.desc=
-# settings.advanced.graphics_backend.default=
-# settings.advanced.graphics_backend.default.desc=
-# settings.advanced.graphics_backend.opengl=
-# settings.advanced.graphics_backend.opengl.desc=
-# settings.advanced.graphics_backend.vulkan=
-# settings.advanced.graphics_backend.vulkan.desc=
-# settings.advanced.graphics_backend.vulkan.desc.global=
-# settings.advanced.graphics_backend.vulkan.desc.unsupported=
+settings.advanced.game_dir.independent=Раздельно («.minecraft/versions/<имя сборки>/», кроме ассетов и библиотек)
+settings.advanced.graphics=Настройки графики
+settings.advanced.graphics_backend=Графический API
+settings.advanced.graphics_backend.desc=Работает только для Minecraft 26.2+
+settings.advanced.graphics_backend.default=По умолчанию
+settings.advanced.graphics_backend.default.desc=Как в настройках игры
+settings.advanced.graphics_backend.opengl=OpenGL
+settings.advanced.graphics_backend.opengl.desc=Использовать OpenGL для рендеринга
+settings.advanced.graphics_backend.vulkan=Vulkan
+settings.advanced.graphics_backend.vulkan.desc=Использовать Vulkan для рендеринга
+settings.advanced.graphics_backend.vulkan.desc.global=Использовать Vulkan для рендеринга (начиная с Minecraft 26.2)
+settings.advanced.graphics_backend.vulkan.desc.unsupported=Использовать Vulkan для рендеринга (не поддерживается текущей версией игры)
 settings.advanced.java_permanent_generation_space=Пространство PermGen
 settings.advanced.jvm=Настройки JVM
 settings.advanced.jvm_args=Аргументы JVM
 settings.advanced.jvm_args.prompt=\  · Если параметр, введённый в «Аргументы JVM», совпадает с параметром по умолчанию, он не будет добавлен.\n\
   \  · Введите любые параметры GC в «Аргументы JVM», параметр G1 по умолчанию будет отключен.\n\
-  \  · Нажмите «Не добавлять аргументы JVM по умолчанию» ниже, чтобы запустить игру без добавления аргументов по умолчанию.
-# settings.advanced.jvm_memory.deprecated=
-# settings.advanced.jvm_memory.deprecated.subtitle=
-# settings.advanced.launch_options=
-# settings.advanced.launch_options.subtitle=
+  \  · Включите «Не добавлять аргументы JVM по умолчанию», чтобы запустить игру без добавления аргументов по умолчанию.
+settings.advanced.jvm_memory.deprecated=Устаревшие настройки памяти JVM
+settings.advanced.jvm_memory.deprecated.subtitle=Эти настройки сохранены только для совместимости со старыми версиями HMCL
+settings.advanced.launch_options=Дополнительные параметры
+settings.advanced.launch_options.subtitle=Рабочая папка, аргументы запуска, переменные среды и приоритет процесса
 settings.advanced.launcher_visibility.close=Закрывать после запуска игры
 settings.advanced.launcher_visibility.hide=Скрыть после запуска игры
 settings.advanced.launcher_visibility.hide_and_reopen=Скрыть после запуска и показать после закрытия игры
@@ -1396,78 +1340,78 @@ settings.advanced.launcher_visibility.keep=Оставлять видимым
 settings.advanced.launcher_visible=Видимость лаунчера
 settings.advanced.minecraft_arguments=Аргументы запуска
 settings.advanced.minecraft_arguments.prompt=По умолчанию
-# settings.advanced.natives_settings=
+settings.advanced.natives_settings=Настройки нативных библиотек
 settings.advanced.natives_directory=Папка с нативными библиотеками
-# settings.advanced.natives_directory.custom.enabled=
+settings.advanced.natives_directory.custom.enabled=Использовать свои нативные библиотеки
 settings.advanced.no_jvm_args=Не добавлять аргументы JVM по умолчанию
-# settings.advanced.no_optimizing_jvm_args=
+settings.advanced.no_optimizing_jvm_args=Не добавлять аргументы оптимизации JVM по умолчанию
 settings.advanced.precall_command=Команда перед запуском
 settings.advanced.precall_command.prompt=Команды, которые необходимо выполнить перед запуском игры
 settings.advanced.process_priority=Приоритет процесса
 settings.advanced.process_priority.low=Низкий
-# settings.advanced.process_priority.low.desc=
+settings.advanced.process_priority.low.desc=
 settings.advanced.process_priority.below_normal=Ниже обычного
-# settings.advanced.process_priority.below_normal.desc=
+settings.advanced.process_priority.below_normal.desc=
 settings.advanced.process_priority.normal=Обычный
-# settings.advanced.process_priority.normal.desc=
+settings.advanced.process_priority.normal.desc=
 settings.advanced.process_priority.above_normal=Выше обычного
-# settings.advanced.process_priority.above_normal.desc=
+settings.advanced.process_priority.above_normal.desc=
 settings.advanced.process_priority.high=Высокий
-# settings.advanced.process_priority.high.desc=
+settings.advanced.process_priority.high.desc=
 settings.advanced.post_exit_command=Команда после выхода
 settings.advanced.post_exit_command.prompt=Команды, которые необходимо выполнить после выхода из игры
 settings.advanced.renderer=Рендерер
 settings.advanced.renderer.default=По умолчанию
-# settings.advanced.renderer.default.desc=
-# settings.advanced.renderer.opengl=
-# settings.advanced.renderer.vulkan=
-# settings.advanced.renderer.gpu_preferences=
-# settings.advanced.renderer.lavapipe=
-# settings.advanced.renderer.lavapipe.desc=
-# settings.advanced.renderer.dozen=
-# settings.advanced.renderer.dozen.desc=
-# settings.advanced.renderer.nvidia_vulkan=
-# settings.advanced.renderer.nvidia_vulkan.desc=
-# settings.advanced.renderer.nvidia_nvk=
-# settings.advanced.renderer.nvidia_nvk.desc=
-# settings.advanced.renderer.amdvlk=
-# settings.advanced.renderer.amdvlk.desc=
-# settings.advanced.renderer.amd_radv=
-# settings.advanced.renderer.amd_radv.desc=
-# settings.advanced.renderer.intel_vulkan=
-# settings.advanced.renderer.intel_vulkan.desc=
-# settings.advanced.renderer.intel_anv=
-# settings.advanced.renderer.intel_anv.desc=
-# settings.advanced.renderer.intel_hasvk=
-# settings.advanced.renderer.intel_hasvk.desc=
-# settings.advanced.renderer.qualcomm=
-# settings.advanced.renderer.qualcomm.desc=
-# settings.advanced.renderer.turnip=
-# settings.advanced.renderer.turnip.desc=
-# settings.advanced.renderer.moltenvk=
-# settings.advanced.renderer.moltenvk.desc=
-# settings.advanced.renderer.kosmickrisp=
-# settings.advanced.renderer.kosmickrisp.desc=
-# settings.advanced.renderer.powervr=
-# settings.advanced.renderer.powervr.desc=
-# settings.advanced.renderer.panvk=
-# settings.advanced.renderer.panvk.desc=
-# settings.advanced.renderer.v3dv=
-# settings.advanced.renderer.v3dv.desc=
+settings.advanced.renderer.default.desc=Системный по умолчанию
+settings.advanced.renderer.opengl=Рендерер/драйвер OpenGL
+settings.advanced.renderer.vulkan=Рендерер/драйвер Vulkan
+settings.advanced.renderer.gpu_preferences=Запускать игры на производительной видеокарте
+settings.advanced.renderer.lavapipe=Mesa Lavapipe
+settings.advanced.renderer.lavapipe.desc=Программный рендерер Vulkan
+settings.advanced.renderer.dozen=Mesa Dozen
+settings.advanced.renderer.dozen.desc=Рендерер Vulkan на основе DirectX 12 (экспериментальный)
+settings.advanced.renderer.nvidia_vulkan=NVIDIA
+settings.advanced.renderer.nvidia_vulkan.desc=Официальный драйвер Vulkan для видеокарт NVIDIA
+settings.advanced.renderer.nvidia_nvk=NVIDIA (NVK)
+settings.advanced.renderer.nvidia_nvk.desc=Открытый драйвер Vulkan для видеокарт NVIDIA
+settings.advanced.renderer.amdvlk=AMD
+settings.advanced.renderer.amdvlk.desc=Официальный драйвер Vulkan для видеокарт AMD
+settings.advanced.renderer.amd_radv=AMD (RADV)
+settings.advanced.renderer.amd_radv.desc=Открытый драйвер Vulkan для видеокарт AMD
+settings.advanced.renderer.intel_vulkan=Intel
+settings.advanced.renderer.intel_vulkan.desc=Официальный драйвер Vulkan для видеокарт Intel
+settings.advanced.renderer.intel_anv=Intel (ANV)
+settings.advanced.renderer.intel_anv.desc=Открытый драйвер Vulkan для видеокарт Intel
+settings.advanced.renderer.intel_hasvk=Intel (HASVK)
+settings.advanced.renderer.intel_hasvk.desc=Открытый драйвер Vulkan для старых видеокарт Intel
+settings.advanced.renderer.qualcomm=Qualcomm
+settings.advanced.renderer.qualcomm.desc=Официальный драйвер Vulkan для графических процессоров Qualcomm Adreno
+settings.advanced.renderer.turnip=Qualcomm (Turnip)
+settings.advanced.renderer.turnip.desc=Открытый драйвер Vulkan для графических процессоров Qualcomm Adreno
+settings.advanced.renderer.moltenvk=MoltenVK
+settings.advanced.renderer.moltenvk.desc=Рендерер Vulkan на основе Metal
+settings.advanced.renderer.kosmickrisp=KosmicKrisp
+settings.advanced.renderer.kosmickrisp.desc=Рендерер Vulkan на основе Metal 4 (экспериментальный)
+settings.advanced.renderer.powervr=PowerVR
+settings.advanced.renderer.powervr.desc=Открытый драйвер Vulkan для графических процессоров PowerVR (экспериментальный)
+settings.advanced.renderer.panvk=PanVK
+settings.advanced.renderer.panvk.desc=Открытый драйвер Vulkan для графических процессоров Arm Mali (экспериментальный)
+settings.advanced.renderer.v3dv=V3DV
+settings.advanced.renderer.v3dv.desc=Открытый драйвер Vulkan для графических процессоров Raspberry Pi 4/5 (экспериментальный)
 settings.advanced.renderer.llvmpipe=Mesa LLVMpipe
-# settings.advanced.renderer.llvmpipe.desc=
+settings.advanced.renderer.llvmpipe.desc=Программный рендерер OpenGL
 settings.advanced.renderer.d3d12=Mesa D3D12
-# settings.advanced.renderer.d3d12.desc=
+settings.advanced.renderer.d3d12.desc=Рендерер OpenGL на основе DirectX 12
 settings.advanced.renderer.zink=Mesa Zink
-# settings.advanced.renderer.zink.desc=
+settings.advanced.renderer.zink.desc=Рендерер OpenGL на основе Vulkan
 settings.advanced.server_ip=Адрес сервера
 settings.advanced.server_ip.prompt=Присоединяться к серверу при запуске игры
 settings.advanced.unsupported_system_options=Настройки, не применимые к текущей системе
 settings.advanced.use_native_glfw_or_sdl=Использовать системный GLFW / SDL
 settings.advanced.use_native_openal=Использовать системный OpenAL
-# settings.advanced.use_native_sdl=
+settings.advanced.use_native_sdl=Использовать системный SDL
 settings.advanced.linux_freebsd_only=Только для Linux/FreeBSD
-# settings.advanced.windows_only=
+settings.advanced.windows_only=Только для Windows
 settings.advanced.wrapper_launcher=Команда-оболочка
 settings.advanced.wrapper_launcher.prompt=Позволяет запускать с помощью дополнительной программы-оболочки, такой как «optirun» в Linux.
 
@@ -1475,84 +1419,84 @@ settings.custom=Пользовательское
 
 settings.game=Настройки
 settings.game.current=Игра
-# settings.game.default_isolation=
-# settings.game.default_isolation.subtitle=
-# settings.game.default_isolation.always=
-# settings.game.default_isolation.always.desc=
-# settings.game.default_isolation.modded=
-# settings.game.default_isolation.modded.desc=
-# settings.game.default_isolation.never=
-# settings.game.default_isolation.never.desc=
+settings.game.default_isolation=Режим изоляции по умолчанию
+settings.game.default_isolation.subtitle=Автоматически включать изоляцию для подходящих сборок при установке новой сборки.
+settings.game.default_isolation.always=Всегда
+settings.game.default_isolation.always.desc=Автоматически включать изоляцию для всех новых сборок
+settings.game.default_isolation.modded=С модами
+settings.game.default_isolation.modded.desc=Автоматически включать изоляцию для сборок с модами
+settings.game.default_isolation.never=Никогда
+settings.game.default_isolation.never.desc=Не включать изоляцию для новых сборок автоматически
 settings.game.dimension=Разрешение
-settings.game.exploration=Расположение
+settings.game.exploration=Открыть папку
 settings.game.fullscreen=Полноэкранный режим
-# settings.game.inherit_global=
-# settings.game.instance_settings.unsupported=
-# settings.game.presets.unsupported=
-# settings.game.isolation=
-# settings.game.isolation.subtitle=
+settings.game.inherit_global=Сейчас этот параметр берётся из пресета настроек игры. Нажмите, чтобы задать отдельное значение для сборки.
+settings.game.instance_settings.unsupported=Текущий файл настроек игры сохранён более новой версией HMCL. Эта версия HMCL не может корректно его загрузить.
+settings.game.presets.unsupported=Файл пресетов настроек игры сохранён более новой версией HMCL. Эта версия HMCL не может изменять глобальные настройки игры.
+settings.game.isolation=Изоляция сборки
+settings.game.isolation.subtitle=Если включено, сборка использует собственную рабочую папку.
 settings.game.java_directory=Java
 settings.game.java_directory.auto=Автовыбор
 settings.game.java_directory.auto.not_found=Совместимая версия Java не была установлена.
 settings.game.java_directory.bit=%s-разрядная
 settings.game.java_directory.choose=Выбрать папку с Java
-settings.game.java_directory.invalid=Неверныая папка Java
+settings.game.java_directory.invalid=Неверный путь к Java
 settings.game.java_directory.version=Укажите версию Java
 settings.game.java_directory.template=%s (%s)
 settings.game.management=Инструменты
-# settings.game.override_global=
-# settings.game.quick_play=
-# settings.game.quick_play.multiplayer=
-# settings.game.quick_play.none=
-# settings.game.quick_play.realms=
-# settings.game.quick_play.singleplayer=
-# settings.game.quick_play.subtitle=
-# settings.game.running_directory=
-# settings.game.section.basic=
-# settings.game.section.game=
-# settings.game.window_type=
-# settings.game.window_type.fullscreen=
-# settings.game.window_type.maximized=
-# settings.game.window_type.windowed=
+settings.game.override_global=Сейчас для этого параметра задано отдельное значение сборки. Нажмите, чтобы брать его из пресета настроек игры.
+settings.game.quick_play=Быстрая игра
+settings.game.quick_play.multiplayer=Сетевая игра
+settings.game.quick_play.none=Нет
+settings.game.quick_play.realms=Realms
+settings.game.quick_play.singleplayer=Одиночная игра
+settings.game.quick_play.subtitle=Сразу заходить на сервер или в мир после запуска игры
+settings.game.running_directory=Рабочая папка игры
+settings.game.section.basic=Основные настройки
+settings.game.section.game=Настройки игры
+settings.game.window_type=Режим окна игры
+settings.game.window_type.fullscreen=Полноэкранный
+settings.game.window_type.maximized=Развёрнутый
+settings.game.window_type.windowed=Оконный
 settings.game.working_directory.choose=Выберите рабочую папку
 
 settings.icon=Значок
-# settings.game_directories.read_only=
+settings.game_directories.read_only=Файл папок игры сохранён более новой версией HMCL. Эта версия HMCL не может изменять папки игры.
 
 settings.launcher=Настройки лаунчера
-# settings.launcher.allow_auto_agent=
-# settings.launcher.allow_auto_agent.subtitle=
-# settings.launcher.animation=
+settings.launcher.allow_auto_agent=Разрешить HMCL изменять игру
+settings.launcher.allow_auto_agent.subtitle=Разрешить HMCL подключать к игре Java Agent, чтобы улучшить игровой процесс
+settings.launcher.animation=Анимация
 settings.launcher.appearance=Внешний вид
-# settings.launcher.brightness=
-# settings.launcher.brightness.auto=
-# settings.launcher.brightness.dark=
-# settings.launcher.brightness.light=
+settings.launcher.brightness=Режим темы
+settings.launcher.brightness.auto=Как в системе
+settings.launcher.brightness.dark=Тёмный
+settings.launcher.brightness.light=Светлый
 settings.launcher.debug=Отладка
-# settings.launcher.disable_april_fools=
-# settings.launcher.disable_auto_game_options=
-settings.launcher.download=Скачать
+settings.launcher.disable_april_fools=Не включать первоапрельские функции
+settings.launcher.disable_auto_game_options=Не менять язык игры
+settings.launcher.download=Загрузки
 settings.launcher.download.threads=Потоки
 settings.launcher.download.threads.auto=Автоопределение
-# settings.launcher.download.threads.custom=
+settings.launcher.download.threads.custom=Своё значение
 settings.launcher.download_source=Источник скачивания
 settings.launcher.download_source.auto=Автовыбор зеркала скачивания
-# settings.launcher.default_addon_source=
-# settings.launcher.misc=
+settings.launcher.default_addon_source=Источник аддонов по умолчанию
+settings.launcher.misc=Прочее
 settings.launcher.font=Шрифт
 settings.launcher.font.anti_aliasing=Сглаживание
-settings.launcher.font.anti_aliasing.auto=Автоматический
+settings.launcher.font.anti_aliasing.auto=Автоматическое
 settings.launcher.font.anti_aliasing.gray=Оттенки серого
-settings.launcher.font.anti_aliasing.lcd=Субпиксель
-# settings.launcher.fonts=
+settings.launcher.font.anti_aliasing.lcd=Субпиксельное
+settings.launcher.fonts=Шрифты
 settings.launcher.general=Общие
 settings.launcher.language=Язык
 settings.launcher.launcher_log.export=Экспорт логов лаунчера
 settings.launcher.launcher_log.export.failed=Не удалось экспортировать логи
 settings.launcher.launcher_log.export.success=Логи экспортированы в %s
-settings.launcher.launcher_log.reveal=Открыть папку журнала
+settings.launcher.launcher_log.reveal=Открыть папку с логами
 settings.launcher.log=Запись логов
-settings.launcher.log.font=Шрифт
+settings.launcher.log.font=Шрифт лога
 settings.launcher.proxy=Прокси
 settings.launcher.proxy.authentication=Требуется авторизация
 settings.launcher.proxy.default=Использовать прокси системы
@@ -1564,35 +1508,35 @@ settings.launcher.proxy.port=Порт
 settings.launcher.proxy.socks=SOCKS
 settings.launcher.proxy.username=Имя пользователя
 settings.launcher.theme=Тема
-# settings.launcher.theme_color=
-# settings.launcher.theme_color_style=
-# settings.launcher.theme_color_style.content=
-# settings.launcher.theme_color_style.content.desc=
-# settings.launcher.theme_color_style.expressive=
-# settings.launcher.theme_color_style.expressive.desc=
-# settings.launcher.theme_color_style.fidelity=
-# settings.launcher.theme_color_style.fidelity.desc=
-# settings.launcher.theme_color_style.fruit_salad=
-# settings.launcher.theme_color_style.fruit_salad.desc=
-# settings.launcher.theme_color_style.monochrome=
-# settings.launcher.theme_color_style.monochrome.desc=
-# settings.launcher.theme_color_style.neutral=
-# settings.launcher.theme_color_style.neutral.desc=
-# settings.launcher.theme_color_style.rainbow=
-# settings.launcher.theme_color_style.rainbow.desc=
-# settings.launcher.theme_color_style.tonal_spot=
-# settings.launcher.theme_color_style.tonal_spot.desc=
-# settings.launcher.theme_color_style.vibrant=
-# settings.launcher.theme_color_style.vibrant.desc=
-# settings.launcher.theme_color_type.background=
-# settings.launcher.theme_color_type.custom=
-# settings.launcher.theme_color_type.custom.description=
-# settings.launcher.theme_color_type.default=
-# settings.launcher.theme_color_type.system=
+settings.launcher.theme_color=Цвет темы
+settings.launcher.theme_color_style=Цветовой стиль
+settings.launcher.theme_color_style.content=По содержимому
+settings.launcher.theme_color_style.content.desc=Использует цвет темы как основной без изменений.
+settings.launcher.theme_color_style.expressive=Выразительный
+settings.launcher.theme_color_style.expressive.desc=Средняя насыщенность, основной цвет отличается от цвета темы.
+settings.launcher.theme_color_style.fidelity=Точный
+settings.launcher.theme_color_style.fidelity.desc=Использует цвет темы как основной без изменений.
+settings.launcher.theme_color_style.fruit_salad=Фруктовый салат
+settings.launcher.theme_color_style.fruit_salad.desc=Более игривый цветовой стиль.
+settings.launcher.theme_color_style.monochrome=Монохромный
+settings.launcher.theme_color_style.monochrome.desc=Простая чёрно-белая схема.
+settings.launcher.theme_color_style.neutral=Нейтральный
+settings.launcher.theme_color_style.neutral.desc=Почти чёрно-белая схема с минимумом цвета.
+settings.launcher.theme_color_style.rainbow=Радуга
+settings.launcher.theme_color_style.rainbow.desc=Более игривый цветовой стиль.
+settings.launcher.theme_color_style.tonal_spot=Тональный акцент
+settings.launcher.theme_color_style.tonal_spot.desc=Сниженная насыщенность для более мягкого вида.
+settings.launcher.theme_color_style.vibrant=Яркий
+settings.launcher.theme_color_style.vibrant.desc=Повышенная насыщенность для более яркого и выразительного вида.
+settings.launcher.theme_color_type.background=Как у фонового изображения
+settings.launcher.theme_color_type.custom=Свой цвет
+settings.launcher.theme_color_type.custom.description=Использовать цвет, выбранный выше.
+settings.launcher.theme_color_type.default=По умолчанию
+settings.launcher.theme_color_type.system=Как в системе
 settings.launcher.title_transparent=Прозрачная строка заголовка
 settings.launcher.turn_off_animations=Отключить анимацию
 settings.launcher.version_list_source=Список версий
-# settings.launcher.window_transparent=
+settings.launcher.window_transparent=Прозрачное окно
 settings.launcher.background.settings.opacity=Непрозрачность
 
 settings.memory=Оперативная память
@@ -1600,150 +1544,150 @@ settings.memory.allocate=Выделено %1$.1f ГиБ
 settings.memory.allocate.exceeded=Выделено %1$.1f ГиБ (Доступно %2$.1f ГиБ)
 settings.memory.auto_allocate=Автовыделение
 settings.memory.lower_bound=Мин. объём памяти
-# settings.memory.manual_allocate=
+settings.memory.manual_allocate=Выделить память вручную
 settings.memory.unit.mib=МиБ
 settings.memory.used_per_total=Использовано %1$.1f ГиБ / Всего %2$.1f ГиБ
 settings.physical_memory=Размер физической памяти
 settings.show_log=Показать логи
-# settings.enable_debug_log_output=
-# settings.file.force_write=
-# settings.file.force_write.confirm=
-settings.tabs.installers=Погрузчики
+settings.enable_debug_log_output=Выводить отладочный лог
+settings.file.force_write=Сделать резервную копию и перезаписать
+settings.file.force_write.confirm=HMCL сделает резервную копию текущего файла конфигурации и перезапишет его данными, загруженными этой версией. Поля, которые эта версия не поддерживает, могут быть потеряны. Продолжить?
+settings.tabs.installers=Загрузчики
 settings.take_effect_after_restart=Применится после перезапуска
-settings.type=Тип настроек экземпляра
+settings.type=Тип настроек сборки
 settings.type.global.manage=Глобальные настройки
-# settings.type.global.preset=
-# settings.type.global.preset.create=
-# settings.type.global.preset.default=
-# settings.type.global.preset.duplicate_name=
-# settings.type.global.preset.help=
-# settings.type.global.preset.manage_all=
-# settings.type.global.preset.name=
-# settings.type.global.preset.rename=
-# settings.type.global.preset.remove=
-# settings.type.global.preset.remove.confirm=
-# settings.type.global.preset.subtitle=
-# settings.type.global.preset.auto_name=
+settings.type.global.preset=Пресет
+settings.type.global.preset.create=Создать пресет
+settings.type.global.preset.default=Использовать пресет по умолчанию
+settings.type.global.preset.duplicate_name=Пресет с таким названием уже существует
+settings.type.global.preset.help=Пресет настроек игры — это набор настроек игры, которые можно изменить на этой странице.\nПо умолчанию все сборки берут настройки игры из текущего пресета. Отдельные параметры можно переопределить на странице настроек игры для сборки.
+settings.type.global.preset.manage_all=Текущий пресет
+settings.type.global.preset.name=Название пресета
+settings.type.global.preset.rename=Переименовать пресет
+settings.type.global.preset.remove=Удалить пресет
+settings.type.global.preset.remove.confirm=Удалить пресет «%s»? Сборки, использующие этот пресет, переключатся на пресет по умолчанию.
+settings.type.global.preset.subtitle=Текущая сборка будет брать настройки игры из выбранного пресета
+settings.type.global.preset.auto_name=Пресет %d
 
-# shaderpack.download.title=
+shaderpack.download.title=Скачать шейдер - %1s
 
 
 system.architecture=Архитектура
 system.operating_system=Операционная система
 
-# terracotta=
-# terracotta.terracotta=
-# terracotta.status=
-# terracotta.back=
-# terracotta.feedback.title=
-# terracotta.feedback.desc=
-# terracotta.feedback.desc.update=
-# terracotta.sudo_installing=
-# terracotta.difficulty.easiest=
-# terracotta.difficulty.simple=
-# terracotta.difficulty.medium=
-# terracotta.difficulty.tough=
-# terracotta.difficulty.estimate_only=
-# terracotta.from_local.title=
-# terracotta.from_local.desc=
-# terracotta.from_local.guide=
-# terracotta.from_local.file_name_mismatch=
-# terracotta.export_log=
-# terracotta.export_log.desc=
-# terracotta.status.bootstrap=
-# terracotta.status.uninitialized.not_exist=
-# terracotta.status.uninitialized.not_exist.title=
-# terracotta.status.uninitialized.update=
-# terracotta.status.uninitialized.update.title=
-# terracotta.status.uninitialized.desc=
-# terracotta.confirm.title=
-# terracotta.confirm.desc=
-# terracotta.status.preparing=
-# terracotta.status.launching=
-# terracotta.status.unknown=
-# terracotta.status.waiting=
-# terracotta.status.waiting.host.title=
-# terracotta.status.waiting.host.desc=
-# terracotta.status.waiting.host.launch.title=
-# terracotta.status.waiting.host.launch.desc=
-# terracotta.status.waiting.host.launch.skip=
-# terracotta.status.waiting.guest.title=
-# terracotta.status.waiting.guest.desc=
-# terracotta.status.waiting.guest.prompt.title=
-# terracotta.status.waiting.guest.prompt.invalid=
-# terracotta.status.scanning=
-# terracotta.status.scanning.desc=
-# terracotta.status.scanning.back=
-# terracotta.status.host_starting=
-# terracotta.status.host_starting.back=
-# terracotta.status.host_ok=
-# terracotta.status.host_ok.code=
-# terracotta.status.host_ok.code.copy=
-# terracotta.status.host_ok.code.copy.toast=
-# terracotta.status.host_ok.code.desc=
-# terracotta.status.host_ok.back=
-# terracotta.status.guest_starting=
-# terracotta.status.guest_starting.back=
-# terracotta.status.guest_ok=
-# terracotta.status.guest_ok.back=
-# terracotta.status.guest_ok.title=
-# terracotta.status.guest_ok.desc=
-# terracotta.status.exception.back=
-# terracotta.status.exception.desc.ping_host_fail=
-# terracotta.status.exception.desc.ping_host_rst=
-# terracotta.status.exception.desc.guest_et_crash=
-# terracotta.status.exception.desc.host_et_crash=
-# terracotta.status.exception.desc.ping_server_rst=
-# terracotta.status.exception.desc.scaffolding_invalid_response=
-# terracotta.status.fatal.retry=
-# terracotta.status.fatal.network=
-# terracotta.status.fatal.install=
-# terracotta.status.fatal.terracotta=
-# terracotta.status.fatal.unknown=
-# terracotta.player_list=
-# terracotta.player_anonymous=
-# terracotta.player_kind.host=
-# terracotta.player_kind.local=
-# terracotta.player_kind.guest=
-# terracotta.unsupported=
-# terracotta.unsupported.os.windows.old=
-# terracotta.unsupported.arch.32bit=
-# terracotta.unsupported.arch.loongarch64_ow=
-# terracotta.unsupported.region=
+terracotta=Сетевая игра
+terracotta.terracotta=Terracotta | Сетевая игра
+terracotta.status=Лобби
+terracotta.back=Выйти
+terracotta.feedback.title=Заполнить форму обратной связи
+terracotta.feedback.desc=Надеемся, вы потратите 10 секунд на заполнение формы обратной связи.
+terracotta.feedback.desc.update=HMCL обновил ядро сетевой игры. Надеемся, вы потратите 10 секунд на заполнение формы обратной связи.
+terracotta.sudo_installing=Перед установкой ядра сетевой игры HMCL должен проверить ваш пароль
+terracotta.difficulty.easiest=Отличная сеть: подключение почти гарантировано!
+terracotta.difficulty.simple=Хорошая сеть: подключение может занять некоторое время
+terracotta.difficulty.medium=Средняя сеть: включаются резервные маршруты, но подключиться может не получиться
+terracotta.difficulty.tough=Плохая сеть: включаются резервные маршруты, но подключиться может не получиться
+terracotta.difficulty.estimate_only=Вероятность успеха — лишь оценка по типам NAT хоста и гостя, только для справки!
+terracotta.from_local.title=Сторонние каналы скачивания ядра сетевой игры
+terracotta.from_local.desc=В некоторых регионах встроенный канал скачивания по умолчанию может работать нестабильно.
+terracotta.from_local.guide=Скачайте пакет ядра сетевой игры с именем %s. После скачивания перетащите файл на эту страницу, чтобы установить его.
+terracotta.from_local.file_name_mismatch=Нужно скачать пакет ядра сетевой игры с именем %1$s, а не %2$s
+terracotta.export_log=Экспорт лога ядра сетевой игры
+terracotta.export_log.desc=Сбор дополнительной информации для анализа
+terracotta.status.bootstrap=Сбор информации
+terracotta.status.uninitialized.not_exist=Ядро сетевой игры: не скачано
+terracotta.status.uninitialized.not_exist.title=Скачать ядро сетевой игры (~ 8 МиБ)
+terracotta.status.uninitialized.update=Ядро сетевой игры: доступно обновление
+terracotta.status.uninitialized.update.title=Обновить ядро сетевой игры (~ 8 МиБ)
+terracotta.status.uninitialized.desc=Вы обязуетесь строго соблюдать все законы и правила своей страны или региона во время сетевой игры.
+terracotta.confirm.title=Уведомление для пользователей
+terracotta.confirm.desc=Terracotta — стороннее бесплатное ПО с открытым исходным кодом. О любых проблемах при использовании сообщайте через соответствующие каналы.\nTerracotta использует технологию P2P. После подключения пользователи в комнате соединяются напрямую друг с другом, и сторонний сервер не передаёт ваш трафик. Качество сетевой игры во многом зависит от сети участников.\nВо время сетевой игры вы обязаны строго соблюдать все законы и правила своей страны и региона.
+terracotta.status.preparing=Ядро сетевой игры: скачивание (НЕ закрывайте HMCL)
+terracotta.status.launching=Ядро сетевой игры: инициализация
+terracotta.status.unknown=Ядро сетевой игры: инициализация
+terracotta.status.waiting=Ядро сетевой игры: готово
+terracotta.status.waiting.host.title=Я хочу быть хостом
+terracotta.status.waiting.host.desc=Создайте комнату и получите код приглашения, чтобы играть с друзьями
+terracotta.status.waiting.host.launch.title=Похоже, вы забыли запустить игру
+terracotta.status.waiting.host.launch.desc=Запущенная игра не найдена
+terracotta.status.waiting.host.launch.skip=Игра запущена
+terracotta.status.waiting.guest.title=Я хочу присоединиться
+terracotta.status.waiting.guest.desc=Введите код приглашения от хоста, чтобы войти в его мир
+terracotta.status.waiting.guest.prompt.title=Введите код приглашения от хоста
+terracotta.status.waiting.guest.prompt.invalid=Недопустимый код приглашения
+terracotta.status.scanning=Поиск миров в локальной сети
+terracotta.status.scanning.desc=<a href="hmcl://game/launch">Запустите игру</a>, откройте мир, нажмите ESC, выберите «Открыть для сети», а затем «Открыть мир для сети».
+terracotta.status.scanning.back=Поиск миров в локальной сети тоже будет остановлен.
+terracotta.status.host_starting=Создание комнаты
+terracotta.status.host_starting.back=Создание комнаты будет остановлено.
+terracotta.status.host_ok=Комната создана
+terracotta.status.host_ok.code=Код приглашения (скопирован)
+terracotta.status.host_ok.code.copy=Скопировать код приглашения
+terracotta.status.host_ok.code.copy.toast=Код приглашения скопирован в буфер обмена
+terracotta.status.host_ok.code.desc=Попросите друзей выбрать режим гостя в HMCL (раздел «Сетевая игра») или в PCL CE и ввести этот код приглашения.
+terracotta.status.host_ok.back=Комната тоже будет закрыта: остальные гости выйдут и не смогут подключиться снова.
+terracotta.status.guest_starting=Подключение к комнате
+terracotta.status.guest_starting.back=Другим гостям это не помешает подключиться к комнате.
+terracotta.status.guest_ok=Вы в комнате
+terracotta.status.guest_ok.back=Другим гостям это не помешает подключиться к комнате.
+terracotta.status.guest_ok.title=Запустите игру, выберите «Сетевая игра» и дважды щёлкните по Terracotta Lobby.
+terracotta.status.guest_ok.desc=Резервный адрес: %s
+terracotta.status.exception.back=Попробуйте ещё раз
+terracotta.status.exception.desc.ping_host_fail=Не удалось подключиться к комнате: комната закрыта или сеть нестабильна
+terracotta.status.exception.desc.ping_host_rst=Соединение с комнатой потеряно: комната закрыта или сеть нестабильна
+terracotta.status.exception.desc.guest_et_crash=Не удалось подключиться к комнате: EasyTier вылетел, сообщите об этом разработчикам
+terracotta.status.exception.desc.host_et_crash=Не удалось создать комнату: EasyTier вылетел, сообщите об этом разработчикам
+terracotta.status.exception.desc.ping_server_rst=Комната закрыта: вы вышли из игрового мира, и комната закрылась автоматически
+terracotta.status.exception.desc.scaffolding_invalid_response=Недопустимый протокол: хост отправил недопустимый ответ, сообщите об этом разработчикам
+terracotta.status.fatal.retry=Повторить
+terracotta.status.fatal.network=Не удалось скачать ядро сетевой игры. Проверьте подключение к сети и попробуйте снова.
+terracotta.status.fatal.install=Критическая ошибка: не удалось установить ядро сетевой игры.
+terracotta.status.fatal.terracotta=Критическая ошибка: не удалось подключиться к ядру сетевой игры.
+terracotta.status.fatal.unknown=Критическая ошибка: неизвестная ошибка.
+terracotta.player_list=Список игроков
+terracotta.player_anonymous=Анонимный игрок
+terracotta.player_kind.host=Хост
+terracotta.player_kind.local=Вы
+terracotta.player_kind.guest=Гость
+terracotta.unsupported=Сетевая игра пока не поддерживается на этой платформе.
+terracotta.unsupported.os.windows.old=Для сетевой игры нужна Windows 10 или новее. Обновите систему.
+terracotta.unsupported.arch.32bit=Сетевая игра не поддерживается на 32-разрядных системах. Перейдите на 64-разрядную систему.
+terracotta.unsupported.arch.loongarch64_ow=Сетевая игра не поддерживается в дистрибутивах Linux LoongArch64 Old World. Перейдите на дистрибутив New World (например, AOSC OS).
+terracotta.unsupported.region=Функция сетевой игры сейчас доступна только пользователям из материкового Китая и может быть недоступна в вашем регионе.
 
-# theme_pack.appearance.follow_theme.tooltip=
-# theme_pack.appearance.custom.tooltip=
-# theme_pack.apply=
-# theme_pack.apply.confirm=
-# theme_pack.apply.failed=
-# theme_pack.builtin=
-# theme_pack.current.missing=
-# theme_pack.delete=
-# theme_pack.delete.confirm=
-# theme_pack.delete.failed=
-# theme_pack.delete.success=
-# theme_pack.directory=
-# theme_pack.empty=
-# theme_pack.export=
-# theme_pack.export.author=
-# theme_pack.export.failed=
-# theme_pack.export.id=
-# theme_pack.export.name=
-# theme_pack.export.subtitle=
-# theme_pack.export.success=
-# theme_pack.export.version=
-# theme_pack.export.title=
-# theme_pack.file=
-# theme_pack.import=
-# theme_pack.import.failed=
-# theme_pack.import.success=
-# theme_pack.import.title=
-# theme_pack.load.failed=
-# theme_pack.manage=
-# theme_pack.theme=
-# theme_pack.theme.id=
-# theme_pack.themes=
-# theme_pack.version=
+theme_pack.appearance.follow_theme.tooltip=Сейчас используется значение из выбранной темы. Нажмите, чтобы задать своё значение в настройках лаунчера.
+theme_pack.appearance.custom.tooltip=Сейчас используется своё значение из настроек лаунчера. Нажмите, чтобы использовать значение из выбранной темы.
+theme_pack.apply=Применить тему
+theme_pack.apply.confirm=Применить тему «%s»?
+theme_pack.apply.failed=Не удалось применить тему.
+theme_pack.builtin=Встроенная
+theme_pack.current.missing=Пакет темы не найден
+theme_pack.delete=Удалить пакет темы
+theme_pack.delete.confirm=Вы уверены, что хотите удалить пакет темы «%s»? Это действие нельзя отменить.
+theme_pack.delete.failed=Не удалось удалить пакет темы.
+theme_pack.delete.success=Пакет темы «%s» удалён.
+theme_pack.directory=Папка пакетов тем
+theme_pack.empty=Пакеты тем не установлены.
+theme_pack.export=Экспортировать текущую тему
+theme_pack.export.author=Имя автора
+theme_pack.export.failed=Не удалось экспортировать пакет темы.
+theme_pack.export.id=ID пакета темы
+theme_pack.export.name=Название темы
+theme_pack.export.subtitle=Сохранить текущий внешний вид лаунчера в файл пакета темы.
+theme_pack.export.success=Пакет темы сохранён в «%s».
+theme_pack.export.version=Версия темы
+theme_pack.export.title=Сохранить пакет темы
+theme_pack.file=Пакет темы HMCL
+theme_pack.import=Импортировать пакет темы
+theme_pack.import.failed=Не удалось импортировать пакет темы.
+theme_pack.import.success=Пакет темы «%s» импортирован.
+theme_pack.import.title=Выберите пакет темы
+theme_pack.load.failed=Не удалось загрузить установленные пакеты тем.
+theme_pack.manage=Управление пакетами тем
+theme_pack.theme=Тема
+theme_pack.theme.id=ID: %s
+theme_pack.themes=Тем: %d
+theme_pack.version=Версия: %s
 
 unofficial.hint=Вы используете неофициальную версию HMCL. Мы не можем гарантировать безопасность.
 
@@ -1751,35 +1695,31 @@ update=Обновление
 update.accept=Обновить
 update.changelog=Изменения
 update.channel.dev=Бета
-update.channel.dev.hint=Вы используете бета-версию, которая может включать некоторые дополнительные функции по сравнению с релизной версией, используемой только для тестирования. Бета-версия может быть нестабильной!\n\
-  \n\
-  Если вы встретили какие-то проблемы, вы можете зайти на <a href="hmcl://settings/feedback">страницу обратной связи</a>.
-update.channel.dev.title=Подсказки для бета-версии
-update.channel.nightly=Альфа
-update.channel.nightly.hint=Вы используете альфа-версию, которая может включать некоторые дополнительные функциональные возможности по сравнению с бета-версией и версией релиза, используемой только для тестирования. Альфа-версия может быть нестабильной!\n\
-  \n\
-  Если вы встретили какие-то проблемы, вы можете зайти на <a href="hmcl://settings/feedback">страницу обратной связи</a>.
-update.channel.nightly.title=Подсказки для альфа-версии
-update.channel.stable=Релиз
+update.channel.dev.hint=Вы используете бета-версию лаунчера. В ней могут быть дополнительные функции, но иногда она работает менее стабильно, чем стабильная версия.\n\nЕсли вы столкнулись с ошибками или проблемами, сообщите о них через каналы, указанные на странице <a href="hmcl://settings/feedback">«Обратная связь»</a>.\n\nПодпишитесь на <a href="https://space.bilibili.com/1445341">@huanghongxun</a> в Bilibili, чтобы следить за важными новостями HMCL, или на <a href="https://space.bilibili.com/20314891">@Glavo</a>, чтобы следить за ходом разработки HMCL.
+update.channel.dev.title=Уведомление о бета-версии
+update.channel.nightly=Ночная
+update.channel.nightly.hint=Вы используете ночную версию лаунчера. В ней могут быть дополнительные функции, но она всегда менее стабильна, чем версии других каналов.\n\nЕсли вы столкнулись с ошибками или проблемами, сообщите о них через каналы, указанные на странице <a href="hmcl://settings/feedback">«Обратная связь»</a>.\n\nПодпишитесь на <a href="https://space.bilibili.com/1445341">@huanghongxun</a> в Bilibili, чтобы следить за важными новостями HMCL, или на <a href="https://space.bilibili.com/20314891">@Glavo</a>, чтобы следить за ходом разработки HMCL.
+update.channel.nightly.title=Уведомление о ночной версии
+update.channel.stable=Стабильная
 update.checking=Проверка наличия обновлений
-# update.check_failed=
-# update.disable_auto_show_update_dialog=
-# update.disable_auto_show_update_dialog.subtitle=
+update.check_failed=Не удалось проверить наличие обновлений. %s
+update.disable_auto_show_update_dialog=Не показывать окно обновления автоматически
+update.disable_auto_show_update_dialog.subtitle=Включите, чтобы HMCL не показывал окно обновления автоматически.
 update.failed=Не удалось выполнить обновление
 update.found=Доступно обновление!
 update.newest_version=Последняя версия: %s
 update.bubble.title=Доступно обновление: %s
 update.bubble.subtitle=Кликните здесь для обновления
-# update.note.stable=
-# update.note.dev=
+update.note.stable=Подходит тем, для кого важнее всего стабильность.\nНовые функции попадают в стабильную версию только после тщательного тестирования.
+update.note.dev=Подходит тем, кто хочет первым опробовать новые функции.\nБета-версия содержит новейшие функции и исправления ошибок,\nно из-за недостаточного тестирования в ней может быть больше проблем.
 update.latest=Это последняя версия.
 update.tooltip=Обновить
-# update.preview=
-# update.preview.subtitle=
-# update.unverified=
+update.preview=Получать предварительные версии HMCL
+update.preview.subtitle=Включите, чтобы получать новые версии HMCL для тестирования раньше официального выпуска.
+update.unverified=Обновление недоступно: эта копия лаунчера не прошла проверку
 
-# warning.java_interpreted_mode=
-# warning.software_rendering=
+warning.java_interpreted_mode=HMCL работает в интерпретируемой среде Java, что сильно снижает производительность.\n\nДля лучшей работы рекомендуем запускать HMCL на Java с поддержкой JIT.
+warning.software_rendering=HMCL сейчас использует программный рендеринг, что сильно снижает производительность.
 
 wiki.tooltip=Страница Minecraft Wiki
 wiki.version.game=https://ru.minecraft.wiki/w/%s_(Java_Edition)
@@ -1787,5 +1727,5 @@ wiki.version.game.snapshot=https://ru.minecraft.wiki/w/%s_(Java_Edition)
 
 wizard.prev=< Пред.
 wizard.failed=Не удалось
-wizard.finish=Завершено
+wizard.finish=Готово
 wizard.next=След. >


### PR DESCRIPTION
- Translate all missing keys (the Russian file now covers all 1492 keys)
- Fix typos, grammar errors and mistranslations in existing strings
- Bring outdated strings in line with the English source (restore lost links and sentences)
- Unify terminology: аккаунт, сервер авторизации, оффлайн-режим, сборка, ассеты, лог, «вылетела» for crashes, «Загрузчики» for loaders